### PR TITLE
Hotfix: Increase client / company limit that is fed into filter

### DIFF
--- a/src/app/api/users/users.service.ts
+++ b/src/app/api/users/users.service.ts
@@ -24,11 +24,12 @@ class UsersService extends BaseService {
     new PoliciesService(user).authorize(UserAction.Read, Resource.Users)
 
     const listArgs: CopilotListArgs = { limit, nextToken }
+    const maxLimitForFiltering = 10_000
 
     const [ius, clients, companies] = await Promise.all([
       this.copilot.getInternalUsers(listArgs),
-      this.copilot.getClients({ limit: 1000, nextToken }),
-      this.copilot.getCompanies({ limit: 1000, nextToken }),
+      this.copilot.getClients({ limit: maxLimitForFiltering, nextToken }),
+      this.copilot.getCompanies({ limit: maxLimitForFiltering, nextToken }),
     ])
 
     // Get current internal user as only IUs are authenticated to access this route


### PR DESCRIPTION
### Tasks

- N/A

### Changes

- [x] Increase the `limit` param for CopilotAPI `ListArgs` so that we filter total set of client / company records.