### PR TITLE
OUT-582 | Due date seems wrong when you make it today

### DIFF
--- a/prisma/migrations/20240716021900_change_tasks_to_accept_date_string/migration.sql
+++ b/prisma/migrations/20240716021900_change_tasks_to_accept_date_string/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Tasks" ALTER COLUMN "dueDate" SET DATA TYPE TEXT;

--- a/prisma/migrations/20240716021900_change_tasks_to_accept_date_string/migration.sql
+++ b/prisma/migrations/20240716021900_change_tasks_to_accept_date_string/migration.sql
@@ -1,2 +1,0 @@
--- AlterTable
-ALTER TABLE "Tasks" ALTER COLUMN "dueDate" SET DATA TYPE TEXT;

--- a/prisma/migrations/20240716094430_change_tasks_to_accept_date_string/migration.sql
+++ b/prisma/migrations/20240716094430_change_tasks_to_accept_date_string/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - The `dueDate` column on the `Tasks` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+
+*/
+-- AlterTable
+ALTER TABLE "Tasks" DROP COLUMN "dueDate",
+ADD COLUMN     "dueDate" VARCHAR(10);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -61,7 +61,7 @@ model Task {
 
   assignedAt         DateTime?
   completedAt        DateTime?
-  dueDate            String?
+  dueDate            String?              @db.VarChar(10)
   deletedAt          DateTime?
   ClientNotification ClientNotification[]
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -61,7 +61,7 @@ model Task {
 
   assignedAt         DateTime?
   completedAt        DateTime?
-  dueDate            DateTime?
+  dueDate            String?
   deletedAt          DateTime?
   ClientNotification ClientNotification[]
 

--- a/src/app/detail/ui/Sidebar.tsx
+++ b/src/app/detail/ui/Sidebar.tsx
@@ -11,8 +11,8 @@ import { selectTaskBoard } from '@/redux/features/taskBoardSlice'
 import { WorkflowStateResponse } from '@/types/dto/workflowStates.dto'
 import { StyledBox } from './styledComponent'
 import { getAssigneeTypeCorrected } from '@/utils/getAssigneeTypeCorrected'
-import { IsoDate, UpdateTaskRequest } from '@/types/dto/tasks.dto'
-import { formatDate, isoToReadableDate } from '@/utils/dateHelper'
+import { UpdateTaskRequest } from '@/types/dto/tasks.dto'
+import { createDateFromFormattedDateString, formatDate } from '@/utils/dateHelper'
 import { selectTaskDetails } from '@/redux/features/taskDetailsSlice'
 import { ToggleButtonContainer } from './ToggleButtonContainer'
 import { NoAssignee, NoAssigneeExtraOptions } from '@/utils/noAssignee'
@@ -24,9 +24,8 @@ import { useState } from 'react'
 import { MiniLoader } from '@/components/atoms/MiniLoader'
 import { setDebouncedFilteredAssignees } from '@/utils/users'
 import { z } from 'zod'
-import { truncateText } from '@/utils/truncateText'
-import { TruncateMaxNumber } from '@/types/constants'
 import { isAssigneeTextMatching } from '@/utils/assignee'
+import { DateStringSchema } from '@/types/date'
 
 const StyledText = styled(Typography)(({ theme }) => ({
   color: theme.color.gray[500],
@@ -45,7 +44,7 @@ export const Sidebar = ({
 }: {
   selectedWorkflowState: WorkflowStateResponse
   selectedAssigneeId: string | undefined
-  dueDate: IsoDate | undefined
+  dueDate: string | undefined
   updateWorkflowState: (workflowState: WorkflowStateResponse) => void
   updateAssignee: (assigneeType: string | null, assigneeId: string | null) => void
   updateTask: (payload: UpdateTaskRequest) => void
@@ -183,12 +182,10 @@ export const Sidebar = ({
           </StyledText>
           <DatePickerComponent
             getDate={(date) => {
-              const isoDate = formatDate(date)
-              updateTask({
-                dueDate: isoDate,
-              })
+              const dueDate = DateStringSchema.parse(formatDate(date))
+              updateTask({ dueDate })
             }}
-            dateValue={dueDate ? isoToReadableDate(dueDate) : undefined}
+            dateValue={dueDate ? createDateFromFormattedDateString(dueDate) : undefined}
             disabled={disabled}
           />
         </Stack>

--- a/src/app/ui/Modal_NewTaskForm.tsx
+++ b/src/app/ui/Modal_NewTaskForm.tsx
@@ -11,6 +11,7 @@ import { CreateAttachmentRequest } from '@/types/dto/attachments.dto'
 import { CreateTaskRequestSchema } from '@/types/dto/tasks.dto'
 import { NewTaskForm } from './NewTaskForm'
 import { ISignedUrlUpload } from '@/types/interfaces'
+import dayjs from 'dayjs'
 
 export const ModalNewTaskForm = ({
   getSignedUrlUpload,
@@ -39,6 +40,7 @@ export const ModalNewTaskForm = ({
           if (title) {
             store.dispatch(setShowModal())
             store.dispatch(clearCreateTaskFields())
+            const formattedDueDate = dueDate && dayjs(new Date(dueDate)).format('YYYY-MM-DD')
             const createdTask = await handleCreate(
               token as string,
               CreateTaskRequestSchema.parse({
@@ -47,7 +49,7 @@ export const ModalNewTaskForm = ({
                 workflowStateId,
                 assigneeType,
                 assigneeId,
-                dueDate,
+                dueDate: formattedDueDate,
               }),
             )
             store.dispatch(appendTask(createdTask))

--- a/src/app/ui/NewTaskForm.tsx
+++ b/src/app/ui/NewTaskForm.tsx
@@ -39,6 +39,7 @@ import { CopilotAvatar } from '@/components/atoms/CopilotAvatar'
 import { setDebouncedFilteredAssignees } from '@/utils/users'
 import { z } from 'zod'
 import { MiniLoader } from '@/components/atoms/MiniLoader'
+import { formatDate } from '@/utils/dateHelper'
 
 const supabaseActions = new SupabaseActions()
 
@@ -270,7 +271,9 @@ export const NewTaskForm = ({
               }}
             >
               <DatePickerComponent
-                getDate={(value) => store.dispatch(setCreateTaskFields({ targetField: 'dueDate', value: value }))}
+                getDate={(value) =>
+                  store.dispatch(setCreateTaskFields({ targetField: 'dueDate', value: formatDate(value) }))
+                }
                 isButton={true}
               />
             </Box>

--- a/src/components/cards/ClientTaskCard.tsx
+++ b/src/components/cards/ClientTaskCard.tsx
@@ -92,7 +92,7 @@ export const ClientTaskCard = ({
               >
                 {task.dueDate && (
                   <Typography variant="bodySm" sx={{ fontSize: '12px', color: (theme) => theme.color.gray[500] }}>
-                    <DueDateLayout date={task.dueDate} />
+                    <DueDateLayout dateString={task.dueDate} />
                   </Typography>
                 )}
               </Box>

--- a/src/components/cards/ListViewTaskCard.tsx
+++ b/src/components/cards/ListViewTaskCard.tsx
@@ -83,7 +83,7 @@ export const ListViewTaskCard = ({
                     whiteSpace: 'nowrap',
                   }}
                 >
-                  {task.dueDate && <DueDateLayout date={task.dueDate} />}
+                  {task.dueDate && <DueDateLayout dateString={task.dueDate} />}
                 </Box>
                 <Box sx={{}}>
                   <Selector

--- a/src/components/cards/TaskCard.tsx
+++ b/src/components/cards/TaskCard.tsx
@@ -4,7 +4,7 @@ import { selectTaskBoard } from '@/redux/features/taskBoardSlice'
 import { TaskResponse } from '@/types/dto/tasks.dto'
 import { IAssigneeCombined } from '@/types/interfaces'
 import { NoAssignee } from '@/utils/noAssignee'
-import { Avatar, Stack, Typography, styled } from '@mui/material'
+import { Stack, Typography, styled } from '@mui/material'
 import { useSelector } from 'react-redux'
 import { DueDateLayout } from '@/components/layouts/DueDateLayout'
 import { CopilotAvatar } from '@/components/atoms/CopilotAvatar'
@@ -62,7 +62,7 @@ export const TaskCard = ({ task, href }: TaskCardProps) => {
           </Typography>
         </Stack>
         <Typography variant="sm">{task.title}</Typography>
-        {task.dueDate && <DueDateLayout date={task.dueDate} />}
+        {task.dueDate && <DueDateLayout dateString={task.dueDate} />}
       </TaskCardContainer>
     </StyledUninvasiveLink>
   )

--- a/src/components/inputs/DatePickerComponent.tsx
+++ b/src/components/inputs/DatePickerComponent.tsx
@@ -1,28 +1,27 @@
-import React, { useRef } from 'react'
 import { DatePicker } from '@mui/x-date-pickers/DatePicker'
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs'
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider'
 import dayjs, { Dayjs } from 'dayjs'
-import { CalenderIcon, CalenderIcon2, CalenderIconSmall } from '@/icons'
-import { IsoDate } from '@/types/dto/tasks.dto'
+import { CalenderIcon, CalenderIconSmall } from '@/icons'
 import { Box, Popper, Stack, Typography } from '@mui/material'
 import { SecondaryBtn } from '../buttons/SecondaryBtn'
+import { useState } from 'react'
 
 interface Prop {
   getDate: (value: string) => void
-  dateValue?: IsoDate
+  dateValue?: Date
   isButton?: boolean
   disabled?: boolean
 }
 
 export const DatePickerComponent = ({ getDate, dateValue, disabled, isButton = false }: Prop) => {
-  const [value, setValue] = React.useState<Dayjs | null>(dateValue ? dayjs(dateValue) : null)
+  const [value, setValue] = useState<Dayjs | null>(dateValue ? dayjs(dateValue) : null)
 
   const formatDate = (date: Dayjs | null) => {
     return date ? date.format('MMM DD, YYYY') : '' // Format the date as "Mar 08, 2024"
   }
 
-  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null)
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
 
   const handleClick = (event: React.MouseEvent<HTMLElement>) => {
     if (!disabled) {

--- a/src/components/layouts/DueDateLayout.tsx
+++ b/src/components/layouts/DueDateLayout.tsx
@@ -3,15 +3,18 @@ import dayjs from 'dayjs'
 import isToday from 'dayjs/plugin/isToday'
 import isTomorrow from 'dayjs/plugin/isTomorrow'
 import { useCallback } from 'react'
+import { createDateFromFormattedDateString } from '@/utils/dateHelper'
+import { DateString } from '@/types/date'
 
 dayjs.extend(isToday)
 dayjs.extend(isTomorrow)
 
 interface DueDateLayoutProp {
-  date: string | Date
+  dateString: DateString
 }
 
-export const DueDateLayout = ({ date }: DueDateLayoutProp) => {
+export const DueDateLayout = ({ dateString }: DueDateLayoutProp) => {
+  const date = createDateFromFormattedDateString(dateString)
   const now = dayjs()
   const calculateFormattedDueDate = useCallback(() => {
     const parsedDate = dayjs(date)

--- a/src/redux/features/createTaskSlice.ts
+++ b/src/redux/features/createTaskSlice.ts
@@ -2,7 +2,7 @@ import { createSlice } from '@reduxjs/toolkit'
 import { RootState } from '../store'
 import { AssigneeType } from '@prisma/client'
 import { CreateAttachmentRequest } from '@/types/dto/attachments.dto'
-import { IsoDate } from '@/types/dto/tasks.dto'
+import { DateString } from '@/types/date'
 
 interface IInitialState {
   showModal: boolean
@@ -12,7 +12,7 @@ interface IInitialState {
   assigneeType?: AssigneeType | null
   assigneeId: string | null
   attachments: CreateAttachmentRequest[]
-  dueDate: IsoDate | null
+  dueDate: DateString | null
 }
 
 const initialState: IInitialState = {

--- a/src/types/date.ts
+++ b/src/types/date.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod'
+
+export const DateStringSchema = z.string().refine(
+  (dateString) => {
+    const datePattern = /^\d{4}-\d{2}-\d{2}$/
+    if (!datePattern.test(dateString)) {
+      return false
+    }
+
+    const [year, month, day] = dateString.split('-').map(Number)
+
+    // Check if year, month, and day are valid
+    if (year < 1000 || year > 9999) return false
+    if (month < 1 || month > 12) return false
+    if (day < 1 || day > 31) return false
+
+    // Check if the day is valid for the given month and year
+    const date = new Date(year, month - 1, day)
+    if (date.getFullYear() !== year || date.getMonth() + 1 !== month || date.getDate() !== day) {
+      return false
+    }
+
+    return true
+  },
+  {
+    message: 'Invalid date format or value. Expected format: YYYY-MM-DD',
+  },
+)
+
+export type DateString = z.infer<typeof DateStringSchema>

--- a/src/types/dto/tasks.dto.ts
+++ b/src/types/dto/tasks.dto.ts
@@ -1,24 +1,10 @@
 import { AssigneeType as PrismaAssigneeType } from '@prisma/client'
 import { z } from 'zod'
 import { WorkflowStateResponseSchema } from './workflowStates.dto'
+import { DateStringSchema } from '@/types/date'
 
 export const AssigneeTypeSchema = z.nativeEnum(PrismaAssigneeType).nullish()
 export type AssigneeType = z.infer<typeof AssigneeTypeSchema>
-
-// Schema for validating ISO 8601 date strings
-export const IsoDateSchema = z
-  .string()
-  .refine(
-    (data) => {
-      return !isNaN(Date.parse(data))
-    },
-    {
-      message: 'Invalid date format, expected ISO 8601 string',
-    },
-  )
-  .transform((data) => new Date(data))
-
-export type IsoDate = z.infer<typeof IsoDateSchema>
 
 export const CreateTaskRequestSchema = z.object({
   assigneeId: z.string().optional().nullish(),
@@ -26,7 +12,7 @@ export const CreateTaskRequestSchema = z.object({
   title: z.string().min(1),
   body: z.string().optional(),
   workflowStateId: z.string().uuid(),
-  dueDate: IsoDateSchema.optional().nullish(),
+  dueDate: DateStringSchema.nullish(),
 })
 export type CreateTaskRequest = z.infer<typeof CreateTaskRequestSchema>
 
@@ -36,7 +22,7 @@ export const UpdateTaskRequestSchema = z.object({
   title: z.string().optional(),
   body: z.string().nullish(),
   workflowStateId: z.string().uuid().optional(),
-  dueDate: IsoDateSchema.optional(),
+  dueDate: DateStringSchema.nullish(),
 })
 export type UpdateTaskRequest = z.infer<typeof UpdateTaskRequestSchema>
 
@@ -51,7 +37,7 @@ export const TaskResponseSchema = z.object({
   createdById: z.string(),
   workflowStateId: z.string().uuid().optional(),
   workflowState: WorkflowStateResponseSchema,
-  dueDate: IsoDateSchema.optional(),
+  dueDate: DateStringSchema.optional(),
 })
 
 export type TaskResponse = z.infer<typeof TaskResponseSchema>

--- a/src/utils/dateHelper.ts
+++ b/src/utils/dateHelper.ts
@@ -1,31 +1,24 @@
-import { IsoDate, IsoDateSchema } from '@/types/dto/tasks.dto'
+import { DateString } from '@/types/date'
 
-export function isoToReadableDate(isoString: IsoDate): IsoDate {
-  // Create a Date object from the ISO string
-  const date = new Date(isoString)
-
-  // Adjust date to make sure it shows correctly for all time zones
-  date.setUTCMinutes(date.getUTCMinutes() + date.getTimezoneOffset())
-
-  // Define options for date formatting
-  const options: Intl.DateTimeFormatOptions = { year: 'numeric', month: 'short', day: 'numeric' }
-
-  // Format the date to a readable format
-  const readableDate = date.toLocaleDateString('en-US', options)
-
-  return IsoDateSchema.parse(readableDate)
-}
-
-export function formatDate(dateString: string): IsoDate {
+export function formatDate(dateString: string): DateString {
   // Parse the date from the input format
   const date = new Date(dateString)
+  const day = String(date.getDate()).padStart(2, '0')
+  const month = String(date.getMonth() + 1).padStart(2, '0') // Months are zero-based
+  const year = date.getFullYear()
 
-  // Set the time to noon to avoid timezone issues causing date rollover
-  date.setHours(12, 0, 0, 0)
+  return `${year}-${month}-${day}`
+}
 
-  // Convert the date to ISO 8601 format in UTC
-  const isoDate = date.toISOString()
+/**
+ * Util to convert datestring to a Date object
+ * @param {DateString} dateString In format YYYY-MM-DD (This is human readable date - month starts from 1, not 0!)
+ * @returns {Date}
+ */
+export function createDateFromFormattedDateString(dateString: string): Date {
+  // Split the date string into day, month, and year
+  const [year, month, day] = dateString.split('-').map(Number)
 
-  // Return only the date part with time reset to midnight UTC
-  return IsoDateSchema.parse(`${isoDate.substring(0, 10)}T00:00:00Z`)
+  // IN JS month is zero-based to increase suffering for humankind, so we subtract 1 from the month
+  return new Date(year, month - 1, day)
 }


### PR DESCRIPTION
### Tasks

- [Due date seems wrong when you make it today](https://linear.app/copilotplatforms/issue/OUT-582/due-date-seems-wrong-when-you-make-it-today)

### Changes

- [x] Change db, backend and frontend to use `Date` instead of `Datetime` / timestamp to avoid all timezone issues in the future
- [x] Migrate preview and prod db data to use Date instead of Datetime
- [x] Change dueDate prisma schema type to use `String` instead of `Datetime` since Prisma doesn't seem to support PostGres `Date` type natively. These dates are parsed at all DTO levels with a regex to avoid faulty dates from being saved.

### Testing Criteria

- [x] [LOOM](https://www.loom.com/share/74ff1d328ef54226b9d5aa398c9fd989?sid=296bd603-5de1-4f06-9658-5bfccdff272d)

## Note:
Use this SQL command to migrate your data to Date string
```sql
UPDATE "Tasks"
SET "dueDate" = SUBSTR("dueDate", 1, 10)
WHERE "dueDate" IS NOT NULL;
```