### PR TITLE
OUT-419 If I start editing a template, then hit Escape (to close), then click New Template, it loads the template I was editing

### DIFF
--- a/src/app/manage-templates/ui/TemplateForm.tsx
+++ b/src/app/manage-templates/ui/TemplateForm.tsx
@@ -12,7 +12,7 @@ import { statusIcons } from '@/utils/iconMatcher'
 import { Close } from '@mui/icons-material'
 import { Avatar, Box, Modal, Stack, Typography, styled } from '@mui/material'
 import { ReactNode } from 'react'
-import { IAssigneeCombined } from '@/types/interfaces'
+import { IAssigneeCombined, TargetMethod } from '@/types/interfaces'
 import { useHandleSelectorComponent } from '@/hooks/useHandleSelectorComponent'
 import { useSelector } from 'react-redux'
 import { selectTaskBoard } from '@/redux/features/taskBoardSlice'
@@ -27,13 +27,13 @@ import { getAssigneeTypeCorrected } from '@/utils/getAssigneeTypeCorrected'
 
 export const TemplateForm = ({ handleCreate }: { handleCreate: () => void }) => {
   const { workflowStates, assignee } = useSelector(selectTaskBoard)
-  const { showTemplateModal } = useSelector(selectCreateTemplate)
-
+  const { showTemplateModal, targetMethod } = useSelector(selectCreateTemplate)
   return (
     <Modal
       open={showTemplateModal}
       onClose={() => {
         store.dispatch(setShowTemplateModal({}))
+        store.dispatch(clearTemplateFields())
       }}
       aria-labelledby="create-task-modal"
       aria-describedby="add-new-task"
@@ -48,7 +48,11 @@ export const TemplateForm = ({ handleCreate }: { handleCreate: () => void }) => 
             padding: '16px 28px',
           }}
         >
-          <Typography variant="md">Create Template</Typography>
+          {targetMethod === TargetMethod.POST ? (
+            <Typography variant="md">Create Template</Typography>
+          ) : (
+            <Typography variant="md">Edit Template</Typography>
+          )}
           <Close
             sx={{ color: (theme) => theme.color.gray[500], cursor: 'pointer' }}
             onClick={() => {
@@ -61,7 +65,7 @@ export const TemplateForm = ({ handleCreate }: { handleCreate: () => void }) => 
         <AppMargin size={SizeofAppMargin.MEDIUM} py="16px">
           <NewTaskFormInputs />
         </AppMargin>
-        <NewTaskFooter handleCreate={handleCreate} />
+        <NewTaskFooter handleCreate={handleCreate} targetMethod={targetMethod} />
       </NewTaskContainer>
     </Modal>
   )
@@ -105,7 +109,7 @@ const NewTaskFormInputs = () => {
   )
 }
 
-const NewTaskFooter = ({ handleCreate }: { handleCreate: () => void }) => {
+const NewTaskFooter = ({ handleCreate, targetMethod }: { handleCreate: () => void; targetMethod: TargetMethod }) => {
   return (
     <Box sx={{ borderTop: (theme) => `1px solid ${theme.color.borders.border2}` }}>
       <AppMargin size={SizeofAppMargin.MEDIUM} py="21px">
@@ -125,7 +129,7 @@ const NewTaskFooter = ({ handleCreate }: { handleCreate: () => void }) => {
                 </Typography>
               }
             />
-            <PrimaryBtn handleClick={handleCreate} buttonText="Create" />
+            <PrimaryBtn handleClick={handleCreate} buttonText={targetMethod === TargetMethod.POST ? 'Create' : 'Edit'} />
           </Stack>
         </Stack>
       </AppMargin>

--- a/src/app/ui/NewTaskForm.tsx
+++ b/src/app/ui/NewTaskForm.tsx
@@ -63,10 +63,6 @@ export const NewTaskForm = ({ handleCreate }: { handleCreate: () => void }) => {
                 getSelectedValue={(_newValue) => {
                   const newValue = _newValue as ITemplate
                   updateTemplateValue(newValue)
-                  const selectedAssignee = assignee.find((el) => el.id === newValue.assigneeId)
-                  const selectedWorkflowState = workflowStates.find((el) => el.id === newValue.workflowStateId)
-                  updateAssigneeValue(selectedAssignee)
-                  updateStatusValue(selectedWorkflowState)
                   store.dispatch(setCreateTaskFields({ targetField: 'title', value: newValue.title }))
                   store.dispatch(setCreateTaskFields({ targetField: 'description', value: newValue.body }))
                   updateStatusValue(todoWorkflowState)

--- a/src/redux/features/templateSlice.tsx
+++ b/src/redux/features/templateSlice.tsx
@@ -28,11 +28,13 @@ const createTemplateSlice = createSlice({
   initialState,
   reducers: {
     setShowTemplateModal: (state, action: { payload: { targetMethod?: TargetMethod; targetTemplateId?: string } }) => {
-      state.showTemplateModal = !state.showTemplateModal
-      if (action.payload.targetMethod && action.payload.targetTemplateId) {
+      if (action.payload.targetMethod) {
         state.targetMethod = action.payload.targetMethod
+      }
+      if (action.payload.targetTemplateId) {
         state.targetTemplateId = action.payload.targetTemplateId
       }
+      state.showTemplateModal = !state.showTemplateModal
     },
     setCreateTemplateFields: (state, action: { payload: { targetField: string; value: string | null } }) => {
       const { targetField, value } = action.payload


### PR DESCRIPTION
### Tasks

- [If I start editing a template, then hit Escape (to close), then click New Template, it loads the template I was editing](https://linear.app/copilotplatforms/issue/OUT-419/if-i-start-editing-a-template-then-hit-escape-to-close-then-click-new)
- [When I load a template, the assignee should not change](https://linear.app/copilotplatforms/issue/OUT-417/when-i-load-a-template-the-assignee-should-not-change)
- [When editing a template, the modal should say Edit Template](https://linear.app/copilotplatforms/issue/OUT-418/when-editing-a-template-the-modal-should-say-edit-template)

### Changes

- [x] Applied clearTemplateFields() from slice in modal's onclose function for OUT-419. (If i start editing a templale, close modal, then click New template, it loads the template I was editing).
- [x] Fix assignee changing issue when loading a template. OUT-417.
- [x] Change modal name and button to Edit Template when editing a template. OUT-418.

### Testing Criteria

- [LOOM](https://www.loom.com/share/9f65ca87083949cb96333505d5a6800d)


