### PR TITLE
OUT-411 When My tasks filter is selected, and I hit New task, default assignee should be me

### DIFF
--- a/src/app/ui/NewTaskForm.tsx
+++ b/src/app/ui/NewTaskForm.tsx
@@ -32,7 +32,10 @@ export const NewTaskForm = ({ handleCreate }: { handleCreate: () => void }) => {
     type: SelectorType.STATUS_SELECTOR,
   })
   const { renderingItem: _assigneeValue, updateRenderingItem: updateAssigneeValue } = useHandleSelectorComponent({
-    item: assignee.find((item) => item.id == filterOptions[FilterOptions.ASSIGNEE]) ?? NoAssignee,
+    item:
+      assignee.find(
+        (item) => item.id == filterOptions[FilterOptions.ASSIGNEE] || item.id == filterOptions[FilterOptions.TYPE],
+      ) ?? NoAssignee,
     type: SelectorType.ASSIGNEE_SELECTOR,
   })
   const { renderingItem: _templateValue, updateRenderingItem: updateTemplateValue } = useHandleSelectorComponent({
@@ -48,7 +51,6 @@ export const NewTaskForm = ({ handleCreate }: { handleCreate: () => void }) => {
 
   const todoWorkflowState = workflowStates.find((el) => el.key === 'todo') || workflowStates[0]
 
-  const { assigneeId, workflowStateId } = useSelector(selectCreateTask)
   return (
     <NewTaskContainer>
       <Stack

--- a/src/components/layouts/FilterBar.tsx
+++ b/src/components/layouts/FilterBar.tsx
@@ -41,6 +41,8 @@ export const FilterBar = ({ updateViewModeSetting }: { updateViewModeSetting: (m
       onClick: async (index: number) => {
         handleFilterOptionsChange(FilterOptions.TYPE, IUTokenSchema.parse(tokenPayload)?.internalUserId)
         setActiveButtonIndex(index)
+        handleFilterOptionsChange(FilterOptions.ASSIGNEE, '')
+        updateAssigneeValue(null)
       },
       id: 'MyTasks',
     },
@@ -69,7 +71,9 @@ export const FilterBar = ({ updateViewModeSetting }: { updateViewModeSetting: (m
       id: 'AllTasks',
     },
   ]
+
   const assigneeValue = _assigneeValue as IAssigneeCombined
+
   return (
     <Box>
       <Box
@@ -97,7 +101,7 @@ export const FilterBar = ({ updateViewModeSetting }: { updateViewModeSetting: (m
                     getSelectedValue={(_newValue) => {
                       const newValue = _newValue as IAssigneeCombined
                       updateAssigneeValue(newValue)
-                      handleFilterOptionsChange(FilterOptions.ASSIGNEE, newValue.id as string)
+                      handleFilterOptionsChange(FilterOptions.ASSIGNEE, newValue?.id as string)
                     }}
                     startIcon={<FilterByAsigneeIcon />}
                     options={assignee}


### PR DESCRIPTION
### Tasks

- [When My tasks filter is selected, and I hit New task, default assignee should be me](https://linear.app/copilotplatforms/issue/OUT-411/when-my-tasks-filter-is-selected-and-i-hit-new-task-default-assignee)
- [When I have a filter applied and I hit backspace to remove the filter, it chooses No Assignee but it shows me all tasks](https://linear.app/copilotplatforms/issue/OUT-431/when-i-have-a-filter-applied-and-i-hit-backspace-to-remove-the-filter)

### Changes

- [x] introduced null check on assignee.id to solve : "when filter is applied and removed through backspace, it chooses no assignee but shows all tasks"
- [x]  when my tasks is selected, it removes assignee values from filter options and assignee value in new task form is updated.

### Testing Criteria

- [LOOM](https://www.loom.com/share/2513e36244c143cb8a728da3f34897ab)


