### PR TITLE
OUT-633 Make assignee a required field while creating task

### DIFF
--- a/src/app/ui/Modal_NewTaskForm.tsx
+++ b/src/app/ui/Modal_NewTaskForm.tsx
@@ -37,7 +37,7 @@ export const ModalNewTaskForm = ({
     >
       <NewTaskForm
         handleCreate={async () => {
-          if (title) {
+          if (title && assigneeId && assigneeType) {
             store.dispatch(setShowModal())
             store.dispatch(clearCreateTaskFields())
             const formattedDueDate = dueDate && dayjs(new Date(dueDate)).format('YYYY-MM-DD')


### PR DESCRIPTION
### Changes

- [x] Checks if assignee is null or undefined before task creation. If it is undefined/null then task creation doesn't proceed.
