### PR TITLE
OUT-669 | OUT-664 | In-product notification is not shown for IU when another IU completed the task

### DIFF
--- a/src/app/api/notification/notification.helpers.ts
+++ b/src/app/api/notification/notification.helpers.ts
@@ -41,7 +41,7 @@ export const getInProductNotificationDetails = (
       ctaParams,
     },
     [NotificationTaskActions.Commented]: {
-      title: 'Tew comment on task',
+      title: 'New comment on task',
       body: `A new comment was left by ${actionUser} on a task where you are set as the assignee. To see details about the task, navigate to the Tasks App below.`,
       ctaParams,
     },

--- a/src/app/api/notification/notification.helpers.ts
+++ b/src/app/api/notification/notification.helpers.ts
@@ -17,31 +17,31 @@ export const getInProductNotificationDetails = (
 
   return {
     [NotificationTaskActions.Assigned]: {
-      title: 'task was assigned to you',
+      title: 'Task was assigned to you',
       body: `The task ‘${task?.title}’  was created and assigned to you by ${actionUser}. To see details about the task, navigate to the Tasks App below.`,
       ctaParams,
     },
     [NotificationTaskActions.AssignedToCompany]: {
-      title: 'task was assigned to your company',
+      title: 'Task was assigned to your company',
       body: `A new task was assigned to your company by ${actionUser}. To see details about the task, navigate to the Tasks App below.`,
     },
     [NotificationTaskActions.ReassignedToIU]: {
-      title: 'task was reassigned to you',
+      title: 'Task was reassigned to you',
       body: `The task ‘${task?.title}’ was reassigned to you by ${actionUser}. To see details about the task, navigate to the Tasks App below.`,
       ctaParams,
     },
     [NotificationTaskActions.CompletedByCompanyMember]: {
-      title: 'task was completed',
+      title: 'Task was completed',
       body: `The task ‘${task?.title}’ was completed by ${actionUser} for ${companyName}. You are receiving this notification because you have access to the client.`,
       ctaParams,
     },
     [NotificationTaskActions.Completed]: {
-      title: 'task was completed',
+      title: 'Task was completed',
       body: `The task ‘${task?.title}’ was completed by ${actionUser}. You are receiving this notification because you have access to the client.`,
       ctaParams,
     },
     [NotificationTaskActions.Commented]: {
-      title: 'tew comment on task',
+      title: 'Tew comment on task',
       body: `A new comment was left by ${actionUser} on a task where you are set as the assignee. To see details about the task, navigate to the Tasks App below.`,
       ctaParams,
     },

--- a/src/app/api/notification/notification.helpers.ts
+++ b/src/app/api/notification/notification.helpers.ts
@@ -17,31 +17,31 @@ export const getInProductNotificationDetails = (
 
   return {
     [NotificationTaskActions.Assigned]: {
-      title: 'Task was assigned to you',
+      title: 'task was assigned to you',
       body: `The task ‘${task?.title}’  was created and assigned to you by ${actionUser}. To see details about the task, navigate to the Tasks App below.`,
       ctaParams,
     },
     [NotificationTaskActions.AssignedToCompany]: {
-      title: 'Task was assigned to your company',
+      title: 'task was assigned to your company',
       body: `A new task was assigned to your company by ${actionUser}. To see details about the task, navigate to the Tasks App below.`,
     },
     [NotificationTaskActions.ReassignedToIU]: {
-      title: 'Task was reassigned to you',
+      title: 'task was reassigned to you',
       body: `The task ‘${task?.title}’ was reassigned to you by ${actionUser}. To see details about the task, navigate to the Tasks App below.`,
       ctaParams,
     },
     [NotificationTaskActions.CompletedByCompanyMember]: {
-      title: 'Task was completed',
+      title: 'task was completed',
       body: `The task ‘${task?.title}’ was completed by ${actionUser} for ${companyName}. You are receiving this notification because you have access to the client.`,
       ctaParams,
     },
     [NotificationTaskActions.Completed]: {
-      title: 'Task was completed',
+      title: 'task was completed',
       body: `The task ‘${task?.title}’ was completed by ${actionUser}. You are receiving this notification because you have access to the client.`,
       ctaParams,
     },
     [NotificationTaskActions.Commented]: {
-      title: 'New comment on task',
+      title: 'tew comment on task',
       body: `A new comment was left by ${actionUser} on a task where you are set as the assignee. To see details about the task, navigate to the Tasks App below.`,
       ctaParams,
     },

--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -428,7 +428,11 @@ export class TasksService extends BaseService {
       updatedTask.assigneeId
     ) {
       if (updatedTask.createdById !== updatedTask.assigneeId) {
-        await notificationService.create(NotificationTaskActions.Completed, updatedTask, { email: true })
+        const action =
+          updatedTask.assigneeType === AssigneeType.company
+            ? NotificationTaskActions.CompletedByCompanyMember
+            : NotificationTaskActions.Completed
+        await notificationService.create(action, updatedTask, { email: true })
       }
 
       if (updatedTask.assigneeType === AssigneeType.client) {

--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -427,7 +427,8 @@ export class TasksService extends BaseService {
       updatedTask?.workflowState?.type === StateType.completed &&
       updatedTask.assigneeId
     ) {
-      const notificationService = new NotificationService(this.user)
+      await notificationService.create(NotificationTaskActions.Completed, updatedTask, { email: true })
+
       if (updatedTask.assigneeType === AssigneeType.client) {
         try {
           await notificationService.markClientNotificationAsRead(updatedTask)

--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -427,7 +427,9 @@ export class TasksService extends BaseService {
       updatedTask?.workflowState?.type === StateType.completed &&
       updatedTask.assigneeId
     ) {
-      await notificationService.create(NotificationTaskActions.Completed, updatedTask, { email: true })
+      if (updatedTask.createdById !== updatedTask.assigneeId) {
+        await notificationService.create(NotificationTaskActions.Completed, updatedTask, { email: true })
+      }
 
       if (updatedTask.assigneeType === AssigneeType.client) {
         try {


### PR DESCRIPTION
### Tasks

- [OUT-669 | In-product notification is not shown for IU when another IU completed the task](https://linear.app/copilotplatforms/issue/OUT-669/in-product-notification-is-not-shown-for-iu-when-another-iu-completed)
- [OUT-664 | Notification has an errant “for undefined”, for task completion on a task that was assigned to a company](https://linear.app/copilotplatforms/issue/OUT-664/notification-has-an-errant-for-undefined-for-task-completion-on-a-task)

### Changes

- [x] Add missing `.complete` call to notifications service when IU completes a task
- [x] Add missing condition to send notification when actionTrigger is IU
- [x] Fetch company name safely when triggering company task completed notification 

### Testing Criteria

![Screenshot from 2024-07-30 16-46-38](https://github.com/user-attachments/assets/05804ac7-bdc2-4962-b96f-80c85b45d826)
