### PR TITLE
OUT-594, OUT-595, OUT-596 Empty state shows heading two times on Client end

### DIFF
--- a/src/app/client/page.tsx
+++ b/src/app/client/page.tsx
@@ -48,7 +48,6 @@ export default async function ClientPage({ searchParams }: { searchParams: { tok
   return (
     <>
       <ClientSideStateUpdate workflowStates={workflowStates} tasks={tasks} token={token} assignee={assignee}>
-        <Header showCreateTaskButton={false} />
         <ClientTaskBoard
           completeTask={async (taskId) => {
             'use server'

--- a/src/app/client/ui/ClientTaskBoard.tsx
+++ b/src/app/client/ui/ClientTaskBoard.tsx
@@ -11,6 +11,7 @@ import { useRouter } from 'next/navigation'
 import { StateType } from '@prisma/client'
 import DashboardEmptyState from '@/components/layouts/EmptyState/DashboardEmptyState'
 import { UserType } from '@/types/interfaces'
+import { Header } from '@/components/layouts/Header'
 
 export const ClientTaskBoard = ({ completeTask }: { completeTask: (taskId: string) => void }) => {
   const { workflowStates, tasks, filteredTasks, token } = useSelector(selectTaskBoard)
@@ -35,36 +36,39 @@ export const ClientTaskBoard = ({ completeTask }: { completeTask: (taskId: strin
   return tasks.length > 0 ? (
     workflowStates.map((list) => {
       return (
-        <TaskRow
-          key={list.id}
-          columnName={list.name}
-          taskCount={taskCountForWorkflowStateId(list.id)}
-          showConfigurableIcons={false}
-        >
-          {filterTaskWithWorkflowStateId(list.id).map((task) => {
-            return (
-              <Box key={task.id}>
-                <ClientTaskCard
-                  task={task}
-                  href={{ pathname: `/detail/${task.id}/cu`, query: { token } }}
-                  key={task.id}
-                  markdoneFlag={list.type == StateType.completed}
-                  handleMarkDone={() => {
-                    if (completedTypeWorkflowState?.id) {
-                      store.dispatch(
-                        updateWorkflowStateIdByTaskId({
-                          taskId: task.id,
-                          targetWorkflowStateId: completedTypeWorkflowState?.id,
-                        }),
-                      )
-                      completeTask(task.id)
-                    }
-                  }}
-                />
-              </Box>
-            )
-          })}
-        </TaskRow>
+        <>
+          <Header showCreateTaskButton={false} />
+          <TaskRow
+            key={list.id}
+            columnName={list.name}
+            taskCount={taskCountForWorkflowStateId(list.id)}
+            showConfigurableIcons={false}
+          >
+            {filterTaskWithWorkflowStateId(list.id).map((task) => {
+              return (
+                <Box key={task.id}>
+                  <ClientTaskCard
+                    task={task}
+                    href={{ pathname: `/detail/${task.id}/cu`, query: { token } }}
+                    key={task.id}
+                    markdoneFlag={list.type == StateType.completed}
+                    handleMarkDone={() => {
+                      if (completedTypeWorkflowState?.id) {
+                        store.dispatch(
+                          updateWorkflowStateIdByTaskId({
+                            taskId: task.id,
+                            targetWorkflowStateId: completedTypeWorkflowState?.id,
+                          }),
+                        )
+                        completeTask(task.id)
+                      }
+                    }}
+                  />
+                </Box>
+              )
+            })}
+          </TaskRow>
+        </>
       )
     })
   ) : (

--- a/src/app/client/ui/ClientTaskBoard.tsx
+++ b/src/app/client/ui/ClientTaskBoard.tsx
@@ -34,10 +34,10 @@ export const ClientTaskBoard = ({ completeTask }: { completeTask: (taskId: strin
 
   const completedTypeWorkflowState = workflowStates.find((el) => el.type === 'completed')
   return tasks.length > 0 ? (
-    workflowStates.map((list) => {
-      return (
-        <>
-          <Header showCreateTaskButton={false} />
+    <>
+      <Header showCreateTaskButton={false} />
+      {workflowStates.map((list) => {
+        return (
           <TaskRow
             key={list.id}
             columnName={list.name}
@@ -68,9 +68,9 @@ export const ClientTaskBoard = ({ completeTask }: { completeTask: (taskId: strin
               )
             })}
           </TaskRow>
-        </>
-      )
-    })
+        )
+      })}
+    </>
   ) : (
     <DashboardEmptyState userType={UserType.CLIENT_USER} />
   )

--- a/src/components/cards/ClientTaskCard.tsx
+++ b/src/components/cards/ClientTaskCard.tsx
@@ -73,14 +73,14 @@ export const ClientTaskCard = ({
           <Stack
             direction="row"
             alignItems="flex-start"
-            minWidth="fit-content"
             columnGap={{ xs: '12px', sm: '32px' }}
             justifyContent={{ xs: 'space-between', sm: 'none' }}
             sx={{
               padding: '6px 0px',
+              width: { xs: '100%', sm: 'auto' },
             }}
           >
-            <Stack direction="row" alignItems="center" minWidth="fit-content" columnGap={{ xs: '0px', sm: '20px' }}>
+            <Stack direction="row" alignItems="center" minWidth="fit-content" columnGap={{ xs: '12px', sm: '20px' }}>
               <Box
                 sx={{
                   flexDirection: 'row',
@@ -102,7 +102,7 @@ export const ClientTaskCard = ({
                 alignItems="flex-start"
                 justifyContent={'left'}
                 columnGap={1}
-                sx={{ padding: '2px', width: '132px' }}
+                sx={{ padding: '2px', minWidth: '132px', maxWidth: '200px' }}
               >
                 <CopilotAvatar currentAssignee={currentAssignee as IAssigneeCombined} />
 
@@ -122,7 +122,13 @@ export const ClientTaskCard = ({
                 </Typography>
               </Stack>
             </Stack>
-            <Box sx={{ minWidth: '80px' }}>
+            <Box
+              sx={{
+                minWidth: '80px',
+                display: 'flex',
+                justifyContent: 'flex-end',
+              }}
+            >
               {!markdoneFlag && (
                 <SecondaryBtn
                   handleClick={handleMarkAsDoneClick}

--- a/src/components/cards/ClientTaskCard.tsx
+++ b/src/components/cards/ClientTaskCard.tsx
@@ -97,7 +97,13 @@ export const ClientTaskCard = ({
                 )}
               </Box>
 
-              <Stack direction="row" alignItems="flex-start" columnGap={1} sx={{ padding: '2px', maxWidth: '100px' }}>
+              <Stack
+                direction="row"
+                alignItems="flex-start"
+                justifyContent={'left'}
+                columnGap={1}
+                sx={{ padding: '2px', width: '132px' }}
+              >
                 <CopilotAvatar currentAssignee={currentAssignee as IAssigneeCombined} />
 
                 <Typography

--- a/src/components/inputs/Selector.tsx
+++ b/src/components/inputs/Selector.tsx
@@ -124,7 +124,7 @@ export default function Selector({
             columnGap="7px"
             justifyContent="flex-start"
             sx={{
-              width: { sm: responsiveNoHide ? buttonWidth ?? '100px' : '20px', md: buttonWidth ?? '100px' },
+              width: { sm: responsiveNoHide ? (buttonWidth ?? '100px') : '20px', md: buttonWidth ?? '100px' },
               justifyContent: { xs: 'flex-start', sm: 'flex-start' },
               cursor: disabled ? 'auto' : 'pointer',
               borderRadius: '4px',

--- a/src/components/inputs/Selector.tsx
+++ b/src/components/inputs/Selector.tsx
@@ -124,7 +124,7 @@ export default function Selector({
             columnGap="7px"
             justifyContent="flex-start"
             sx={{
-              width: { sm: responsiveNoHide ? (buttonWidth ?? '100px') : '20px', md: buttonWidth ?? '100px' },
+              width: { sm: responsiveNoHide ? buttonWidth || '100px' : '20px', md: buttonWidth || '100px' },
               justifyContent: { xs: 'flex-start', sm: 'flex-start' },
               cursor: disabled ? 'auto' : 'pointer',
               borderRadius: '4px',

--- a/src/components/layouts/DueDateLayout.tsx
+++ b/src/components/layouts/DueDateLayout.tsx
@@ -24,7 +24,28 @@ export const DueDateLayout = ({ dateString }: DueDateLayoutProp) => {
     } else if (parsedDate.isTomorrow()) {
       return 'Tomorrow'
     } else {
-      return parsedDate.format('MMMM D, YYYY')
+      const monthFormats: { [key: string]: string } = {
+        January: 'Jan',
+        February: 'Feb',
+        March: 'March',
+        April: 'April',
+        May: 'May',
+        June: 'June',
+        July: 'July',
+        August: 'Aug',
+        September: 'Sep',
+        October: 'Oct',
+        November: 'Nov',
+        December: 'Dec',
+      }
+
+      const month = parsedDate.format('MMMM')
+      const day = parsedDate.format('D')
+      const year = parsedDate.format('YYYY')
+
+      const formattedMonth = month.length <= 5 ? month : monthFormats[month]
+
+      return `${formattedMonth} ${day}, ${year}`
     }
   }, [date])
 


### PR DESCRIPTION
### Tasks

- [Empty state shows heading two times on Client end](https://linear.app/copilotplatforms/issue/OUT-594/empty-state-shows-heading-two-times-on-client-end)
- [Assignee name is shown with ellipse on Client end](https://linear.app/copilotplatforms/issue/OUT-595/assignee-name-is-shown-with-ellipse-on-client-end)
- [Fix Assignee alignment issue](https://linear.app/copilotplatforms/issue/OUT-596/fix-assignee-alignment-issue)

### Changes

- [x] header removed for empty state for client view
- [x] alignment and assigneename width increased
- [x] date format changed to align figma designs and some responsive fixes

### Testing Criteria

- [LOOM](https://www.loom.com/share/56bc1928e1924083847a97344eedc880)  


