### PR TITLE
OUT-358 | API - Soft delete records in database

### DIFF
--- a/prisma/migrations/20240509154310_add_deleted_at_to_all_tables/migration.sql
+++ b/prisma/migrations/20240509154310_add_deleted_at_to_all_tables/migration.sql
@@ -1,0 +1,11 @@
+-- AlterTable
+ALTER TABLE "TaskTemplates" ADD COLUMN     "deletedAt" TIMESTAMP(3);
+
+-- AlterTable
+ALTER TABLE "Tasks" ADD COLUMN     "deletedAt" TIMESTAMP(3);
+
+-- AlterTable
+ALTER TABLE "ViewSettings" ADD COLUMN     "deletedAt" TIMESTAMP(3);
+
+-- AlterTable
+ALTER TABLE "WorkflowStates" ADD COLUMN     "deletedAt" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -31,6 +31,7 @@ model WorkflowState {
   color         String?        @db.VarChar(32)
   tasks         Task[]
   taskTemplates TaskTemplate[]
+  deletedAt     DateTime?
 
   @@unique([workspaceId, key], name: "UQ_WorkflowStates_workspaceId_key")
   @@index([workspaceId, key], name: "IX_WorkflowStates_workspaceId_key")
@@ -49,6 +50,7 @@ model Task {
   workflowStateId String        @db.Uuid
   assignedAt      DateTime?
   completedAt     DateTime?
+  deletedAt       DateTime?
 
   @@map("Tasks")
 }
@@ -69,6 +71,7 @@ model TaskTemplate {
   workflowState   WorkflowState @relation(fields: [workflowStateId], references: [id], onDelete: Cascade)
   workflowStateId String        @db.Uuid
   createdById     String        @db.Uuid
+  deletedAt       DateTime?
 
   @@unique([workspaceId, templateName], name: "UQ_TaskTemplates_workspaceId_templateName")
   @@index([workspaceId, templateName], name: "IX_TaskTemplates_workspaceId_templateName")
@@ -76,10 +79,11 @@ model TaskTemplate {
 }
 
 model ViewSetting {
-  id          String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  userId      String   @db.Uuid
-  viewMode    ViewMode @default(board)
-  workspaceId String   @db.VarChar(32)
+  id          String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  userId      String    @db.Uuid
+  viewMode    ViewMode  @default(board)
+  workspaceId String    @db.VarChar(32)
+  deletedAt   DateTime?
 
   @@unique([userId, workspaceId], name: "UQ_ViewSettings_userId_workspaceId")
   @@index([userId, workspaceId], name: "IX_ViewSettings_userId_workspaceId")

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,4 +1,5 @@
 import { PrismaClient } from '@prisma/client'
+import { filterSoftDeleted, softDelete, softDeleteMany } from '@/lib/prismaExtensions'
 
 class DBClient {
   private static client: PrismaClient
@@ -19,7 +20,8 @@ class DBClient {
     if (!this.client) {
       if (!this.isInitialized) {
         // Make sure that prisma client is only created once
-        this.client = new PrismaClient()
+        // @ts-expect-error $use is deprecated but it is expected
+        this.client = new PrismaClient().$extends(softDelete).$extends(softDeleteMany).$extends(filterSoftDeleted)
         this.isInitialized = true
 
         // disconnect the client when the Node.js process exits

--- a/src/lib/prismaExtensions.ts
+++ b/src/lib/prismaExtensions.ts
@@ -1,0 +1,64 @@
+import { Prisma } from '@prisma/client'
+
+/**
+ * Prisma extension for soft delete
+ */
+export const softDelete = Prisma.defineExtension({
+  name: 'softDelete',
+  model: {
+    $allModels: {
+      async delete<M, A>(this: M, args: Prisma.Args<M, 'delete'>['where']): Promise<Prisma.Result<M, A, 'update'>> {
+        const context = Prisma.getExtensionContext(this)
+
+        return (context as any).update({
+          where: { ...args.where },
+          data: {
+            deletedAt: new Date(),
+          },
+        })
+      },
+    },
+  },
+})
+
+/**
+ * Prisma extension for bulk soft delete
+ */
+export const softDeleteMany = Prisma.defineExtension({
+  name: 'softDeleteMany',
+  model: {
+    $allModels: {
+      async deleteMany<M, A>(
+        this: M,
+        args: Prisma.Args<M, 'deleteMany'>['where'],
+      ): Promise<Prisma.Result<M, A, 'updateMany'>> {
+        const context = Prisma.getExtensionContext(this)
+
+        return (context as any).updateMany({
+          where: { ...args.where },
+          data: {
+            deletedAt: new Date(),
+          },
+        })
+      },
+    },
+  },
+})
+
+/**
+ * Prisma extension for filtering out soft deleted values from all relevant operations
+ */
+export const filterSoftDeleted = Prisma.defineExtension({
+  name: 'filterSoftDeleted',
+  query: {
+    $allModels: {
+      async $allOperations({ model, operation, args, query }) {
+        if (operation === 'findUnique' || operation === 'findFirst' || operation === 'findMany') {
+          args.where = { ...args.where, deletedAt: null }
+          return query(args)
+        }
+        return query(args)
+      },
+    },
+  },
+})


### PR DESCRIPTION
### Tasks

- [OUT-358 | API - Soft delete records in database](https://linear.app/copilotplatforms/issue/OUT-358/api-soft-delete-records-in-database)

### Changes

- [x] Implement 3 prisma extensions for `softDelete`, `softDeleteMany` and `filterSoftDeleted`
- [x] Extend the global prisma client export with these three client extensions 
- [x] Add deletedAt column in all tables to implement softdelete

### Testing Criteria

- [x] Tested CRUD for all resources and records were found to be soft deleted
- [x] [LOOM](https://www.loom.com/share/bb9246961f7f447882f0ac86883ea539?sid=604afde8-2680-4eda-b7c5-4eb8911814b9) 

### Notes

- Prisma Client Extensions [docs](https://www.prisma.io/docs/orm/prisma-client/client-extensions)
- `$use` is used everywhere online - even Prisma doc's middlewares example uses it, but it is deprecated - use client extensions instead.