### PR TITLE
OUT-479 Task card overflow issue

### DIFF
--- a/src/components/cards/AttachmentCard.tsx
+++ b/src/components/cards/AttachmentCard.tsx
@@ -48,8 +48,11 @@ export const AttachmentCard = ({ file, deleteAttachment }: Prop) => {
       >
         <Box>{attachmentIcons[fileType]}</Box>
         <Stack direction="column" rowGap="7px">
-          <Typography variant="sm" sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-            {truncateText(fileName, TruncateMaxNumber.ATTACHMENT)}
+          <Typography
+            variant="sm"
+            sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', width: '100px' }}
+          >
+            {fileName}
           </Typography>
           <Typography variant="bodySm">{Math.floor(fileSize / 1024)} KB</Typography>
         </Stack>

--- a/src/components/cards/ClientTaskCard.tsx
+++ b/src/components/cards/ClientTaskCard.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Avatar, Box, Stack, Typography } from '@mui/material'
+import { Avatar, Box, Divider, Stack, Typography } from '@mui/material'
 import { SecondaryBtn } from '../buttons/SecondaryBtn'
 import { TaskResponse } from '@/types/dto/tasks.dto'
 import { useSelector } from 'react-redux'
@@ -35,89 +35,92 @@ export const ClientTaskCard = ({
         },
       }}
     >
-      <AppMargin size={SizeofAppMargin.LARGE} py="2px">
-        <Stack direction={{ xs: 'column', sm: 'row' }} rowGap={2} alignItems="flex-start" justifyContent="space-between">
-          <Stack sx={{ width: '100%', cursor: 'pointer' }} direction="column" onClick={() => handleRouteChange()}>
-            <Typography variant="sm">{task?.title}</Typography>
-            <Box
-              sx={{
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                maxWidth: '64em',
-              }}
-            >
-              <Typography variant="bodySm">
-                {truncateText(extractHtml(task.body ?? ''), TruncateMaxNumber.CLIENT_TASK_DESCRIPTION)}
-              </Typography>
-            </Box>
-          </Stack>
-          <Stack direction="row" alignItems="flex-start" minWidth="fit-content" columnGap={4} justifyContent="space-between">
-            <Stack
-              direction="row"
-              alignItems="flex-end"
-              minWidth="200px"
-              columnGap={{ xs: 1, sm: 3 }}
-              sx={{ padding: '2px' }}
-            >
+      <AppMargin size={SizeofAppMargin.LARGE} py="12px">
+        <Box sx={{ paddingTop: '2px', paddingBottom: '2px' }}>
+          <Stack direction={{ xs: 'column', sm: 'row' }} alignItems="flex-start" justifyContent="space-between">
+            <Stack sx={{ width: '100%', cursor: 'pointer' }} direction="column" onClick={() => handleRouteChange()}>
+              <Typography variant="sm">{task?.title}</Typography>
               <Box
-                minWidth={{ xs: '90px' }}
                 sx={{
-                  flexDirection: 'row',
-                  alignItems: { sm: 'flex-end' },
-                  justifyContent: { sm: 'right' },
-                  display: 'flex',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  maxWidth: '64em',
                 }}
               >
-                {task.dueDate && (
-                  <Typography variant="bodySm">
-                    <DueDateLayout date={task.dueDate} />
-                  </Typography>
-                )}
+                <Typography variant="bodySm">
+                  {truncateText(extractHtml(task.body ?? ''), TruncateMaxNumber.CLIENT_TASK_DESCRIPTION)}
+                </Typography>
               </Box>
-              <Stack direction="row" alignItems="flex-start" columnGap={1} sx={{ padding: '2px' }}>
-                <Avatar
-                  src={currentAssignee?.iconImageUrl || currentAssignee?.avatarImageUrl || 'user'}
-                  alt={currentAssignee?.givenName || currentAssignee?.familyName || currentAssignee?.name}
-                  sx={{ width: '20px', height: '20px' }}
-                  variant={currentAssignee?.type === 'companies' ? 'rounded' : 'circular'}
-                />
-
-                <Typography
-                  variant="bodySm"
+            </Stack>
+            <Stack
+              direction="row"
+              alignItems="flex-start"
+              minWidth="fit-content"
+              columnGap={4}
+              justifyContent="space-between"
+            >
+              <Stack direction="row" alignItems="flex-end" minWidth="200px" columnGap={{ xs: 1, sm: 3 }}>
+                <Box
+                  minWidth={{ xs: '90px' }}
                   sx={{
-                    color: (theme) => theme.color.gray[600],
-                    textOverflow: 'ellipsis',
-                    whiteSpace: 'nowrap',
-                    overflow: 'hidden',
+                    flexDirection: 'row',
+                    alignItems: { sm: 'flex-end' },
+                    justifyContent: { sm: 'right' },
+                    display: 'flex',
                   }}
                 >
