### PR TITLE
OUT-660 Loading spinner shows when going back to task list first time

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
   },
   "lint-staged": {
     "src/**/*.{ts,tsx}": [
+      "yarn lint:fix",
       "yarn prettier:fix"
     ]
   }

--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
   },
   "lint-staged": {
     "src/**/*.{ts,tsx}": [
-      "yarn lint:fix",
       "yarn prettier:fix"
     ]
   }

--- a/src/app/detail/ui/Sidebar.tsx
+++ b/src/app/detail/ui/Sidebar.tsx
@@ -73,7 +73,6 @@ export const Sidebar = ({
       const currentTask = tasks.find((el) => el.id === task_id)
       const currentWorkflowState = workflowStates.find((el) => el?.id === currentTask?.workflowStateId)
       const currentAssigneeId = currentTask?.assigneeId
-      console.log('assigneeId>>', currentAssigneeId)
       const currentAssignee = currentAssigneeId ? assignee.find((el) => el.id === currentAssigneeId) : NoAssignee
       updateStatusValue(currentWorkflowState)
       updateAssigneeValue(currentAssignee)

--- a/src/app/detail/ui/TaskEditor.tsx
+++ b/src/app/detail/ui/TaskEditor.tsx
@@ -90,6 +90,11 @@ export const TaskEditor = ({
 
   const resetTypingFlag = useCallback(() => {
     setIsUserTyping(false)
+    if (userType === UserType.INTERNAL_USER) {
+      router.prefetch(`/?token=${token}`)
+    } else {
+      router.prefetch(`/client?token=${token}`)
+    }
   }, [])
 
   const debouncedResetTypingFlag = useDebounce(resetTypingFlag, 1500)
@@ -114,14 +119,6 @@ export const TaskEditor = ({
     detailsUpdateDebounced(content)
     debouncedResetTypingFlag()
   }
-
-  useEffect(() => {
-    if (userType === UserType.INTERNAL_USER) {
-      router.prefetch(`/?token=${token}`)
-    } else {
-      router.prefetch(`/client?token=${token}`)
-    }
-  }, [])
 
   return (
     <>

--- a/src/app/detail/ui/TaskEditor.tsx
+++ b/src/app/detail/ui/TaskEditor.tsx
@@ -90,6 +90,9 @@ export const TaskEditor = ({
 
   const resetTypingFlag = useCallback(() => {
     setIsUserTyping(false)
+  }, [])
+
+  useEffect(() => {
     if (userType === UserType.INTERNAL_USER) {
       console.log('runninggggg')
       router.prefetch(`/?token=${token}`)

--- a/src/app/detail/ui/TaskEditor.tsx
+++ b/src/app/detail/ui/TaskEditor.tsx
@@ -115,6 +115,14 @@ export const TaskEditor = ({
     debouncedResetTypingFlag()
   }
 
+  useEffect(() => {
+    if (userType === UserType.INTERNAL_USER) {
+      router.prefetch(`/?token=${token}`)
+    } else {
+      router.prefetch(`/client?token=${token}`)
+    }
+  }, [])
+
   return (
     <>
       <StyledTextField

--- a/src/app/detail/ui/TaskEditor.tsx
+++ b/src/app/detail/ui/TaskEditor.tsx
@@ -91,6 +91,7 @@ export const TaskEditor = ({
   const resetTypingFlag = useCallback(() => {
     setIsUserTyping(false)
     if (userType === UserType.INTERNAL_USER) {
+      console.log('runninggggg')
       router.prefetch(`/?token=${token}`)
     } else {
       router.prefetch(`/client?token=${token}`)

--- a/src/cmd/load-testing/deleteClients.ts
+++ b/src/cmd/load-testing/deleteClients.ts
@@ -14,7 +14,6 @@ const run = async () => {
   const apiKey = z.string().parse(process.env.COPILOT_API_KEY)
   const copilot = new CopilotAPI(token, apiKey)
   const clients = await copilot.getClients({ limit: 10_000 })
-  console.log('Clients:', clients.data?.length)
 
   if (!clients.data) {
     throw new Error('No clients to delete')


### PR DESCRIPTION
### Changes

- [x] Adds custom prefetching using `route.prefetch` in `TaskEditor` to prefetch `/` route after `/details` is loaded

### Testing Criteria
- [LOOM](https://www.loom.com/share/827f8f2048fc4db1b13cae9e8e82901c?sid=bd3e29b8-8022-4ce1-85a8-0c35774c8d82) video shows the fast navigation from details page to the task board.