### PR TITLE
OUT-692, OUT-693, OUT-694 Reduce spacing between assignees in drop-down on mobile experience

### DIFF
--- a/src/components/buttons/FilterByAssigneeBtn.tsx
+++ b/src/components/buttons/FilterByAssigneeBtn.tsx
@@ -5,15 +5,7 @@ import { Avatar, IconButton, Stack, Typography } from '@mui/material'
 import { CopilotAvatar } from '../atoms/CopilotAvatar'
 import { getAssigneeName } from '@/utils/assignee'
 
-export const FilterByAssigneeBtn = ({
-  assigneeValue,
-  updateAssigneeValue,
-  handleClick,
-}: {
-  assigneeValue: IAssigneeCombined
-  updateAssigneeValue: (newValue: unknown) => void
-  handleClick: (optionType: FilterOptions, value: string | null) => void
-}) => {
+export const FilterByAssigneeBtn = ({ assigneeValue }: { assigneeValue: IAssigneeCombined }) => {
   return (
     <Stack direction="row" alignItems="center" columnGap={1}>
       <Typography
@@ -34,25 +26,12 @@ export const FilterByAssigneeBtn = ({
               textOverflow: 'ellipsis',
               whiteSpace: 'nowrap',
               overflow: 'hidden',
-              maxWidth: '90px',
+              maxWidth: '100px',
             }}
             title={getAssigneeName(assigneeValue)}
           >
             {getAssigneeName(assigneeValue)}
           </Typography>
-          <IconButton
-            aria-label="remove"
-            onClick={(e) => {
-              e.stopPropagation()
-              updateAssigneeValue(null)
-              handleClick(FilterOptions.ASSIGNEE, '')
-            }}
-            sx={{ cursor: 'pointer' }}
-            disableRipple
-            disableTouchRipple
-          >
-            <CrossIcon />
-          </IconButton>
         </Stack>
       ) : (
         <Typography

--- a/src/components/inputs/Selector.tsx
+++ b/src/components/inputs/Selector.tsx
@@ -328,6 +328,9 @@ const AssigneeSelectorRenderer = ({ props, option }: { props: HTMLAttributes<HTM
       component="li"
       {...props}
       sx={(theme) => ({
+        '&.MuiAutocomplete-option': {
+          minHeight: { xs: '32px' },
+        },
         overflow: 'hidden',
         textOverflow: 'ellipsis',
         whiteSpace: 'nowrap',

--- a/src/components/inputs/Selector.tsx
+++ b/src/components/inputs/Selector.tsx
@@ -187,7 +187,6 @@ export default function Selector({
           openOnFocus
           onKeyDown={handleKeyDown}
           ListboxProps={{ sx: { maxHeight: { xs: '175px', sm: '291px' } } }}
-          autoHighlight
           options={extraOption ? [extraOption, ...options] : options}
           value={value}
           onChange={(_, newValue: unknown) => {
@@ -320,21 +319,22 @@ const StatusSelectorRenderer = ({ props, option }: { props: HTMLAttributes<HTMLL
 }
 const AssigneeSelectorRenderer = ({ props, option }: { props: HTMLAttributes<HTMLLIElement>; option: unknown }) => {
   const assignee = option as IAssigneeCombined
+
   return (
     <Box
       component="li"
       {...props}
-      sx={{
+      sx={(theme) => ({
         overflow: 'hidden',
         textOverflow: 'ellipsis',
         whiteSpace: 'nowrap',
-        '&.MuiAutocomplete-option[aria-selected="true"]': {
-          bgcolor: (theme) => theme.color.gray[100],
-        },
         '&.MuiAutocomplete-option[aria-selected="true"].Mui-focused': {
-          bgcolor: (theme) => theme.color.gray[100],
+          bgcolor: theme.color.gray[150],
         },
-      }}
+        '&.MuiAutocomplete-option.Mui-focused': {
+          bgcolor: theme.color.gray[150],
+        },
+      })}
     >
       <Stack direction="row" alignItems="center" columnGap={3}>
         <CopilotAvatar currentAssignee={assignee} />

--- a/src/components/inputs/Selector.tsx
+++ b/src/components/inputs/Selector.tsx
@@ -237,6 +237,10 @@ export default function Selector({
                   handleInputChange?.(e.target.value)
                   setInputStatusValue(e.target.value)
                 }}
+                onBlur={() => {
+                  setInputStatusValue('')
+                  handleInputChange?.('')
+                }}
               />
             )
           }}

--- a/src/components/inputs/Selector.tsx
+++ b/src/components/inputs/Selector.tsx
@@ -43,6 +43,7 @@ interface Prop {
   filterOption?: any
   onClick?: () => void
   error?: boolean
+  endIcon?: ReactNode
 }
 
 export default function Selector({
@@ -65,6 +66,7 @@ export default function Selector({
   filterOption,
   onClick,
   error,
+  endIcon,
 }: Prop) {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
 
@@ -164,6 +166,7 @@ export default function Selector({
               padding={padding}
               height={buttonHeight}
               error={error}
+              endIcon={endIcon}
             />
             {error && <StyledHelperText> Required</StyledHelperText>}
           </>
@@ -356,6 +359,7 @@ const SelectorButton = ({
   disabled,
   height,
   error,
+  endIcon,
 }: {
   startIcon?: ReactNode
   buttonContent: ReactNode
@@ -366,11 +370,13 @@ const SelectorButton = ({
   disabled?: boolean
   height?: string
   error?: boolean
+  endIcon?: ReactNode
 }) => {
   return (
     <Button
       variant="outlined"
       startIcon={startIcon ? startIcon : null}
+      endIcon={endIcon ? endIcon : null}
       sx={(theme) => ({
         textTransform: 'none',
         border:
@@ -381,6 +387,7 @@ const SelectorButton = ({
               : `1px solid ${theme.color.borders.border}`,
         bgcolor: enableBackground ? theme.color.gray[150] : '',
         '&:hover': {
+          bgcolor: theme.color.base.white,
           border:
             enableBackground || outlined
               ? 'none'

--- a/src/components/inputs/Selector.tsx
+++ b/src/components/inputs/Selector.tsx
@@ -212,7 +212,15 @@ export default function Selector({
             ) : (
               <Box key={params.key} component="li">
                 <Stack direction="row" alignItems="center" columnGap={2}>
-                  <Typography variant={'sm'} sx={{ color: (theme) => theme.color.gray[500], marginLeft: '10px' }} p={1}>
+                  <Typography
+                    variant={'sm'}
+                    sx={{
+                      color: (theme) => theme.color.gray[500],
+                      marginLeft: '18px',
+                      padding: '2px 0px',
+                      lineHeight: '24px',
+                    }}
+                  >
                     {params.group}
                   </Typography>
                 </Stack>

--- a/src/components/layouts/FilterBar.tsx
+++ b/src/components/layouts/FilterBar.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Box, CircularProgress, Stack } from '@mui/material'
+import { Box, CircularProgress, IconButton, Stack } from '@mui/material'
 import { AppMargin, SizeofAppMargin } from '@/hoc/AppMargin'
 import { useState } from 'react'
 import store from '@/redux/store'
@@ -11,7 +11,7 @@ import { useHandleSelectorComponent } from '@/hooks/useHandleSelectorComponent'
 import { selectTaskBoard } from '@/redux/features/taskBoardSlice'
 import { useSelector } from 'react-redux'
 import { FilterByOptions, FilterOptions, FilterOptionsKeywords, IAssigneeCombined } from '@/types/interfaces'
-import { FilterByAsigneeIcon } from '@/icons'
+import { CrossIcon, FilterByAsigneeIcon } from '@/icons'
 import { ViewModeSelector } from '../inputs/ViewModeSelector'
 import { FilterByAssigneeBtn } from '../buttons/FilterByAssigneeBtn'
 import FilterButtonGroup from '@/components/buttonsGroup/FilterButtonsGroup'
@@ -24,6 +24,7 @@ import { CreateViewSettingsDTO } from '@/types/dto/viewSettings.dto'
 import { z } from 'zod'
 import { setDebouncedFilteredAssignees } from '@/utils/users'
 import { MiniLoader } from '@/components/atoms/MiniLoader'
+import { getAssigneeName } from '@/utils/getAssigneeName'
 
 export const FilterBar = ({
   updateViewModeSetting,
@@ -149,6 +150,31 @@ export const FilterBar = ({
                     handleFilterOptionsChange(FilterOptions.ASSIGNEE, newValue?.id as string)
                   }}
                   startIcon={<FilterByAsigneeIcon />}
+                  endIcon={
+                    getAssigneeName(assigneeValue) && (
+                      <IconButton
+                        aria-label="remove"
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          updateAssigneeValue(null)
+                          handleFilterOptionsChange(FilterOptions.ASSIGNEE, '')
+                        }}
+                        sx={{
+                          cursor: 'default',
+                          borderRadius: 0,
+                          padding: '6px 10px 6px 6px',
+
+                          '&:hover': {
+                            bgcolor: (theme) => theme.color.gray[100],
+                          },
+                        }}
+                        disableRipple
+                        disableTouchRipple
+                      >
+                        <CrossIcon />
+                      </IconButton>
+                    )
+                  }
                   options={loading ? [] : filteredAssignee}
                   placeholder="Assignee"
                   value={assigneeValue}
@@ -172,14 +198,8 @@ export const FilterBar = ({
                       )
                     )
                   }}
-                  buttonContent={
-                    <FilterByAssigneeBtn
-                      assigneeValue={assigneeValue}
-                      updateAssigneeValue={updateAssigneeValue}
-                      handleClick={handleFilterOptionsChange}
-                    />
-                  }
-                  padding="2px 10px"
+                  buttonContent={<FilterByAssigneeBtn assigneeValue={assigneeValue} />}
+                  padding="2px 5px 2px 10px"
                   handleInputChange={async (newInputValue: string) => {
                     if (!newInputValue) {
                       setFilteredAssignee(filteredAssigneeList)
@@ -235,6 +255,31 @@ export const FilterBar = ({
                     handleFilterOptionsChange(FilterOptions.ASSIGNEE, newValue?.id as string)
                   }}
                   startIcon={<FilterByAsigneeIcon />}
+                  endIcon={
+                    getAssigneeName(assigneeValue) && (
+                      <IconButton
+                        aria-label="remove"
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          updateAssigneeValue(null)
+                          handleFilterOptionsChange(FilterOptions.ASSIGNEE, '')
+                        }}
+                        sx={{
+                          cursor: 'default',
+                          borderRadius: 0,
+                          padding: '6px 10px 6px 6px',
+
+                          '&:hover': {
+                            bgcolor: (theme) => theme.color.gray[100],
+                          },
+                        }}
+                        disableRipple
+                        disableTouchRipple
+                      >
+                        <CrossIcon />
+                      </IconButton>
+                    )
+                  }
                   options={loading ? [] : filteredAssignee}
                   placeholder="Assignee"
                   value={assigneeValue}
@@ -246,26 +291,20 @@ export const FilterBar = ({
                         <>
                           {/* //****Disabling re-assignment completely for now*** */}
                           {/* <ExtraOptionRendererAssignee
-                              props={props}
-                              onClick={(e) => {
-                                updateAssigneeValue({ id: '', name: 'No assignee' })
-                                setAnchorEl(anchorEl ? null : e.currentTarget)
-                                handleFilterOptionsChange(FilterOptions.ASSIGNEE, 'No assignee')
-                              }}
-                            /> */}
+                             props={props}
+                             onClick={(e) => {
+                               updateAssigneeValue({ id: '', name: 'No assignee' })
+                               setAnchorEl(anchorEl ? null : e.currentTarget)
+                               handleFilterOptionsChange(FilterOptions.ASSIGNEE, 'No assignee')
+                             }}
+                           /> */}
                           {loading && <MiniLoader />}
                         </>
                       )
                     )
                   }}
-                  buttonContent={
-                    <FilterByAssigneeBtn
-                      assigneeValue={assigneeValue}
-                      updateAssigneeValue={updateAssigneeValue}
-                      handleClick={handleFilterOptionsChange}
-                    />
-                  }
-                  padding="2px 10px"
+                  buttonContent={<FilterByAssigneeBtn assigneeValue={assigneeValue} />}
+                  padding="2px 5px 2px 10px"
                   handleInputChange={async (newInputValue: string) => {
                     if (!newInputValue) {
                       setFilteredAssignee(filteredAssigneeList)

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -187,8 +187,8 @@ export const theme = createTheme({
     MuiAutocomplete: {
       styleOverrides: {
         option: {
-          height: '32px !important',
-          minHeight: '32px !important', //minHeight required here because in selector component, props className MuiAutocomplete-options overrides by applying minWidth : 48px in smaller screens
+          height: '32px',
+          minHeight: '32px', //minHeight required here because in selector component, props className MuiAutocomplete-options overrides by applying minWidth : 48px in smaller screens
         },
       },
     },

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -187,8 +187,8 @@ export const theme = createTheme({
     MuiAutocomplete: {
       styleOverrides: {
         option: {
-          height: '32px',
-          minHeight: '32px', //minHeight required here because in selector component, props className MuiAutocomplete-options overrides by applying minWidth : 48px in smaller screens
+          height: '32px !important',
+          minHeight: '32px !important', //minHeight required here because in selector component, props className MuiAutocomplete-options overrides by applying minWidth : 48px in smaller screens
         },
       },
     },

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -187,11 +187,8 @@ export const theme = createTheme({
     MuiAutocomplete: {
       styleOverrides: {
         option: {
-          '&[aria-selected="true"]': {
-            backgroundColor: '#e3abed',
-          },
           height: '32px !important',
-          minHeight: '32px !important',
+          minHeight: '32px !important', //minHeight required here because in selector component, props className MuiAutocomplete-options overrides by applying minWidth : 48px in smaller screens
         },
       },
     },

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -183,14 +183,4 @@ export const theme = createTheme({
       lineHeight: '18px',
     },
   },
-  components: {
-    MuiAutocomplete: {
-      styleOverrides: {
-        option: {
-          height: '32px !important',
-          minHeight: '32px !important', //minHeight required here because in selector component, props className MuiAutocomplete-options overrides by applying minWidth : 48px in smaller screens
-        },
-      },
-    },
-  },
 })

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -183,4 +183,17 @@ export const theme = createTheme({
       lineHeight: '18px',
     },
   },
+  components: {
+    MuiAutocomplete: {
+      styleOverrides: {
+        option: {
+          '&[aria-selected="true"]': {
+            backgroundColor: '#e3abed',
+          },
+          height: '32px !important',
+          minHeight: '32px !important',
+        },
+      },
+    },
+  },
 })


### PR DESCRIPTION
### Tasks

- [Reduce spacing between assignees in drop-down on mobile experience](https://linear.app/copilotplatforms/issue/OUT-692/reduce-spacing-between-assignees-in-drop-down-on-mobile-experience)
- [First assignee is always shown as selected in Assignee drop-down](https://linear.app/copilotplatforms/issue/OUT-693/first-assignee-is-always-shown-as-selected-in-assignee-drop-down)
- [Search text does not reset to default state when switching between tabs](https://linear.app/copilotplatforms/issue/OUT-694/search-text-does-not-reset-to-default-state-when-switching-between)

### Changes

- [x] overwritten mui's css to apply own custom css and removed autohighlight prop from autocomplete
- [x] added global mui theme for autocompletes throughtout the application to align with figma design
- [x] added clear value function in onBlur prop of the selector's autocomplete's textfield component  

### Testing Criteria

- [LOOM](https://www.loom.com/share/02a6db3045684b8d84d12715b16e7905)