-                  {truncateText(
-                    (currentAssignee as IAssigneeCombined)?.name ||
-                      `${(currentAssignee as IAssigneeCombined)?.givenName ?? ''} ${(currentAssignee as IAssigneeCombined)?.familyName ?? ''}`.trim() ||
-                      'No Assignee',
-                    TruncateMaxNumber.SELECTOR,
+                  {task.dueDate && (
+                    <Typography variant="bodySm">
+                      <DueDateLayout date={task.dueDate} />
+                    </Typography>
                   )}
-                </Typography>
+                </Box>
+                <Stack direction="row" alignItems="flex-start" columnGap={1} sx={{ padding: '2px' }}>
+                  <Avatar
+                    src={currentAssignee?.iconImageUrl || currentAssignee?.avatarImageUrl || 'user'}
+                    alt={currentAssignee?.givenName || currentAssignee?.familyName || currentAssignee?.name}
+                    sx={{ width: '20px', height: '20px' }}
+                    variant={currentAssignee?.type === 'companies' ? 'rounded' : 'circular'}
+                  />
+
+                  <Typography
+                    variant="bodySm"
+                    sx={{
+                      color: (theme) => theme.color.gray[600],
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                      overflow: 'hidden',
+                    }}
+                  >
+                    {truncateText(
+                      (currentAssignee as IAssigneeCombined)?.name ||
+                        `${(currentAssignee as IAssigneeCombined)?.givenName ?? ''} ${(currentAssignee as IAssigneeCombined)?.familyName ?? ''}`.trim() ||
+                        'No Assignee',
+                      TruncateMaxNumber.SELECTOR,
+                    )}
+                  </Typography>
+                </Stack>
+              </Stack>
+
+              <Stack direction="row" alignItems="flex-start" minWidth={'120px'} columnGap={2} ml="12px">
+                <Box minWidth="fit-content" ml="12px">
+                  {!markdoneFlag && (
+                    <SecondaryBtn
+                      handleClick={() => handleMarkDone()}
+                      buttonContent={
+                        <Typography variant="sm" sx={{ color: (theme) => theme.color.gray[700] }}>
+                          Mark done
+                        </Typography>
+                      }
+                    />
+                  )}
+                </Box>
               </Stack>
             </Stack>
-
-            <Stack direction="row" alignItems="flex-start" minWidth={'120px'} columnGap={2} ml="12px">
-              <Box minWidth="fit-content" ml="12px">
-                {!markdoneFlag && (
-                  <SecondaryBtn
-                    handleClick={() => handleMarkDone()}
-                    buttonContent={
-                      <Typography variant="sm" sx={{ color: (theme) => theme.color.gray[700] }}>
-                        Mark done
-                      </Typography>
-                    }
-                  />
-                )}
-              </Box>
-            </Stack>
           </Stack>
-        </Stack>
+        </Box>
       </AppMargin>
+      <Divider sx={{ bgcolor: (theme) => theme.color.gray[150], borderBottomWidth: '1px' }} />
     </Box>
   )
 }

