### PR TITLE
OUT 475 | OUT-476 Issues with Assignee selector

### DIFF
--- a/src/app/ui/NewTaskForm.tsx
+++ b/src/app/ui/NewTaskForm.tsx
@@ -17,7 +17,7 @@ import { statusIcons } from '@/utils/iconMatcher'
 import { Close } from '@mui/icons-material'
 import { Avatar, Box, Stack, Typography, styled } from '@mui/material'
 import React, { ReactNode, useEffect } from 'react'
-import { FilterOptions, IAssigneeCombined, ISignedUrlUpload, ITemplate } from '@/types/interfaces'
+import { FilterOptions, IAssigneeCombined, ISignedUrlUpload, ITemplate, TruncateMaxNumber } from '@/types/interfaces'
 import { useHandleSelectorComponent } from '@/hooks/useHandleSelectorComponent'
 import { useSelector } from 'react-redux'
 import { selectTaskBoard } from '@/redux/features/taskBoardSlice'
@@ -37,6 +37,7 @@ import { bulkRemoveAttachments } from '@/utils/bulkRemoveAttachments'
 import { advancedFeatureFlag } from '@/config'
 import { getAssigneeName } from '@/utils/getAssigneeName'
 import { WorkflowStateSelector } from '@/components/inputs/Selector-WorkflowState'
+import { truncateText } from '@/utils/truncateText'
 
 const supabaseActions = new SupabaseActions()
 
@@ -89,7 +90,6 @@ export const NewTaskForm = ({
     }
   }, [])
 
-  const { assigneeId, workflowStateId } = useSelector(selectCreateTask)
   return (
     <NewTaskContainer>
       <Stack
@@ -217,7 +217,11 @@ export const NewTaskForm = ({
               selectorType={SelectorType.ASSIGNEE_SELECTOR}
               buttonContent={
                 <Typography variant="bodySm" lineHeight="16px" sx={{ color: (theme) => theme.color.gray[600] }}>
-                  {assigneeValue?.name || assigneeValue?.givenName}
+                  {truncateText(
+                    (assigneeValue as IAssigneeCombined)?.name ||
+                      `${(assigneeValue as IAssigneeCombined)?.givenName ?? ''} ${(assigneeValue as IAssigneeCombined)?.familyName ?? ''}`.trim(),
+                    TruncateMaxNumber.SELECTOR,
+                  )}
                 </Typography>
               }
             />

--- a/src/components/inputs/Selector.tsx
+++ b/src/components/inputs/Selector.tsx
@@ -1,5 +1,4 @@
 import { Avatar, Box, Button, Popper, Stack, Typography } from '@mui/material'
-import { SecondaryBtn } from '@/components/buttons/SecondaryBtn'
 import { StyledAutocomplete } from '@/components/inputs/Autocomplete'
 import { statusIcons } from '@/utils/iconMatcher'
 import { useFocusableInput } from '@/hooks/useFocusableInput'
@@ -63,7 +62,11 @@ export default function Selector({
 
   function detectSelectorType(option: unknown) {
     if (selectorType === SelectorType.ASSIGNEE_SELECTOR) {
-      return ((option as IAssigneeCombined).name as string) || ((option as IAssigneeCombined).givenName as string)
+      return truncateText(
+        (option as IAssigneeCombined)?.name ||
+          `${(option as IAssigneeCombined)?.givenName ?? ''} ${(option as IAssigneeCombined)?.familyName ?? ''}`.trim(),
+        TruncateMaxNumber.SELECTOR,
+      )
     }
 
     if (selectorType === SelectorType.STATUS_SELECTOR) {
@@ -142,8 +145,8 @@ export default function Selector({
           options={extraOption ? [extraOption, ...options] : options}
           value={value}
           onChange={(_, newValue: unknown) => {
-            getSelectedValue(newValue)
             if (newValue) {
+              getSelectedValue(newValue)
               setAnchorEl(null)
             }
           }}
@@ -263,7 +266,7 @@ const AssigneeSelectorRenderer = ({ props, option }: { props: HTMLAttributes<HTM
         <Typography variant="sm" fontWeight={400}>
           {truncateText(
             (option as IAssigneeCombined)?.name ||
-              `${(option as IAssigneeCombined)?.givenName ?? ''}  ${(option as IAssigneeCombined)?.familyName ?? ''}`.trim(),
+              `${(option as IAssigneeCombined)?.givenName ?? ''} ${(option as IAssigneeCombined)?.familyName ?? ''}`.trim(),
             TruncateMaxNumber.SELECTOR,
           )}
         </Typography>


### PR DESCRIPTION
### Tasks

- [Assignee dropdown allows me to set assignee as empty text](https://linear.app/copilotplatforms/issue/OUT-475/assignee-dropdown-allows-me-to-set-assignee-as-empty-text)
- [Assignee autocomplete stops working after a space is inserted](https://linear.app/copilotplatforms/issue/OUT-476/assignee-autocomplete-stops-working-after-a-space-is-inserted)

### Changes

- [x] Fixes assignee dropdown allowing to set empty text
- [x] Fixes autocomplete not working with spacing
