### PR TITLE
OUT-572 | Only show tasks and clients which IU has access to

### DIFF
--- a/src/app/api/notification/notification.service.ts
+++ b/src/app/api/notification/notification.service.ts
@@ -160,7 +160,7 @@ export class NotificationService extends BaseService {
         const userInfo = await copilot.me()
         senderId = z.string().parse(userInfo?.id)
         recipientId = z.string().parse(task.assigneeId)
-        actionTrigger = userInfo as MeResponse
+        actionTrigger = userInfo as CopilotUser
         break
     }
 

--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -83,7 +83,8 @@ export class TasksService extends BaseService {
     const currentInternalUser = await copilot.getInternalUser(this.user.internalUserId)
     if (!currentInternalUser.isClientAccessLimited) return tasks
 
-    const clients = await copilot.getClients()
+    const hasClientTasks = tasks.some((task) => task.assigneeType === AssigneeType.client)
+    const clients = hasClientTasks ? await copilot.getClients() : { data: [] }
 
     return tasks.filter((task) => {
       // Allow IU to access unassigned tasks or tasks assigned to another IU within workspace

--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -67,11 +67,36 @@ export class TasksService extends BaseService {
     // while clients can only view the tasks assigned to them or their company
     const filters = this.buildReadFilters()
 
-    return await this.db.task.findMany({
+    let tasks = await this.db.task.findMany({
       ...filters,
       include: {
         workflowState: { select: { name: true } },
       },
+    })
+
+    if (!this.user.internalUserId) {
+      return tasks
+    }
+
+    // Now we have the challenge of figuring out if a task is assigned to a client / company that falls in IU's access list
+    const copilot = new CopilotAPI(this.user.token)
+    const currentInternalUser = await copilot.getInternalUser(this.user.internalUserId)
+    if (!currentInternalUser.isClientAccessLimited) return tasks
+
+    const clients = await copilot.getClients()
+
+    return tasks.filter((task) => {
+      // Allow IU to access unassigned tasks or tasks assigned to another IU within workspace
+      if (!task.assigneeId || task.assigneeType === AssigneeType.internalUser) return true
+
+      // TODO: Refactor this hacky abomination of code as soon as copilot API natively supports access scopes
+      // Filter out only tasks that belong to a client that has companyId in IU's companyAccessList
+      if (task.assigneeType === AssigneeType.company) {
+        return currentInternalUser.companyAccessList?.includes(task.assigneeId)
+      }
+      const taskClient = clients.data?.find((client) => client.id === task.assigneeId)
+      const taskClientsCompanyId = z.string().parse(taskClient?.companyId)
+      return currentInternalUser.companyAccessList?.includes(taskClientsCompanyId)
     })
   }
 

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -127,6 +127,8 @@ export const InternalUsersSchema = z.object({
   familyName: z.string(),
   email: z.string().email(),
   avatarImageUrl: z.string().optional(),
+  isClientAccessLimited: z.boolean(),
+  companyAccessList: z.array(z.string()).nullable(),
 })
 export type InternalUsers = z.infer<typeof InternalUsersSchema>
 


### PR DESCRIPTION
### Tasks

- [OUT-572 | Only show clients where IU has access](https://linear.app/copilotplatforms/issue/OUT-572/only-show-clients-where-iu-has-access)

### Changes

- [x] Filter out clients and companies that are not in IU's company access list
- [x] Filter out tasks that belong to client and companies that are not in IU's company access list 

### Testing Criteria

- [x] [LOOM](https://www.loom.com/share/3174cd95e4b647fe96c9786eaf7f47d8?sid=aeec395e-6998-460a-adc4-2c8f5477d153) 
