### PR TITLE
OUT-643 | Search result shows duplicate records when searching with last name

### DIFF
--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -192,6 +192,7 @@ export const UserSchema = z.object({
 })
 
 export interface FilterableUser {
+  id: string
   givenName?: string
   familyName?: string
   name?: string

--- a/src/utils/users.ts
+++ b/src/utils/users.ts
@@ -26,7 +26,21 @@ export const filterUsersByKeyword = (users: FilterableUser[], keyword: string): 
       contains(givenName) || contains(familyName) || contains(`${givenName} ${familyName}`) || contains(name),
   )
 
-  return [...usersStartingWithKeyword, ...usersContainingKeyword]
+  const combinedUsers = [...usersStartingWithKeyword, ...usersContainingKeyword]
+
+  // Use a set to prevent dup records
+  const addedIds = new Set<string>()
+  const uniqueUsers = combinedUsers.filter((user) => {
+    let isUniqueId = false
+    if (!addedIds.has(user.id)) {
+      addedIds.add(user.id)
+      isUniqueId = true
+    }
+
+    return isUniqueId
+  })
+
+  return uniqueUsers
 }
 
 export const setDebouncedFilteredAssignees = (


### PR DESCRIPTION
### Tasks

- [OUT-643 | Search result shows duplicate records when searching with last name](https://linear.app/copilotplatforms/issue/OUT-643/search-result-shows-duplicate-records-when-searching-with-last-name)

### Changes

- [x] Use sets to prevent duplicating records between match criterias

### Testing Criteria

![image](https://github.com/user-attachments/assets/cc10e76b-73b4-4e7f-99ee-b1a56feaab34)
![image](https://github.com/user-attachments/assets/6bed760d-6ccb-44fd-91b4-b019309986dc)
