### PR TITLE
OUT-703 Able to create task by entering only blank spaces in Task name

### DIFF
--- a/src/app/detail/ui/TaskEditor.tsx
+++ b/src/app/detail/ui/TaskEditor.tsx
@@ -96,6 +96,9 @@ export const TaskEditor = ({
 
   const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newTitle = e.target.value
+    if (newTitle.trim() == '') {
+      return
+    }
     setUpdateTitle(newTitle)
     setIsUserTyping(true)
     titleUpdateDebounced(newTitle)

--- a/src/app/ui/NewTaskForm.tsx
+++ b/src/app/ui/NewTaskForm.tsx
@@ -398,10 +398,14 @@ const NewTaskFooter = ({
             />
             <PrimaryBtn
               handleClick={() => {
-                !title && store.dispatch(setErrors({ key: CreateTaskErrors.TITLE, value: true }))
-                !assigneeId && store.dispatch(setErrors({ key: CreateTaskErrors.ASSIGNEE, value: true }))
-
-                handleCreate()
+                const hasTitleError = !title.trim()
+                const hasAssigneeError = !assigneeId
+                if (hasTitleError || hasAssigneeError) {
+                  hasTitleError && store.dispatch(setErrors({ key: CreateTaskErrors.TITLE, value: true }))
+                  hasAssigneeError && store.dispatch(setErrors({ key: CreateTaskErrors.ASSIGNEE, value: true }))
+                } else {
+                  handleCreate()
+                }
               }}
               buttonText="Create"
             />


### PR DESCRIPTION
### Tasks

- [Able to create task by entering only blank spaces in Task name](https://linear.app/copilotplatforms/issue/OUT-703/able-to-create-task-by-entering-only-blank-spaces-in-task-name)

### Changes

- [x] added a validation for whitespaces using trim() method

### Testing Criteria

- [LOOM](https://www.loom.com/share/be1c0ac3b7a449a4b925fcfee5b8734d)
