### PR TITLE
OUT-412 When I'm looking at Client Tasks and I hit Filter by, options should match

### DIFF
--- a/src/app/ui/NewTaskForm.tsx
+++ b/src/app/ui/NewTaskForm.tsx
@@ -32,7 +32,10 @@ export const NewTaskForm = ({ handleCreate }: { handleCreate: () => void }) => {
     type: SelectorType.STATUS_SELECTOR,
   })
   const { renderingItem: _assigneeValue, updateRenderingItem: updateAssigneeValue } = useHandleSelectorComponent({
-    item: assignee.find((item) => item.id == filterOptions[FilterOptions.ASSIGNEE]) ?? NoAssignee,
+    item:
+      assignee.find(
+        (item) => item.id == filterOptions[FilterOptions.ASSIGNEE] || item.id == filterOptions[FilterOptions.TYPE],
+      ) ?? NoAssignee,
     type: SelectorType.ASSIGNEE_SELECTOR,
   })
   const { renderingItem: _templateValue, updateRenderingItem: updateTemplateValue } = useHandleSelectorComponent({
@@ -48,7 +51,6 @@ export const NewTaskForm = ({ handleCreate }: { handleCreate: () => void }) => {
 
   const todoWorkflowState = workflowStates.find((el) => el.key === 'todo') || workflowStates[0]
 
-  const { assigneeId, workflowStateId } = useSelector(selectCreateTask)
   return (
     <NewTaskContainer>
       <Stack

--- a/src/components/layouts/FilterBar.tsx
+++ b/src/components/layouts/FilterBar.tsx
@@ -80,6 +80,7 @@ export const FilterBar = ({ updateViewModeSetting }: { updateViewModeSetting: (m
         store.dispatch(setFilteredAssgineeList({ filteredType: 'none' }))
         handleFilterOptionsChange(FilterOptions.ASSIGNEE, '')
         updateAssigneeValue(null)
+        setNoAssigneeOptionFlag(true)
       },
       id: 'AllTasks',
     },

--- a/src/components/layouts/FilterBar.tsx
+++ b/src/components/layouts/FilterBar.tsx
@@ -41,6 +41,8 @@ export const FilterBar = ({ updateViewModeSetting }: { updateViewModeSetting: (m
       onClick: async (index: number) => {
         handleFilterOptionsChange(FilterOptions.TYPE, IUTokenSchema.parse(tokenPayload)?.internalUserId)
         setActiveButtonIndex(index)
+        handleFilterOptionsChange(FilterOptions.ASSIGNEE, '')
+        updateAssigneeValue(null)
       },
       id: 'MyTasks',
     },
@@ -69,7 +71,9 @@ export const FilterBar = ({ updateViewModeSetting }: { updateViewModeSetting: (m
       id: 'AllTasks',
     },
   ]
+
   const assigneeValue = _assigneeValue as IAssigneeCombined
+
   return (
     <Box>
       <Box
@@ -97,7 +101,7 @@ export const FilterBar = ({ updateViewModeSetting }: { updateViewModeSetting: (m
                     getSelectedValue={(_newValue) => {
                       const newValue = _newValue as IAssigneeCombined
                       updateAssigneeValue(newValue)
-                      handleFilterOptionsChange(FilterOptions.ASSIGNEE, newValue.id as string)
+                      handleFilterOptionsChange(FilterOptions.ASSIGNEE, newValue?.id as string)
                     }}
                     startIcon={<FilterByAsigneeIcon />}
                     options={assignee}

--- a/src/components/layouts/FilterBar.tsx
+++ b/src/components/layouts/FilterBar.tsx
@@ -10,7 +10,14 @@ import Selector, { SelectorType } from '@/components/inputs/Selector'
 import { useHandleSelectorComponent } from '@/hooks/useHandleSelectorComponent'
 import { selectTaskBoard } from '@/redux/features/taskBoardSlice'
 import { useSelector } from 'react-redux'
-import { FilterOptions, FilterOptionsKeywords, IAssigneeCombined, IFilterOptions, View } from '@/types/interfaces'
+import {
+  FilterByOptions,
+  FilterOptions,
+  FilterOptionsKeywords,
+  IAssigneeCombined,
+  IFilterOptions,
+  View,
+} from '@/types/interfaces'
 import { FilterByAsigneeIcon } from '@/icons'
 import { ViewModeSelector } from '../inputs/ViewModeSelector'
 import { FilterByAssigneeBtn } from '../buttons/FilterByAssigneeBtn'
@@ -43,7 +50,7 @@ export const FilterBar = ({ updateViewModeSetting }: { updateViewModeSetting: (m
         handleFilterOptionsChange(FilterOptions.TYPE, IUTokenSchema.parse(tokenPayload)?.internalUserId)
         setActiveButtonIndex(index)
         handleFilterOptionsChange(FilterOptions.ASSIGNEE, '')
-        store.dispatch(setFilteredAssgineeList({ filteredType: 'none' }))
+        store.dispatch(setFilteredAssgineeList({ filteredType: FilterByOptions.NOFILTER }))
         updateAssigneeValue(null)
       },
       id: 'MyTasks',
@@ -53,7 +60,7 @@ export const FilterBar = ({ updateViewModeSetting }: { updateViewModeSetting: (m
       onClick: (index: number) => {
         handleFilterOptionsChange(FilterOptions.TYPE, FilterOptionsKeywords.TEAM)
         setActiveButtonIndex(index)
-        store.dispatch(setFilteredAssgineeList({ filteredType: 'internalUsers' }))
+        store.dispatch(setFilteredAssgineeList({ filteredType: FilterByOptions.IUS }))
         handleFilterOptionsChange(FilterOptions.ASSIGNEE, '')
         updateAssigneeValue(null)
         setNoAssigneeOptionFlag(false)
@@ -65,7 +72,7 @@ export const FilterBar = ({ updateViewModeSetting }: { updateViewModeSetting: (m
       onClick: (index: number) => {
         handleFilterOptionsChange(FilterOptions.TYPE, FilterOptionsKeywords.CLIENTS)
         setActiveButtonIndex(index)
-        store.dispatch(setFilteredAssgineeList({ filteredType: 'clients' }))
+        store.dispatch(setFilteredAssgineeList({ filteredType: FilterByOptions.CLIENT }))
         handleFilterOptionsChange(FilterOptions.ASSIGNEE, '')
         updateAssigneeValue(null)
         setNoAssigneeOptionFlag(false)
@@ -77,7 +84,7 @@ export const FilterBar = ({ updateViewModeSetting }: { updateViewModeSetting: (m
       onClick: (index: number) => {
         handleFilterOptionsChange(FilterOptions.TYPE, '')
         setActiveButtonIndex(index)
-        store.dispatch(setFilteredAssgineeList({ filteredType: 'none' }))
+        store.dispatch(setFilteredAssgineeList({ filteredType: FilterByOptions.NOFILTER }))
         handleFilterOptionsChange(FilterOptions.ASSIGNEE, '')
         updateAssigneeValue(null)
         setNoAssigneeOptionFlag(true)

--- a/src/redux/features/taskBoardSlice.tsx
+++ b/src/redux/features/taskBoardSlice.tsx
@@ -2,7 +2,7 @@ import { createSlice } from '@reduxjs/toolkit'
 import { RootState } from '../store'
 import { WorkflowStateResponse } from '@/types/dto/workflowStates.dto'
 import { TaskResponse } from '@/types/dto/tasks.dto'
-import { AssigneeType, FilterOptions, IAssigneeCombined, IFilterOptions, View } from '@/types/interfaces'
+import { AssigneeType, FilterByOptions, FilterOptions, IAssigneeCombined, IFilterOptions, View } from '@/types/interfaces'
 
 interface IInitialState {
   workflowStates: WorkflowStateResponse[]
@@ -68,15 +68,17 @@ const taskBoardSlice = createSlice({
         [action.payload.optionType]: action.payload.newValue,
       }
     },
-    setFilteredAssgineeList: (state, action: { payload: { filteredType: string } }) => {
+    setFilteredAssgineeList: (state, action: { payload: { filteredType: FilterByOptions } }) => {
       const filteredType = action.payload.filteredType
       if (filteredType == 'internalUsers') {
-        state.filteredAssigneeList = state.assignee.filter((el) => el.type == 'internalUsers')
+        state.filteredAssigneeList = state.assignee.filter((el) => el.type == FilterByOptions.IUS)
       }
       if (filteredType == 'clients') {
-        state.filteredAssigneeList = state.assignee.filter((el) => el.type == 'clients' || el.type == 'companies')
+        state.filteredAssigneeList = state.assignee.filter(
+          (el) => el.type == FilterByOptions.CLIENT || el.type == FilterByOptions.COMPANY,
+        )
       }
-      if (filteredType == 'none') {
+      if (filteredType == FilterByOptions.NOFILTER) {
         state.filteredAssigneeList = state.assignee
       }
     },

--- a/src/redux/features/taskBoardSlice.tsx
+++ b/src/redux/features/taskBoardSlice.tsx
@@ -12,6 +12,7 @@ interface IInitialState {
   view: View
   filteredTasks: TaskResponse[]
   filterOptions: IFilterOptions
+  filteredAssigneeList: IAssigneeCombined[]
 }
 
 const initialState: IInitialState = {
@@ -26,6 +27,7 @@ const initialState: IInitialState = {
     [FilterOptions.KEYWORD]: '',
     [FilterOptions.TYPE]: '',
   },
+  filteredAssigneeList: [],
 }
 
 const taskBoardSlice = createSlice({
@@ -55,6 +57,7 @@ const taskBoardSlice = createSlice({
     },
     setAssigneeList: (state, action: { payload: IAssigneeCombined[] }) => {
       state.assignee = action.payload
+      state.filteredAssigneeList = action.payload
     },
     setViewSettings: (state, action: { payload: View }) => {
       state.view = action.payload
@@ -63,6 +66,18 @@ const taskBoardSlice = createSlice({
       state.filterOptions = {
         ...state.filterOptions,
         [action.payload.optionType]: action.payload.newValue,
+      }
+    },
+    setFilteredAssgineeList: (state, action: { payload: { filteredType: string } }) => {
+      const filteredType = action.payload.filteredType
+      if (filteredType == 'internalUsers') {
+        state.filteredAssigneeList = state.assignee.filter((el) => el.type == 'internalUsers')
+      }
+      if (filteredType == 'clients') {
+        state.filteredAssigneeList = state.assignee.filter((el) => el.type == 'clients' || el.type == 'companies')
+      }
+      if (filteredType == 'none') {
+        state.filteredAssigneeList = state.assignee
       }
     },
   },
@@ -79,6 +94,7 @@ export const {
   setFilteredTasks,
   setViewSettings,
   setFilterOptions,
+  setFilteredAssgineeList,
 } = taskBoardSlice.actions
 
 export default taskBoardSlice.reducer

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -48,6 +48,13 @@ export enum FilterOptions {
   TYPE = 'type',
 }
 
+export enum FilterByOptions {
+  CLIENT = 'clients',
+  COMPANY = 'companies',
+  IUS = 'internalUsers',
+  NOFILTER = 'none',
+}
+
 export enum FilterOptionsKeywords {
   CLIENTS = 'clients_companies',
   TEAM = 'ius',


### PR DESCRIPTION
### Tasks

- [When I'm looking at Client Tasks and I hit Filter by, options should match](https://linear.app/copilotplatforms/issue/OUT-412/when-im-looking-at-client-tasks-and-i-hit-filter-by-options-should)

### Changes

- [x] created new functions and variable on taskBoardSlice : FilteredAssigneeList and SetFilteredAssigneeList
- [x] When my team tasks filter is selected, only internal users are filtered using setFilteredAssigneeList and no assignee option is removed (using state flag)
- [x] When client tasks filter is selected, only clients and companies are shown in filtered by.  

### Testing Criteria

- [LOOM](https://www.loom.com/share/a519c30ecae442c8b207c1c6b32f5982)

