### PR TITLE
OUT-557 No assignee shown as input in the textfield of autocomplete when the task is unassigned.

### DIFF
--- a/src/app/detail/ui/Sidebar.tsx
+++ b/src/app/detail/ui/Sidebar.tsx
@@ -59,7 +59,7 @@ export const Sidebar = ({
 
   const statusValue = _statusValue as WorkflowStateResponse //typecasting
   const assigneeValue = _assigneeValue as IAssigneeCombined //typecasting
-
+  console.log(assigneeValue)
   const matches = useMediaQuery('(max-width:600px)')
   return (
     <Box
@@ -120,7 +120,7 @@ export const Sidebar = ({
               )
             }
             options={assignee}
-            value={assigneeValue}
+            value={assigneeValue.name == 'No assignee' ? null : assigneeValue}
             selectorType={SelectorType.ASSIGNEE_SELECTOR}
             extraOption={NoAssigneeExtraOptions}
             extraOptionRenderer={(setAnchorEl, anchorEl, props) => {

--- a/src/app/detail/ui/Sidebar.tsx
+++ b/src/app/detail/ui/Sidebar.tsx
@@ -59,7 +59,7 @@ export const Sidebar = ({
 
   const statusValue = _statusValue as WorkflowStateResponse //typecasting
   const assigneeValue = _assigneeValue as IAssigneeCombined //typecasting
-  console.log(assigneeValue)
+
   const matches = useMediaQuery('(max-width:600px)')
   return (
     <Box


### PR DESCRIPTION
### Tasks

- [No assignee shown as input in the textfield of autocomplete when the task is unassigned.](https://linear.app/copilotplatforms/issue/OUT-557/no-assignee-shown-as-input-in-the-textfield-of-autocomplete-when-the)

### Changes

- [x] passed selector value as null to selector component if assignee value == no assignee

### Testing Criteria

- [LOOM](https://www.loom.com/share/d384bb03d05f4bd0aa19a6a88ffb24ca)