--- a/src/components/cards/ClientTaskCard.tsx
+++ b/src/components/cards/ClientTaskCard.tsx
@@ -44,7 +44,7 @@ export const ClientTaskCard = ({
                 sx={{
                   overflow: 'hidden',
                   textOverflow: 'ellipsis',
-                  maxWidth: '64em',
+                  maxWidth: '70em',
                 }}
               >
                 <Typography variant="bodySm">
@@ -75,7 +75,7 @@ export const ClientTaskCard = ({
                     </Typography>
                   )}
                 </Box>
-                <Stack direction="row" alignItems="flex-start" columnGap={1} sx={{ padding: '2px' }}>
+                <Stack direction="row" alignItems="flex-start" columnGap={1} sx={{ padding: '2px', maxWidth: '200px' }}>
                   <Avatar
                     src={currentAssignee?.iconImageUrl || currentAssignee?.avatarImageUrl || 'user'}
                     alt={currentAssignee?.givenName || currentAssignee?.familyName || currentAssignee?.name}
@@ -92,12 +92,9 @@ export const ClientTaskCard = ({
                       overflow: 'hidden',
                     }}
                   >
-                    {truncateText(
-                      (currentAssignee as IAssigneeCombined)?.name ||
-                        `${(currentAssignee as IAssigneeCombined)?.givenName ?? ''} ${(currentAssignee as IAssigneeCombined)?.familyName ?? ''}`.trim() ||
-                        'No Assignee',
-                      TruncateMaxNumber.SELECTOR,
-                    )}
+                    {(currentAssignee as IAssigneeCombined)?.name ||
+                      `${(currentAssignee as IAssigneeCombined)?.givenName ?? ''} ${(currentAssignee as IAssigneeCombined)?.familyName ?? ''}`.trim() ||
+                      'No Assignee'}
                   </Typography>
                 </Stack>
               </Stack>

--- a/src/components/cards/ClientTaskCard.tsx
+++ b/src/components/cards/ClientTaskCard.tsx
@@ -120,7 +120,7 @@ export const ClientTaskCard = ({
           </Stack>
         </Box>
       </AppMargin>
-      <Divider sx={{ bgcolor: (theme) => theme.color.gray[150], borderBottomWidth: '1px' }} />
+      <Divider sx={{ borderColor: (theme) => theme.color.gray[150], borderBottomWidth: '1px' }} />
     </Box>
   )
 }

--- a/src/components/cards/TaskCard.tsx
+++ b/src/components/cards/TaskCard.tsx
@@ -7,6 +7,8 @@ import { NoAssignee } from '@/utils/noAssignee'
 import { Avatar, Stack, Typography, styled } from '@mui/material'
 import { useSelector } from 'react-redux'
 import { DueDateLayout } from '@/components/utils/DueDateLayout'
+import { truncateText } from '@/utils/truncateText'
+import { TruncateMaxNumber } from '@/types/constants'
 
 const TaskCardContainer = styled(Stack)(({ theme }) => ({
   border: `1px solid ${theme.color.borders.border}`,
@@ -37,8 +39,11 @@ export const TaskCard = ({ task }: { task: TaskResponse }) => {
           <Typography variant="sm" fontSize="12px" sx={{ color: (theme) => theme.color.gray[500] }}>
             {(currentAssignee as IAssigneeCombined).name === 'No assignee'
               ? 'No assignee'
-              : (currentAssignee as IAssigneeCombined)?.name ||
-                `${(currentAssignee as IAssigneeCombined)?.givenName ?? ''} ${(currentAssignee as IAssigneeCombined)?.familyName ?? ''}`.trim()}
+              : truncateText(
+                  (currentAssignee as IAssigneeCombined)?.name ||
+                    `${(currentAssignee as IAssigneeCombined)?.givenName ?? ''} ${(currentAssignee as IAssigneeCombined)?.familyName ?? ''}`.trim(),
+                  TruncateMaxNumber.TASK_CARD_NAME,
+                )}
           </Typography>
         </Stack>
         <Typography variant="bodyXs" fontWeight={400} sx={{ color: (theme) => theme.color.gray[500] }}>

--- a/src/components/cards/TaskCard.tsx
+++ b/src/components/cards/TaskCard.tsx
@@ -7,8 +7,6 @@ import { NoAssignee } from '@/utils/noAssignee'
 import { Avatar, Stack, Typography, styled } from '@mui/material'
 import { useSelector } from 'react-redux'
 import { DueDateLayout } from '@/components/utils/DueDateLayout'
-import { truncateText } from '@/utils/truncateText'
-import { TruncateMaxNumber } from '@/types/constants'
 
 const TaskCardContainer = styled(Stack)(({ theme }) => ({
   border: `1px solid ${theme.color.borders.border}`,
@@ -36,14 +34,21 @@ export const TaskCard = ({ task }: { task: TaskResponse }) => {
             sx={{ width: '20px', height: '20px' }}
             variant={(currentAssignee as IAssigneeCombined)?.type === 'companies' ? 'rounded' : 'circular'}
           />
-          <Typography variant="sm" fontSize="12px" sx={{ color: (theme) => theme.color.gray[500] }}>
+          <Typography
+            variant="sm"
+            fontSize="12px"
+            sx={{
+              color: (theme) => theme.color.gray[500],
+              width: '146px',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
             {(currentAssignee as IAssigneeCombined).name === 'No assignee'
               ? 'No assignee'
-              : truncateText(
-                  (currentAssignee as IAssigneeCombined)?.name ||
-                    `${(currentAssignee as IAssigneeCombined)?.givenName ?? ''} ${(currentAssignee as IAssigneeCombined)?.familyName ?? ''}`.trim(),
-                  TruncateMaxNumber.TASK_CARD_NAME,
-                )}
+              : (currentAssignee as IAssigneeCombined)?.name ||
+                `${(currentAssignee as IAssigneeCombined)?.givenName ?? ''} ${(currentAssignee as IAssigneeCombined)?.familyName ?? ''}`.trim()}
           </Typography>
         </Stack>
         <Typography variant="bodyXs" fontWeight={400} sx={{ color: (theme) => theme.color.gray[500] }}>

--- a/src/types/constants.ts
+++ b/src/types/constants.ts
@@ -2,4 +2,5 @@ export enum TruncateMaxNumber {
   ATTACHMENT = 15,
   SELECTOR = 16,
   CLIENT_TASK_DESCRIPTION = 256,
+  TASK_CARD_NAME = 22,
 }

--- a/src/types/constants.ts
+++ b/src/types/constants.ts
@@ -1,6 +1,4 @@
 export enum TruncateMaxNumber {
-  ATTACHMENT = 15,
   SELECTOR = 16,
   CLIENT_TASK_DESCRIPTION = 256,
-  TASK_CARD_NAME = 22,
 }


### PR DESCRIPTION
- also introduced divider in CU view

### Tasks

- [Task card overflow issue](https://linear.app/copilotplatforms/issue/OUT-479/task-card-overflow-issue)

### Changes

- [x] Fixed task card overflow in board view by truncating text which are more than 22 char for assignee Name.
- [x] Introduces divider in CU task view with 1px padding and color aligning to figma design.

### Testing Criteria

![image](https://github.com/copilot-platforms/tasks-app/assets/46821825/47d74281-9d2e-4f39-8f9d-4d98639e7b00)

