### PR TITLE
OUT-579 Tasks that clients mark as done disappear

### DIFF
--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -242,6 +242,7 @@ export class TasksService extends BaseService {
     const completedWorkFlowState = await this.db.workflowState.findFirst({
       where: {
         type: StateType.completed,
+        workspaceId: this.user.workspaceId,
       },
     })
     const data = {


### PR DESCRIPTION
### Changes

- [x] Adds workspaceId parameter in the `findFirst` db call in the `completeTask` API