### PR TITLE
OUT-552 input shifting down when opening assignee dropdown in new task dialog

### DIFF
--- a/src/app/ui/NewTaskForm.tsx
+++ b/src/app/ui/NewTaskForm.tsx
@@ -218,6 +218,7 @@ export const NewTaskForm = ({
                 )
               }}
               selectorType={SelectorType.ASSIGNEE_SELECTOR}
+              buttonHeight="auto"
               buttonContent={
                 <Typography
                   variant="bodySm"
@@ -238,14 +239,13 @@ export const NewTaskForm = ({
               }
             />
           </Stack>
-          <Stack alignSelf="flex-start" sx={{ padding: { xs: '2px', sm: '0px' } }}>
+          <Stack alignSelf="flex-start">
             <Box
               sx={{
                 textOverflow: 'ellipsis',
                 whiteSpace: 'nowrap',
                 overflow: 'hidden',
                 maxWidth: { xs: '102px', sm: 'none' },
-                display: '',
               }}
             >
               <DatePickerComponent

--- a/src/components/buttons/SecondaryBtn.tsx
+++ b/src/components/buttons/SecondaryBtn.tsx
@@ -27,7 +27,7 @@ export const SecondaryBtn = ({
         '&:hover': {
           border: enableBackground || outlined ? 'none' : `1px solid ${theme.color.borders.border}`,
         },
-        padding: { xs: '1px 9px', md: '4px 16px' },
+        padding: { xs: '2px 9px', md: '4px 16px' },
         cursor: 'pointer',
       })}
       onClick={handleClick}

--- a/src/components/inputs/Selector.tsx
+++ b/src/components/inputs/Selector.tsx
@@ -35,6 +35,7 @@ interface Prop {
   disableOutline?: boolean
   padding?: string
   buttonWidth?: string
+  buttonHeight?: string
   responsiveNoHide?: boolean
 }
 
@@ -52,6 +53,7 @@ export default function Selector({
   disableOutline,
   padding,
   buttonWidth,
+  buttonHeight,
   responsiveNoHide,
 }: Prop) {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
@@ -149,6 +151,7 @@ export default function Selector({
             outlined={disableOutline}
             disabled={disabled}
             padding={padding}
+            height={buttonHeight}
           />
         )}
       </Box>
@@ -169,6 +172,7 @@ export default function Selector({
           }}
           openOnFocus
           onKeyDown={handleKeyDown}
+          ListboxProps={{ sx: { maxHeight: { xs: '175px', sm: '299px' } } }}
           autoHighlight
           options={extraOption ? [extraOption, ...options] : options}
           value={value}
@@ -325,6 +329,7 @@ const SelectorButton = ({
   outlined,
   padding,
   disabled,
+  height,
 }: {
   startIcon?: ReactNode
   buttonContent: ReactNode
@@ -333,6 +338,7 @@ const SelectorButton = ({
   outlined?: boolean
   padding?: string
   disabled?: boolean
+  height?: string
 }) => {
   return (
     <Button
@@ -355,7 +361,7 @@ const SelectorButton = ({
             fontSize: '13px',
           },
         },
-        height: '32px',
+        height: height ? height : '32px',
       })}
       onClick={handleClick}
       disableRipple

--- a/src/components/inputs/Selector.tsx
+++ b/src/components/inputs/Selector.tsx
@@ -172,7 +172,7 @@ export default function Selector({
           }}
           openOnFocus
           onKeyDown={handleKeyDown}
-          ListboxProps={{ sx: { maxHeight: { xs: '175px', sm: '299px' } } }}
+          ListboxProps={{ sx: { maxHeight: { xs: '175px', sm: '291px' } } }}
           autoHighlight
           options={extraOption ? [extraOption, ...options] : options}
           value={value}
@@ -361,7 +361,7 @@ const SelectorButton = ({
             fontSize: '13px',
           },
         },
-        height: height ? height : '32px',
+        height: height ?? '32px',
       })}
       onClick={handleClick}
       disableRipple


### PR DESCRIPTION
### Tasks

- [input shifting down when opening assignee dropdown in new task dialog](https://linear.app/copilotplatforms/issue/OUT-552/input-shifting-down-when-opening-assignee-dropdown-in-new-task-dialog)

### Changes

- [x] changed assignee dropdown height with respect to sm and xs
- [x] button fixes 

### Testing Criteria

- [LOOM](https://www.loom.com/share/2568b2b1a3024d1297a94855b539e847)