### PR TITLE
OUT-510 Client should not be allowed to change due dates in the UI

### DIFF
--- a/src/app/detail/ui/Sidebar.tsx
+++ b/src/app/detail/ui/Sidebar.tsx
@@ -160,6 +160,7 @@ export const Sidebar = ({
                 })
               }}
               dateValue={dueDate ? isoToReadableDate(dueDate) : undefined}
+              disabled={disabled}
             />
           </Box>
         </Stack>

--- a/src/components/inputs/DatePickerComponent.tsx
+++ b/src/components/inputs/DatePickerComponent.tsx
@@ -10,9 +10,10 @@ import { Box, Popper, Stack, Typography } from '@mui/material'
 interface Prop {
   getDate: (value: string) => void
   dateValue?: IsoDate
+  disabled?: boolean
 }
 
-export const DatePickerComponent = ({ getDate, dateValue }: Prop) => {
+export const DatePickerComponent = ({ getDate, dateValue, disabled }: Prop) => {
   const [value, setValue] = React.useState<Dayjs | null>(dateValue ? dayjs(dateValue) : null)
 
   const formatDate = (date: Dayjs | null) => {
@@ -22,7 +23,9 @@ export const DatePickerComponent = ({ getDate, dateValue }: Prop) => {
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null)
 
   const handleClick = (event: React.MouseEvent<HTMLElement>) => {
-    setAnchorEl(anchorEl ? null : event.currentTarget)
+    if (!disabled) {
+      setAnchorEl(anchorEl ? null : event.currentTarget)
+    }
   }
 
   const open = Boolean(anchorEl)


### PR DESCRIPTION
### Tasks

- [Client should not be allowed to change due dates in the UI](https://linear.app/copilotplatforms/issue/OUT-510/client-should-not-be-allowed-to-change-due-dates-in-the-ui)

### Changes

- [x] Clients not allowed to modify/add due dates in the details page