### PR TITLE
OUT-518 Popper changing to top placement when there is not enough space.

### DIFF
--- a/src/app/detail/ui/Sidebar.tsx
+++ b/src/app/detail/ui/Sidebar.tsx
@@ -148,22 +148,20 @@ export const Sidebar = ({
             responsiveNoHide
           />
         </Stack>
-        <Stack direction="row" m="20px 0px" alignItems="center" columnGap="10px">
+        <Stack direction="row" m="20px 0px" alignItems="center" columnGap="10px" minWidth="fit-content">
           <StyledText variant="md" minWidth="80px">
             Due Date
           </StyledText>
-          <Box sx={{ minWidth: '200px' }}>
-            <DatePickerComponent
-              getDate={(date) => {
-                const isoDate = formatDate(date)
-                updateTask({
-                  dueDate: isoDate,
-                })
-              }}
-              dateValue={dueDate ? isoToReadableDate(dueDate) : undefined}
-              disabled={disabled}
-            />
-          </Box>
+          <DatePickerComponent
+            getDate={(date) => {
+              const isoDate = formatDate(date)
+              updateTask({
+                dueDate: isoDate,
+              })
+            }}
+            dateValue={dueDate ? isoToReadableDate(dueDate) : undefined}
+            disabled={disabled}
+          />
         </Stack>
       </AppMargin>
     </Box>

--- a/src/components/inputs/DatePickerComponent.tsx
+++ b/src/components/inputs/DatePickerComponent.tsx
@@ -85,16 +85,10 @@ export const DatePickerComponent = ({ getDate, dateValue, disabled, isButton = f
         open={open}
         anchorEl={anchorEl}
         placement="bottom-start"
-        modifiers={[
-          {
-            name: 'offset',
-            options: {
-              offset: [0, 4],
-            },
-          },
-        ]}
         // This hides popper's tooltip that helps position the content. display: none would mess up the positioning
-        sx={{ opacity: 0 }}
+        sx={{
+          opacity: 0,
+        }}
       >
         <DatePicker
           disablePast
@@ -104,6 +98,15 @@ export const DatePickerComponent = ({ getDate, dateValue, disabled, isButton = f
           onChange={(newValue) => {
             getDate(formatDate(newValue))
             setValue(newValue)
+          }}
+          slotProps={{
+            day: {
+              sx: {
+                '&.MuiPickersDay-root.Mui-selected': {
+                  backgroundColor: (theme) => theme.color.gray[500],
+                },
+              },
+            },
           }}
           sx={{
             '& .MuiOutlinedInput-input': {

--- a/src/hoc/CustomScrollbar.tsx
+++ b/src/hoc/CustomScrollbar.tsx
@@ -18,8 +18,8 @@ export const CustomScrollbar = ({ children, style }: { children: ReactNode; styl
           }}
         />
       )}
-      autoHideTimeout={200}
-      autoHideDuration={200}
+      autoHideTimeout={500}
+      autoHideDuration={500}
       hideTracksWhenNotNeeded={true}
     >
       {children}


### PR DESCRIPTION
### Changes

- [x] Fixes the popper positioning issue 
- [x] Adds `gray[500]` background color to the selected date in date picker
- [x] Fixes the width of the date picker
- [x] Patch - adjusted the timeout duration of the the scroll bar as a patch fix


### Testing Criteria

- [LOOM](https://www.loom.com/share/5c22f6962ad247c89656a0ec13250f7d?sid=d47115a4-7d11-4ea8-a8bf-b78fb47bedeb)