### PR TITLE
OUT-515 | Empty rounded & bordered div shows up when clicking on Due Date

### DIFF
--- a/src/components/inputs/DatePickerComponent.tsx
+++ b/src/components/inputs/DatePickerComponent.tsx
@@ -93,6 +93,8 @@ export const DatePickerComponent = ({ getDate, dateValue, disabled, isButton = f
             },
           },
         ]}
+        // This hides popper's tooltip that helps position the content. display: none would mess up the positioning
+        sx={{ opacity: 0 }}
       >
         <DatePicker
           disablePast


### PR DESCRIPTION
### Tasks

- [Empty rounded & bordered div shows up when clicking on Due Date](https://linear.app/copilotplatforms/issue/OUT-515/empty-rounded-and-bordered-div-shows-up-when-clicking-on-due-date)

### Changes

- [x] Set the positioning tooltip to have an opacity of 0 so that it still positions our calendar while remaining hidden

### Testing Criteria

- [x] [LOOM](https://www.loom.com/share/2a23ffcda1d74f38857af1d94ee7d2de?sid=39378909-edf8-4587-ab0f-16e1afa42212) (the slowness was probably due to my RAM usage being at 93%)