### PR TITLE
OUT-435 Typeahead not working for templates

### DIFF
--- a/src/app/ui/NewTaskForm.tsx
+++ b/src/app/ui/NewTaskForm.tsx
@@ -63,8 +63,8 @@ export const NewTaskForm = ({ handleCreate }: { handleCreate: () => void }) => {
                 getSelectedValue={(_newValue) => {
                   const newValue = _newValue as ITemplate
                   updateTemplateValue(newValue)
-                  store.dispatch(setCreateTaskFields({ targetField: 'title', value: newValue.title }))
-                  store.dispatch(setCreateTaskFields({ targetField: 'description', value: newValue.body }))
+                  store.dispatch(setCreateTaskFields({ targetField: 'title', value: newValue?.title }))
+                  store.dispatch(setCreateTaskFields({ targetField: 'description', value: newValue?.body }))
                   updateStatusValue(todoWorkflowState)
                 }}
                 startIcon={<TemplateIconSm />}
@@ -81,6 +81,7 @@ export const NewTaskForm = ({ handleCreate }: { handleCreate: () => void }) => {
                 extraOptionRenderer={(setAnchorEl, anchorEl, props) => {
                   return (
                     <Stack
+                      key={'Manage templates'}
                       direction="row"
                       pl="20px"
                       py="6px"

--- a/src/components/inputs/Selector.tsx
+++ b/src/components/inputs/Selector.tsx
@@ -66,6 +66,9 @@ export default function Selector({
 
     if (selectorType === SelectorType.STATUS_SELECTOR) {
       return (option as WorkflowStateResponse).name as string
+    }
+    if (selectorType === SelectorType.TEMPLATE_SELECTOR) {
+      return (option as ITemplate).templateName as string
     } else {
       return ''
     }
@@ -85,6 +88,8 @@ export default function Selector({
     }
   }, [])
 
+  console.log(value)
+
   return (
     <Stack direction="column">
       <Box onClick={handleClick} aria-describedby={id}>
@@ -101,7 +106,7 @@ export default function Selector({
         placement="bottom-start"
       >
         <StyledAutocomplete
-          id="status-box"
+          id={selectorType}
           onBlur={() => {
             setAnchorEl(null)
           }}
@@ -159,6 +164,7 @@ export default function Selector({
 const TemplateSelectorRenderer = ({ props, option }: { props: HTMLAttributes<HTMLLIElement>; option: unknown }) => {
   return (
     <Box
+      key={(option as ITemplate).id}
       component="li"
       {...props}
       sx={{


### PR DESCRIPTION
### Tasks

- [Typeahead not working for templates](https://linear.app/copilotplatforms/issue/OUT-435/typeahead-not-working-for-templates)

### Changes

- [x] Fixes typeahead on templates