### PR TITLE
OUT-626 CU redirects to task details page when clicking 'Mark done' button

### DIFF
--- a/src/components/cards/ClientTaskCard.tsx
+++ b/src/components/cards/ClientTaskCard.tsx
@@ -31,6 +31,7 @@ export const ClientTaskCard = ({
   const handleMarkAsDoneClick = (e: React.MouseEvent) => {
     // Since mark as done button is nested inside a `next/link` Link, we need to stop the event from propagating
     // to the behavior of a tag - that would redirect it to the details age
+    e.stopPropagation()
     e.preventDefault()
     handleMarkDone()
   }


### PR DESCRIPTION
### Tasks

- [CU redirects to task details page when clicking 'Mark done' button](https://linear.app/copilotplatforms/issue/OUT-626/cu-redirects-to-task-details-page-when-clicking-mark-done-button)

### Changes

- [x]  added event.stopPropagation() on handleMarkDone

### Testing Criteria

- [LOOM](https://www.loom.com/share/238e91c348e04ec8a1a466897fe2bd22)