### PR TITLE
OUT-387 | OUT-533 | Backend Notification Bugs

### DIFF
--- a/src/app/api/core/types/tasks.ts
+++ b/src/app/api/core/types/tasks.ts
@@ -1,5 +1,6 @@
 export enum NotificationTaskActions {
   Assigned = 'assigned',
+  AssignedToCompany = 'assignedToCompany',
   Completed = 'completed',
   Commented = 'commented',
   Mentioned = 'mentioned',

--- a/src/app/api/notification/notification.helpers.ts
+++ b/src/app/api/notification/notification.helpers.ts
@@ -17,7 +17,7 @@ export const getInProductNotificationDetails = (
       body: `A new task was assigned to you by ${actionUser}. To see details about the task, navigate to the Tasks App below.`,
     },
     [NotificationTaskActions.AssignedToCompany]: {
-      title: 'Task was assigned to you your company',
+      title: 'Task was assigned to your company',
       body: `A new task was assigned to your company by ${actionUser}. To see details about the task, navigate to the Tasks App below.`,
     },
     [NotificationTaskActions.Completed]: {

--- a/src/app/api/notification/notification.helpers.ts
+++ b/src/app/api/notification/notification.helpers.ts
@@ -16,6 +16,10 @@ export const getInProductNotificationDetails = (
       title: 'Task was assigned to you',
       body: `A new task was assigned to you by ${actionUser}. To see details about the task, navigate to the Tasks App below.`,
     },
+    [NotificationTaskActions.AssignedToCompany]: {
+      title: 'Task was assigned to you your company',
+      body: `A new task was assigned to your company by ${actionUser}. To see details about the task, navigate to the Tasks App below.`,
+    },
     [NotificationTaskActions.Completed]: {
       title: 'A client completed a task',
       body: `A new task was completed by ${actionUser}. You are receiving this notification because you have access to the client.`,
@@ -48,6 +52,12 @@ export const getEmailDetails = (
       subject: 'Task was assigned to you',
       header: 'Task was assigned to you',
       body: `A new task was assigned to you by ${actionUser}. To see details about the task, navigate to the Tasks App below.`,
+    },
+    [NotificationTaskActions.AssignedToCompany]: {
+      title: 'Task was assigned to your company',
+      subject: 'Task was assigned to your company',
+      header: 'Task was assigned to your company',
+      body: `A new task was assigned to your company by ${actionUser}. To see details about the task, navigate to the Tasks App below.`,
     },
     [NotificationTaskActions.Completed]: {
       title: 'A client completed a task',

--- a/src/app/api/notification/notification.service.ts
+++ b/src/app/api/notification/notification.service.ts
@@ -64,9 +64,10 @@ export class NotificationService extends BaseService {
    * defined by NotificationTaskActions. This method returns the senderId, receiverId, and actionUser (user that is creating the notification action)
    * based on the NotificationTaskActions.
    */
-  private async getNotificationParties(copilot: CopilotAPI, task: Task, action: NotificationTaskActions) {
+  async getNotificationParties(copilot: CopilotAPI, task: Task, action: NotificationTaskActions) {
     let senderId: string
-    let recipientId: string
+    let recipientId: string = ''
+    let recipientIds: string[] = []
     let actionTrigger: CopilotUser | CompanyResponse
 
     const getAssignedTo = async (): Promise<CopilotUser | CompanyResponse> => {
@@ -88,6 +89,11 @@ export class NotificationService extends BaseService {
         recipientId = z.string().parse(task.assigneeId)
         actionTrigger = await copilot.getInternalUser(senderId)
         break
+      case NotificationTaskActions.AssignedToCompany:
+        senderId = task.createdById
+        recipientIds = (await copilot.getCompanyClients(z.string().parse(task.assigneeId))).map((client) => client.id)
+        actionTrigger = await copilot.getInternalUser(senderId)
+        break
       case NotificationTaskActions.Completed:
         senderId = z.string().parse(task.assigneeId)
         recipientId = task.createdById
@@ -106,6 +112,6 @@ export class NotificationService extends BaseService {
         ? (actionTrigger as CompanyResponse).name
         : `${(actionTrigger as CopilotUser).givenName} ${(actionTrigger as CopilotUser).familyName}`
 
-    return { senderId, recipientId, actionUser }
+    return { senderId, recipientId, recipientIds, actionUser }
   }
 }

--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -112,7 +112,8 @@ export class TasksService extends BaseService {
     }
 
     // If new task is assigned to someone (IU / Client), send proper notification + email to them
-    if (newTask.assigneeId) {
+    // But if the task was assigned to the same user that created the task, skip notifications entirely
+    if (newTask.assigneeId && newTask.assigneeId !== newTask.createdById) {
       const notificationService = new NotificationService(this.user)
       if (newTask.assigneeType === AssigneeType.company) {
         const copilot = new CopilotAPI(this.user.token)

--- a/src/utils/CopilotAPI.ts
+++ b/src/utils/CopilotAPI.ts
@@ -96,7 +96,7 @@ export class CopilotAPI {
     return CompaniesResponseSchema.parse(await this.copilot.listCompanies(args))
   }
 
-  async getCompanyClients(companyId: string) {
+  async getCompanyClients(companyId: string): Promise<ClientResponse[]> {
     return (await this.getClients({ limit: 10000, companyId })).data || []
   }
 

--- a/src/utils/CopilotAPI.ts
+++ b/src/utils/CopilotAPI.ts
@@ -79,7 +79,7 @@ export class CopilotAPI {
     return ClientResponseSchema.parse(await this.copilot.retrieveClient({ id }))
   }
 
-  async getClients(args: CopilotListArgs = {}) {
+  async getClients(args: CopilotListArgs & { companyId?: string } = {}) {
     return ClientsResponseSchema.parse(await this.copilot.listClients(args))
   }
 
@@ -94,6 +94,10 @@ export class CopilotAPI {
 
   async getCompanies(args: CopilotListArgs = {}): Promise<CompaniesResponse> {
     return CompaniesResponseSchema.parse(await this.copilot.listCompanies(args))
+  }
+
+  async getCompanyClients(companyId: string) {
+    return (await this.getClients({ limit: 10000, companyId })).data || []
   }
 
   async getCustomFields(): Promise<CustomFieldResponse> {


### PR DESCRIPTION
### Tasks

- [OUT-387 | Task assigned to company should also trigger client notification](https://linear.app/copilotplatforms/issue/OUT-387/task-assigned-to-company-should-also-trigger-client-notification)
- [OUT-533 | As an internal user when I create a task assigned to myself I should not receive an in-product or email notification](https://linear.app/copilotplatforms/issue/OUT-533/as-an-internal-user-when-i-create-a-task-assigned-to-myself-i-should)

### Changes

- [x] Add CopilotAPI method to fetch clients for a given company (separate method was created for better abstraction)
- [x] Fetch company client ids and bulk send notifications to each of them
- [x] Add condition for not sending notification when createdBy and Assignee id is the same 

### Testing Criteria

- [x] [LOOM for OUT-387](https://www.loom.com/share/43b2c1fb9dc94d92a85cfee5aa208fcc?sid=db5b8483-91d9-4f84-a3bb-0f96f68f3102)
- [x] [LOOM for OUT-533](https://www.loom.com/share/4cda44e727ca439caeba93dae1b70760?sid=27475cf8-d7ee-452b-9b5d-95641ff90fe2) - Here I didn't open my inbox but notification was not sent in mail or in-product. 

### Notes

- Dependencies on other PRs, any required changes in config/setup to test behaviour, or links to external documents, threads, etc -- if any of them are required
