### PR TITLE
OUT-654 Improving task details opening experience

### DIFF
--- a/src/app/api/activity-logs/[id]/route.ts
+++ b/src/app/api/activity-logs/[id]/route.ts
@@ -5,7 +5,7 @@ import { IdParams } from '@api/core/types/api'
 import { unstable_noStore as noStore } from 'next/cache'
 
 export const GET = async (req: NextRequest, { params: { id } }: IdParams) => {
-  noStore()
+  // noStore()
   const user = await authenticate(req)
 
   const activityLogger = new ActivityLogService(user)

--- a/src/app/api/attachments/attachments.controller.ts
+++ b/src/app/api/attachments/attachments.controller.ts
@@ -29,7 +29,7 @@ export const createMultipleAttachments = async (req: NextRequest) => {
 }
 
 export const getAttachments = async (req: NextRequest) => {
-  noStore()
+  // noStore()
   const taskId = req.nextUrl.searchParams.get('taskId')
   if (!taskId) {
     throw new APIError(httpStatus.BAD_REQUEST, 'taskId is required')

--- a/src/app/api/tasks/tasks.controller.ts
+++ b/src/app/api/tasks/tasks.controller.ts
@@ -7,7 +7,7 @@ import authenticate from '@api/core/utils/authenticate'
 import { unstable_noStore as noStore } from 'next/cache'
 
 export const getTasks = async (req: NextRequest) => {
-  noStore()
+  // noStore()
   const user = await authenticate(req)
 
   const tasksService = new TasksService(user)

--- a/src/app/api/users/users.controller.ts
+++ b/src/app/api/users/users.controller.ts
@@ -4,7 +4,7 @@ import authenticate from '@api/core/utils/authenticate'
 import { unstable_noStore as noStore } from 'next/cache'
 
 export const getUsers = async (req: NextRequest) => {
-  noStore()
+  // noStore()
   const user = await authenticate(req)
   const usersService = new UsersService(user)
   const keyword = req.nextUrl.searchParams.get('search')
@@ -22,7 +22,7 @@ export const getUsers = async (req: NextRequest) => {
 }
 
 export const getClients = async (req: NextRequest) => {
-  noStore()
+  // noStore()
   const user = await authenticate(req)
   const rawLimit = req.nextUrl.searchParams.get('limit')
   const limit = rawLimit ? +rawLimit : undefined

--- a/src/app/api/view-settings/viewSettings.controller.ts
+++ b/src/app/api/view-settings/viewSettings.controller.ts
@@ -5,7 +5,7 @@ import { CreateViewSettingsSchema } from '@/types/dto/viewSettings.dto'
 import { unstable_noStore as noStore } from 'next/cache'
 
 export const getViewSetting = async (req: NextRequest) => {
-  noStore()
+  // noStore()
   const user = await authenticate(req)
 
   const viewSettingsService = new ViewSettingsService(user)

--- a/src/app/api/workflow-states/workflowStates.controller.ts
+++ b/src/app/api/workflow-states/workflowStates.controller.ts
@@ -6,7 +6,7 @@ import authenticate from '@api/core/utils/authenticate'
 import { unstable_noStore as noStore } from 'next/cache'
 
 export const getWorkflowStates = async (req: NextRequest) => {
-  noStore()
+  // noStore()
   const user = await authenticate(req)
 
   const workflowStatesService = new WorkflowStatesService(user)

--- a/src/app/detail/[task_id]/[user_type]/_StateOptimizer_.tsx
+++ b/src/app/detail/[task_id]/[user_type]/_StateOptimizer_.tsx
@@ -1,0 +1,29 @@
+import { selectTaskBoard } from '@/redux/features/taskBoardSlice'
+import { setStateOptimizers_taskDetailsSlice } from '@/redux/features/taskDetailsSlice'
+import store from '@/redux/store'
+import { ReactNode, useMemo } from 'react'
+import { useSelector } from 'react-redux'
+
+export const StateOptimizer = ({ task_id, children }: { task_id: string; children: ReactNode }) => {
+  const { tasks, workflowStates, assignee } = useSelector(selectTaskBoard)
+
+  useMemo(() => {
+    const currentTask = tasks.find((el) => el.id === task_id)
+    const currentWorkflowState = workflowStates.find((el) => el?.id === currentTask?.workflowStateId)
+    const currentAssignee = assignee.find((el) => el.id === currentTask?.assigneeId)
+
+    if (currentTask) {
+      store.dispatch(setStateOptimizers_taskDetailsSlice({ currentTask }))
+    }
+
+    if (currentWorkflowState) {
+      store.dispatch(setStateOptimizers_taskDetailsSlice({ currentWorkflowState }))
+    }
+
+    if (currentAssignee) {
+      store.dispatch(setStateOptimizers_taskDetailsSlice({ currentAssignee }))
+    }
+  }, [tasks, workflowStates, assignee])
+
+  return children
+}

--- a/src/app/detail/[task_id]/[user_type]/_StateOptimizer_.tsx
+++ b/src/app/detail/[task_id]/[user_type]/_StateOptimizer_.tsx
@@ -10,9 +10,9 @@ export const StateOptimizer = ({ task_id, children }: { task_id: string; childre
   const { tasks, workflowStates, assignee } = useSelector(selectTaskBoard)
 
   useMemo(() => {
-    // const currentTask = tasks.find((el) => el.id === task_id)
-    // const currentWorkflowState = workflowStates.find((el) => el?.id === currentTask?.workflowStateId)
-    // const currentAssignee = assignee.find((el) => el.id === currentTask?.assigneeId)
+    const currentTask = tasks.find((el) => el.id === task_id)
+    const currentWorkflowState = workflowStates.find((el) => el?.id === currentTask?.workflowStateId)
+    const currentAssignee = assignee.find((el) => el.id === currentTask?.assigneeId)
 
     store.dispatch(
       setStateOptimizers_taskDetailsSlice({

--- a/src/app/detail/[task_id]/[user_type]/_StateOptimizer_.tsx
+++ b/src/app/detail/[task_id]/[user_type]/_StateOptimizer_.tsx
@@ -14,13 +14,7 @@ export const StateOptimizer = ({ task_id, children }: { task_id: string; childre
     const currentWorkflowState = workflowStates.find((el) => el?.id === currentTask?.workflowStateId)
     const currentAssignee = assignee.find((el) => el.id === currentTask?.assigneeId)
 
-    store.dispatch(
-      setStateOptimizers_taskDetailsSlice({
-        currentTask: tasks[0],
-        currentWorkflowState: workflowStates[0],
-        currentAssignee: assignee[0],
-      }),
-    )
+    store.dispatch(setStateOptimizers_taskDetailsSlice({ currentTask, currentWorkflowState, currentAssignee }))
   }, [tasks, workflowStates, assignee])
 
   return children

--- a/src/app/detail/[task_id]/[user_type]/_StateOptimizer_.tsx
+++ b/src/app/detail/[task_id]/[user_type]/_StateOptimizer_.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { selectTaskBoard } from '@/redux/features/taskBoardSlice'
 import { setStateOptimizers_taskDetailsSlice } from '@/redux/features/taskDetailsSlice'
 import store from '@/redux/store'
@@ -12,17 +14,7 @@ export const StateOptimizer = ({ task_id, children }: { task_id: string; childre
     const currentWorkflowState = workflowStates.find((el) => el?.id === currentTask?.workflowStateId)
     const currentAssignee = assignee.find((el) => el.id === currentTask?.assigneeId)
 
-    if (currentTask) {
-      store.dispatch(setStateOptimizers_taskDetailsSlice({ currentTask }))
-    }
-
-    if (currentWorkflowState) {
-      store.dispatch(setStateOptimizers_taskDetailsSlice({ currentWorkflowState }))
-    }
-
-    if (currentAssignee) {
-      store.dispatch(setStateOptimizers_taskDetailsSlice({ currentAssignee }))
-    }
+    store.dispatch(setStateOptimizers_taskDetailsSlice({ currentTask, currentWorkflowState, currentAssignee }))
   }, [tasks, workflowStates, assignee])
 
   return children

--- a/src/app/detail/[task_id]/[user_type]/_StateOptimizer_.tsx
+++ b/src/app/detail/[task_id]/[user_type]/_StateOptimizer_.tsx
@@ -10,11 +10,17 @@ export const StateOptimizer = ({ task_id, children }: { task_id: string; childre
   const { tasks, workflowStates, assignee } = useSelector(selectTaskBoard)
 
   useMemo(() => {
-    const currentTask = tasks.find((el) => el.id === task_id)
-    const currentWorkflowState = workflowStates.find((el) => el?.id === currentTask?.workflowStateId)
-    const currentAssignee = assignee.find((el) => el.id === currentTask?.assigneeId)
+    // const currentTask = tasks.find((el) => el.id === task_id)
+    // const currentWorkflowState = workflowStates.find((el) => el?.id === currentTask?.workflowStateId)
+    // const currentAssignee = assignee.find((el) => el.id === currentTask?.assigneeId)
 
-    store.dispatch(setStateOptimizers_taskDetailsSlice({ currentTask, currentWorkflowState, currentAssignee }))
+    store.dispatch(
+      setStateOptimizers_taskDetailsSlice({
+        currentTask: tasks[0],
+        currentWorkflowState: workflowStates[0],
+        currentAssignee: assignee[0],
+      }),
+    )
   }, [tasks, workflowStates, assignee])
 
   return children

--- a/src/app/detail/[task_id]/[user_type]/page.tsx
+++ b/src/app/detail/[task_id]/[user_type]/page.tsx
@@ -1,4 +1,5 @@
-export const fetchCache = 'force-no-store'
+// export const fetchCache = 'force-no-store'
+export const revalidate = 1000
 
 import { AppMargin, SizeofAppMargin } from '@/hoc/AppMargin'
 import { TaskEditor } from '@/app/detail/ui/TaskEditor'

--- a/src/app/detail/[task_id]/[user_type]/page.tsx
+++ b/src/app/detail/[task_id]/[user_type]/page.tsx
@@ -44,6 +44,7 @@ import { MAX_FETCH_ASSIGNEE_COUNT } from '@/constants/users'
 import { RealTime } from '@/hoc/RealTime'
 import { WorkflowStateResponse } from '@/types/dto/workflowStates.dto'
 import { CustomScrollbar } from '@/hoc/CustomScrollbar'
+import { StateOptimizer } from '@/app/detail/[task_id]/[user_type]/_StateOptimizer_'
 
 async function getOneTask(token: string, taskId: string): Promise<TaskResponse> {
   const res = await fetch(`${apiUrl}/api/tasks/${taskId}?token=${token}`, {
@@ -155,140 +156,144 @@ export default async function TaskDetailPage({
       workflowStates={workflowStates}
     >
       <RealTime>
-        <EscapeHandler />
-        <Stack direction="row" sx={{ height: '100vh' }}>
-          <ToggleController>
-            <StyledBox>
-              <AppMargin size={SizeofAppMargin.LARGE} py="16px">
-                <Stack direction="row" justifyContent="space-between">
-                  <Stack direction="row" alignItems="center" columnGap={3}>
-                    <Link href={params.user_type === UserType.INTERNAL_USER ? `/?token=${token}` : `/client?token=${token}`}>
-                      <SecondaryBtn
-                        buttonContent={
-                          <StyledTypography variant="sm" lineHeight={'21px'}>
-                            Tasks
-                          </StyledTypography>
-                        }
-                        variant="breadcrumb"
-                      />
-                    </Link>
-                    <StyledKeyboardIcon />
-                    <Typography variant="sm">{task?.label}</Typography>
-                  </Stack>
-                  <Stack direction="row" alignItems="center" columnGap="8px">
-                    {params.user_type === UserType.INTERNAL_USER && <MenuBoxContainer />}
-                    <ToggleButtonContainer />
-                  </Stack>
-                </Stack>
-              </AppMargin>
-            </StyledBox>
-            <CustomScrollbar style={{ width: '8px' }}>
-              <StyledTiptapDescriptionWrapper>
-                <AppMargin size={SizeofAppMargin.LARGE} py="30px">
-                  <TaskEditor
-                    attachment={attachments}
-                    task_id={task_id}
-                    isEditable={params.user_type === UserType.INTERNAL_USER}
-                    updateTaskDetail={async (detail) => {
-                      'use server'
-                      await updateTaskDetail({ token, taskId: task_id, payload: { body: detail } })
-                    }}
-                    updateTaskTitle={async (title) => {
-                      'use server'
-                      await updateTaskDetail({ token, taskId: task_id, payload: { title } })
-                    }}
-                    deleteTask={async () => {
-                      'use server'
-                      await deleteTask(token, task_id)
-                    }}
-                    postAttachment={async (postAttachmentPayload) => {
-                      'use server'
-                      await postAttachment(token, postAttachmentPayload)
-                    }}
-                    deleteAttachment={async (id: string) => {
-                      'use server'
-                      await deleteAttachment(token, id)
-                    }}
-                    getSignedUrlUpload={async (fileName: string) => {
-                      'use server'
-                      const data = await getSignedUrlUpload(token, fileName)
-                      return data
-                    }}
-                    userType={params.user_type}
-                  />
-                </AppMargin>
-              </StyledTiptapDescriptionWrapper>
-              {advancedFeatureFlag && (
-                <AppMargin size={SizeofAppMargin.LARGE} py="18.5px">
-                  <Stack direction="column" alignItems="left" p="10px 5px" rowGap={5}>
-                    <Typography variant="xl">Activity</Typography>
-                    <Stack direction="column" alignItems="left" p="10px 5px" rowGap={4}>
-                      {activities?.map((item: LogResponse, index: number) => {
-                        return (
-                          <Box
-                            sx={{
-                              height: 'auto',
-                              display: 'block',
-                            }}
-                            key={item.id}
-                          >
-                            {item.type == ActivityType.COMMENT_ADDED ? (
-                              <Comments
-                                comment={item}
-                                createComment={async (postCommentPayload: CreateComment) => {
-                                  'use server'
-                                  await postComment(token, postCommentPayload)
-                                }}
-                                deleteComment={async (id: string) => {
-                                  'use server'
-                                  await deleteComment(token, id)
-                                }}
-                                task_id={task_id}
-                              />
-                            ) : (
-                              <ActivityLog log={item} />
-                            )}
-                          </Box>
-                        )
-                      })}
-
-                      <CommentInput
-                        createComment={async (postCommentPayload: CreateComment) => {
-                          'use server'
-                          await postComment(token, postCommentPayload)
-                        }}
-                        task_id={task_id}
-                      />
+        <StateOptimizer task_id={task_id}>
+          <EscapeHandler />
+          <Stack direction="row" sx={{ height: '100vh' }}>
+            <ToggleController>
+              <StyledBox>
+                <AppMargin size={SizeofAppMargin.LARGE} py="16px">
+                  <Stack direction="row" justifyContent="space-between">
+                    <Stack direction="row" alignItems="center" columnGap={3}>
+                      <Link
+                        href={params.user_type === UserType.INTERNAL_USER ? `/?token=${token}` : `/client?token=${token}`}
+                      >
+                        <SecondaryBtn
+                          buttonContent={
+                            <StyledTypography variant="sm" lineHeight={'21px'}>
+                              Tasks
+                            </StyledTypography>
+                          }
+                          variant="breadcrumb"
+                        />
+                      </Link>
+                      <StyledKeyboardIcon />
+                      <Typography variant="sm">{task?.label}</Typography>
+                    </Stack>
+                    <Stack direction="row" alignItems="center" columnGap="8px">
+                      {params.user_type === UserType.INTERNAL_USER && <MenuBoxContainer />}
+                      <ToggleButtonContainer />
                     </Stack>
                   </Stack>
                 </AppMargin>
-              )}
-            </CustomScrollbar>
-          </ToggleController>
-          <Box>
-            <Sidebar
-              assignee={assignee}
-              task_id={task_id}
-              selectedAssigneeId={task?.assigneeId}
-              selectedWorkflowState={task?.workflowState}
-              updateWorkflowState={async (workflowState) => {
-                'use server'
-                params.user_type === UserType.CLIENT_USER
-                  ? await clientUpdateTask(token, task_id, workflowState.id)
-                  : await updateWorkflowStateIdOfTask(token, task_id, workflowState?.id)
-              }}
-              updateAssignee={async (assigneeType, assigneeId) => {
-                'use server'
-                await updateAssignee(token, task_id, assigneeType, assigneeId)
-              }}
-              updateTask={async (payload) => {
-                'use server'
-                await updateTaskDetail({ token, taskId: task_id, payload })
-              }}
-              disabled={params.user_type === UserType.CLIENT_USER}
-            />
-          </Box>
-        </Stack>
+              </StyledBox>
+              <CustomScrollbar style={{ width: '8px' }}>
+                <StyledTiptapDescriptionWrapper>
+                  <AppMargin size={SizeofAppMargin.LARGE} py="30px">
+                    <TaskEditor
+                      attachment={attachments}
+                      task_id={task_id}
+                      isEditable={params.user_type === UserType.INTERNAL_USER}
+                      updateTaskDetail={async (detail) => {
+                        'use server'
+                        await updateTaskDetail({ token, taskId: task_id, payload: { body: detail } })
+                      }}
+                      updateTaskTitle={async (title) => {
+                        'use server'
+                        await updateTaskDetail({ token, taskId: task_id, payload: { title } })
+                      }}
+                      deleteTask={async () => {
+                        'use server'
+                        await deleteTask(token, task_id)
+                      }}
+                      postAttachment={async (postAttachmentPayload) => {
+                        'use server'
+                        await postAttachment(token, postAttachmentPayload)
+                      }}
+                      deleteAttachment={async (id: string) => {
+                        'use server'
+                        await deleteAttachment(token, id)
+                      }}
+                      getSignedUrlUpload={async (fileName: string) => {
+                        'use server'
+                        const data = await getSignedUrlUpload(token, fileName)
+                        return data
+                      }}
+                      userType={params.user_type}
+                    />
+                  </AppMargin>
+                </StyledTiptapDescriptionWrapper>
+                {advancedFeatureFlag && (
+                  <AppMargin size={SizeofAppMargin.LARGE} py="18.5px">
+                    <Stack direction="column" alignItems="left" p="10px 5px" rowGap={5}>
+                      <Typography variant="xl">Activity</Typography>
+                      <Stack direction="column" alignItems="left" p="10px 5px" rowGap={4}>
+                        {activities?.map((item: LogResponse, index: number) => {
+                          return (
+                            <Box
+                              sx={{
+                                height: 'auto',
+                                display: 'block',
+                              }}
+                              key={item.id}
+                            >
+                              {item.type == ActivityType.COMMENT_ADDED ? (
+                                <Comments
+                                  comment={item}
+                                  createComment={async (postCommentPayload: CreateComment) => {
+                                    'use server'
+                                    await postComment(token, postCommentPayload)
+                                  }}
+                                  deleteComment={async (id: string) => {
+                                    'use server'
+                                    await deleteComment(token, id)
+                                  }}
+                                  task_id={task_id}
+                                />
+                              ) : (
+                                <ActivityLog log={item} />
+                              )}
+                            </Box>
+                          )
+                        })}
+
+                        <CommentInput
+                          createComment={async (postCommentPayload: CreateComment) => {
+                            'use server'
+                            await postComment(token, postCommentPayload)
+                          }}
+                          task_id={task_id}
+                        />
+                      </Stack>
+                    </Stack>
+                  </AppMargin>
+                )}
+              </CustomScrollbar>
+            </ToggleController>
+            <Box>
+              <Sidebar
+                assignee={assignee}
+                task_id={task_id}
+                selectedAssigneeId={task?.assigneeId}
+                selectedWorkflowState={task?.workflowState}
+                updateWorkflowState={async (workflowState) => {
+                  'use server'
+                  params.user_type === UserType.CLIENT_USER
+                    ? await clientUpdateTask(token, task_id, workflowState.id)
+                    : await updateWorkflowStateIdOfTask(token, task_id, workflowState?.id)
+                }}
+                updateAssignee={async (assigneeType, assigneeId) => {
+                  'use server'
+                  await updateAssignee(token, task_id, assigneeType, assigneeId)
+                }}
+                updateTask={async (payload) => {
+                  'use server'
+                  await updateTaskDetail({ token, taskId: task_id, payload })
+                }}
+                disabled={params.user_type === UserType.CLIENT_USER}
+              />
+            </Box>
+          </Stack>
+        </StateOptimizer>
       </RealTime>
     </ClientSideStateUpdate>
   )

--- a/src/app/detail/ui/Sidebar.tsx
+++ b/src/app/detail/ui/Sidebar.tsx
@@ -50,19 +50,17 @@ export const Sidebar = ({
   workflowDisabled?: false
 }) => {
   const { tasks, token, workflowStates } = useSelector(selectTaskBoard)
-  const { showSidebar } = useSelector(selectTaskDetails)
+  const { currentTask, currentAssignee, currentWorkflowState, showSidebar } = useSelector(selectTaskDetails)
   const [filteredAssignees, setFilteredAssignees] = useState(assignee)
   const [activeDebounceTimeoutId, setActiveDebounceTimeoutId] = useState<NodeJS.Timeout | null>(null)
   const [loading, setLoading] = useState(false)
   const [dueDate, setDueDate] = useState<Date | string | undefined>()
 
   const { renderingItem: _statusValue, updateRenderingItem: updateStatusValue } = useHandleSelectorComponent({
-    // item: selectedWorkflowState,
     item: null,
     type: SelectorType.STATUS_SELECTOR,
   })
   const { renderingItem: _assigneeValue, updateRenderingItem: updateAssigneeValue } = useHandleSelectorComponent({
-    // item: selectedAssigneeId ? assignee.find((el) => el.id === selectedAssigneeId) : NoAssignee,
     item: null,
     type: SelectorType.ASSIGNEE_SELECTOR,
   })
@@ -71,15 +69,13 @@ export const Sidebar = ({
   const assigneeValue = _assigneeValue as IAssigneeCombined //typecasting
 
   useEffect(() => {
-    if (tasks && workflowStates) {
-      const currentTask = tasks.find((el) => el.id === task_id)
-      const currentWorkflowState = workflowStates.find((el) => el?.id === currentTask?.workflowStateId)
+    if (currentTask && currentWorkflowState) {
       const currentAssigneeId = currentTask?.assigneeId
       updateStatusValue(currentWorkflowState)
-      updateAssigneeValue(currentAssigneeId ? assignee.find((el) => el.id === currentAssigneeId) : NoAssignee)
+      updateAssigneeValue(currentAssigneeId ? currentAssignee : NoAssignee)
       setDueDate(currentTask?.dueDate)
     }
-  }, [tasks, workflowStates])
+  }, [currentAssignee, currentTask, currentWorkflowState])
 
   const matches = useMediaQuery('(max-width:600px)')
   if (!tasks) return null

--- a/src/app/detail/ui/TaskEditor.tsx
+++ b/src/app/detail/ui/TaskEditor.tsx
@@ -45,7 +45,6 @@ export const TaskEditor = ({
   getSignedUrlUpload,
   userType,
 }: Prop) => {
-  const { tasks } = useSelector(selectTaskBoard)
   const [updateTitle, setUpdateTitle] = useState('')
   const [updateDetail, setUpdateDetail] = useState('')
   const { currentTask, showConfirmDeleteModal } = useSelector(selectTaskDetails)

--- a/src/app/detail/ui/TaskEditor.tsx
+++ b/src/app/detail/ui/TaskEditor.tsx
@@ -48,7 +48,7 @@ export const TaskEditor = ({
   const { tasks } = useSelector(selectTaskBoard)
   const [updateTitle, setUpdateTitle] = useState('')
   const [updateDetail, setUpdateDetail] = useState('')
-  const { showConfirmDeleteModal } = useSelector(selectTaskDetails)
+  const { currentTask, showConfirmDeleteModal } = useSelector(selectTaskDetails)
   const [isUserTyping, setIsUserTyping] = useState(false)
 
   const handleFileSelect = async (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -67,13 +67,12 @@ export const TaskEditor = ({
 
   useEffect(() => {
     if (!isUserTyping) {
-      const currentTask = tasks.find((el) => el.id === task_id)
       if (currentTask) {
         setUpdateTitle(currentTask.title || '')
         setUpdateDetail(currentTask.body ?? '')
       }
     }
-  }, [tasks, task_id, isUserTyping])
+  }, [currentTask, task_id, isUserTyping])
 
   const _titleUpdateDebounced = async (title: string) => updateTaskTitle(title)
 

--- a/src/app/detail/ui/TaskEditor.tsx
+++ b/src/app/detail/ui/TaskEditor.tsx
@@ -72,7 +72,7 @@ export const TaskEditor = ({
         setUpdateDetail(currentTask.body ?? '')
       }
     }
-  }, [currentTask, task_id, isUserTyping])
+  }, [currentTask, isUserTyping])
 
   const _titleUpdateDebounced = async (title: string) => updateTaskTitle(title)
 

--- a/src/hooks/useFilter.tsx
+++ b/src/hooks/useFilter.tsx
@@ -45,11 +45,11 @@ export const useFilter = (filterOptions: IFilterOptions) => {
 
   function applyFilter(tasks: TaskResponse[], filterOptions: IFilterOptions) {
     let filteredTasks = [...tasks]
-    for (const [filterType, filterValue] of Object.entries(filterOptions)) {
-      if (!filterValue) continue
-      const filterFn = FilterFunctions[filterType as FilterOptions]
-      filteredTasks = filterFn(filteredTasks, filterValue)
-    }
+    // for (const [filterType, filterValue] of Object.entries(filterOptions)) {
+    //   if (!filterValue) continue
+    //   const filterFn = FilterFunctions[filterType as FilterOptions]
+    //   filteredTasks = filterFn(filteredTasks, filterValue)
+    // }
     store.dispatch(setFilteredTasks(filteredTasks))
   }
 

--- a/src/hooks/useFilter.tsx
+++ b/src/hooks/useFilter.tsx
@@ -45,11 +45,11 @@ export const useFilter = (filterOptions: IFilterOptions) => {
 
   function applyFilter(tasks: TaskResponse[], filterOptions: IFilterOptions) {
     let filteredTasks = [...tasks]
-    // for (const [filterType, filterValue] of Object.entries(filterOptions)) {
-    //   if (!filterValue) continue
-    //   const filterFn = FilterFunctions[filterType as FilterOptions]
-    //   filteredTasks = filterFn(filteredTasks, filterValue)
-    // }
+    for (const [filterType, filterValue] of Object.entries(filterOptions)) {
+      if (!filterValue) continue
+      const filterFn = FilterFunctions[filterType as FilterOptions]
+      filteredTasks = filterFn(filteredTasks, filterValue)
+    }
     store.dispatch(setFilteredTasks(filteredTasks))
   }
 

--- a/src/redux/features/taskDetailsSlice.ts
+++ b/src/redux/features/taskDetailsSlice.ts
@@ -1,17 +1,25 @@
 import { createSlice } from '@reduxjs/toolkit'
 import { RootState } from '../store'
-import { IAssigneeSuggestions } from '@/types/interfaces'
+import { IAssigneeCombined, IAssigneeSuggestions } from '@/types/interfaces'
+import { TaskResponse } from '@/types/dto/tasks.dto'
+import { WorkflowStateResponse } from '@/types/dto/workflowStates.dto'
 
 interface IInitialState {
   showConfirmDeleteModal: boolean
   showSidebar: boolean
   assigneeSuggestions: IAssigneeSuggestions[]
+  currentTask: TaskResponse | undefined
+  currentAssignee: IAssigneeCombined | undefined
+  currentWorkflowState: WorkflowStateResponse | undefined
 }
 
 const initialState: IInitialState = {
   showConfirmDeleteModal: false,
   showSidebar: false,
   assigneeSuggestions: [],
+  currentTask: undefined,
+  currentAssignee: undefined,
+  currentWorkflowState: undefined,
 }
 
 const taskDetailsSlice = createSlice({
@@ -27,11 +35,27 @@ const taskDetailsSlice = createSlice({
     setAssigneeSuggestion: (state, action: { payload: IAssigneeSuggestions[] }) => {
       state.assigneeSuggestions = action.payload
     },
+    setStateOptimizers_taskDetailsSlice: (
+      state,
+      action: {
+        payload: {
+          currentTask?: TaskResponse
+          currentAssignee?: IAssigneeCombined
+          currentWorkflowState?: WorkflowStateResponse
+        }
+      },
+    ) => {
+      const { currentTask, currentAssignee, currentWorkflowState } = action.payload
+      state.currentTask = currentTask
+      state.currentWorkflowState = currentWorkflowState
+      state.currentAssignee = currentAssignee
+    },
   },
 })
 
 export const selectTaskDetails = (state: RootState) => state.taskDetail
 
-export const { setShowConfirmDeleteModal, setShowSidebar, setAssigneeSuggestion } = taskDetailsSlice.actions
+export const { setShowConfirmDeleteModal, setShowSidebar, setAssigneeSuggestion, setStateOptimizers_taskDetailsSlice } =
+  taskDetailsSlice.actions
 
 export default taskDetailsSlice.reducer


### PR DESCRIPTION
### Changes

- [x] Adds a `_StateOptimizer_` hoc which contains a memoized looping script to find the `currentTask`, `currentAssignee`, and `currentWorkflowState` that are essential for the details page

**Note:** 
Previously, we were performing this calculation (to find `currenTask`, `currentAssignee`, and `currentWorkflowState` which is a long scripting operation) on both `TaskEditor` and `Sidebar` which was creating a long scripting time. This doesn't ensure a drastic performance improvement, however a overload has been decreased because now we are performing the calculation in a memoized fashion inside `_StateOptimizer_`. Another place where such long scripting operation is performed is in the `TaskCard` and `FilterBar`, which is not possible to take away. 

**Possible improvement -**
It would be nice if we can send the `assigneeDetails` from the API response along with the array of `tasks`. This will make sure all the required data are available during the initial fetch request for the tasks.  
