### PR TITLE
OUT-592 | In-product notifications don´t disappear for Clients after company task is deleted

### DIFF
--- a/src/app/api/notification/notification.service.ts
+++ b/src/app/api/notification/notification.service.ts
@@ -113,7 +113,13 @@ export class NotificationService extends BaseService {
         assigneeType: AssigneeType.client,
       }),
     )
-    await Promise.all(markAsReadPromises)
+
+    // Mark as read while preventing burst ratelimits
+    const batchSize = 10
+    for (let i = 0; i <= markAsReadPromises.length; i += batchSize) {
+      const batchPromises = markAsReadPromises.slice(i, batchSize)
+      await Promise.all(batchPromises)
+    }
   }
 
   /**

--- a/src/app/api/notification/notification.service.ts
+++ b/src/app/api/notification/notification.service.ts
@@ -78,7 +78,7 @@ export class NotificationService extends BaseService {
    * Marks a client notification in Copilot Notifications service as read
    * @param id Notification ID for object as exists in Copilot
    */
-  async markClientNotificationAsRead(task: Task) {
+  markClientNotificationAsRead = async (task: Task) => {
     const copilot = new CopilotAPI(this.user.token)
     try {
       const relatedNotification = await this.db.clientNotification.findFirst({
@@ -103,7 +103,7 @@ export class NotificationService extends BaseService {
     }
   }
 
-  async markAsReadForAllRecipients(task: Task) {
+  markAsReadForAllRecipients = async (task: Task) => {
     const copilot = new CopilotAPI(this.user.token)
     const { recipientIds } = await this.getNotificationParties(copilot, task, NotificationTaskActions.AssignedToCompany)
     const markAsReadPromises = recipientIds.map((recipientId) =>

--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -254,7 +254,7 @@ export class TasksService extends BaseService {
         [AssigneeType.company]: notificationsService.markAsReadForAllRecipients,
       }
       // @ts-expect-error This is completely safe
-      handleNotificationRead[task?.assigneeType]?.(task)
+      await handleNotificationRead[task?.assigneeType]?.(task)
     }
     //delete the associated label
     const labelMappingService = new LabelMappingService(this.user)

--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -247,9 +247,14 @@ export class TasksService extends BaseService {
 
     if (!task) throw new APIError(httpStatus.NOT_FOUND, 'The requested task to delete was not found')
 
-    if (task?.assigneeType === AssigneeType.client && task.workflowState.type !== NotificationTaskActions.Completed) {
-      const notificationsService = new NotificationService(this.user)
-      await notificationsService.markClientNotificationAsRead(task)
+    const notificationsService = new NotificationService(this.user)
+    if (task?.assigneeType && task.workflowState.type !== NotificationTaskActions.Completed) {
+      const handleNotificationRead = {
+        [AssigneeType.client]: notificationsService.markClientNotificationAsRead,
+        [AssigneeType.company]: notificationsService.markAsReadForAllRecipients,
+      }
+      // @ts-expect-error This is completely safe
+      handleNotificationRead[task?.assigneeType]?.(task)
     }
     //delete the associated label
     const labelMappingService = new LabelMappingService(this.user)


### PR DESCRIPTION
### Tasks

- [OUT-592 | In-product notifications don´t disappear for Clients after company task is deleted](https://linear.app/copilotplatforms/issue/OUT-592/in-product-notifications-don%C2%B4t-disappear-for-clients-after-company)

### Changes

- [x] Implement proper logic so that task deletion trigger a Mark Notification as Read for each members associated with the company

### Testing Criteria

- [x] [LOOM](https://www.loom.com/share/c6b91cd7a9834e838ef6724a952598c7?sid=8c5344df-db34-402f-b2d0-03c0dfe2a573)