### PR TITLE
OUT-696 | In-product notification content needs to be updated

### DIFF
--- a/src/app/api/core/types/tasks.ts
+++ b/src/app/api/core/types/tasks.ts
@@ -3,7 +3,9 @@ export enum NotificationTaskActions {
   AssignedToCompany = 'assignedToCompany',
   ReassignedToIU = 'reassignedToIu',
   CompletedByCompanyMember = 'completedByCompanyMember',
+  CompletedForCompanyByIU = 'completedForCompanyByIu',
   Completed = 'completed',
+  CompletedByIU = 'completedByIu',
   Commented = 'commented',
   Mentioned = 'mentioned',
 }

--- a/src/app/api/notification/notification.helpers.ts
+++ b/src/app/api/notification/notification.helpers.ts
@@ -32,7 +32,7 @@ export const getInProductNotificationDetails = (
     },
     [NotificationTaskActions.CompletedByCompanyMember]: {
       title: 'Task was completed',
-      body: `The task ‘${task?.title}’ was completed by ${actionUser} for ${companyName}. You are receiving this notification because you have access to the client.`,
+      body: `The task ‘${task?.title}’ was completed by ${actionUser} for ${companyName}.`,
       ctaParams,
     },
     [NotificationTaskActions.Completed]: {

--- a/src/app/api/notification/notification.helpers.ts
+++ b/src/app/api/notification/notification.helpers.ts
@@ -32,7 +32,7 @@ export const getInProductNotificationDetails = (
     },
     [NotificationTaskActions.CompletedByCompanyMember]: {
       title: 'Task was completed',
-      body: `The task ‘${task?.title}’ was completed by ${actionUser} for ${companyName}.`,
+      body: `The task ‘${task?.title}’ was completed by ${actionUser} for ${companyName}. You are receiving this notification because you have access to the client.`,
       ctaParams,
     },
     [NotificationTaskActions.Completed]: {

--- a/src/app/api/notification/notification.helpers.ts
+++ b/src/app/api/notification/notification.helpers.ts
@@ -35,9 +35,19 @@ export const getInProductNotificationDetails = (
       body: `The task ‘${task?.title}’ was completed by ${actionUser} for ${companyName}. You are receiving this notification because you have access to the client.`,
       ctaParams,
     },
+    [NotificationTaskActions.CompletedForCompanyByIU]: {
+      title: 'Task was completed',
+      body: `The task ‘${task?.title}’ was completed by ${actionUser} for ${companyName}.`,
+      ctaParams,
+    },
     [NotificationTaskActions.Completed]: {
       title: 'Task was completed',
       body: `The task ‘${task?.title}’ was completed by ${actionUser}. You are receiving this notification because you have access to the client.`,
+      ctaParams,
+    },
+    [NotificationTaskActions.CompletedByIU]: {
+      title: 'Task was completed',
+      body: `The task ‘${task?.title}’ was completed by ${actionUser}.`,
       ctaParams,
     },
     [NotificationTaskActions.Commented]: {

--- a/src/app/api/notification/notification.service.ts
+++ b/src/app/api/notification/notification.service.ts
@@ -191,7 +191,8 @@ export class NotificationService extends BaseService {
         actionTrigger = await getAssignedTo()
         break
       case NotificationTaskActions.CompletedForCompanyByIU:
-        companyName = (await copilot.getCompany(z.string().parse(task.assigneeId))).name
+        const company = await copilot.getCompany(z.string().parse(task.assigneeId))
+        companyName = company.name
       case NotificationTaskActions.CompletedByIU:
         senderId = z.string().parse(this.user.internalUserId)
         recipientId = task.createdById

--- a/src/app/api/notification/notification.service.ts
+++ b/src/app/api/notification/notification.service.ts
@@ -13,9 +13,9 @@ export class NotificationService extends BaseService {
     try {
       const copilot = new CopilotAPI(this.user.token)
 
-      const { senderId, recipientId, actionUser } = await this.getNotificationParties(copilot, task, action)
+      const { senderId, recipientId, actionUser, companyName } = await this.getNotificationParties(copilot, task, action)
 
-      const inProduct = getInProductNotificationDetails(actionUser, task)[action]
+      const inProduct = getInProductNotificationDetails(actionUser, task, companyName)[action]
       const email = disable.email ? undefined : getEmailDetails(actionUser, task)[action]
       const notificationDetails = {
         senderId,
@@ -149,6 +149,7 @@ export class NotificationService extends BaseService {
     let recipientId: string = ''
     let recipientIds: string[] = []
     let actionTrigger: CopilotUser | CompanyResponse
+    let companyName: string | undefined
 
     const getAssignedTo = async (): Promise<CopilotUser | CompanyResponse> => {
       switch (task.assigneeType) {
@@ -189,6 +190,13 @@ export class NotificationService extends BaseService {
         recipientId = task.createdById
         actionTrigger = await getAssignedTo()
         break
+      case NotificationTaskActions.CompletedForCompanyByIU:
+        companyName = (await copilot.getCompany(z.string().parse(task.assigneeId))).name
+      case NotificationTaskActions.CompletedByIU:
+        senderId = z.string().parse(this.user.internalUserId)
+        recipientId = task.createdById
+        actionTrigger = await copilot.getInternalUser(senderId)
+        break
       default:
         const userInfo = await copilot.me()
         senderId = z.string().parse(userInfo?.id)
@@ -197,11 +205,11 @@ export class NotificationService extends BaseService {
         break
     }
 
-    const actionUser =
-      task.assigneeType === AssigneeType.company
+    let actionUser =
+      task.assigneeType === AssigneeType.company && action !== NotificationTaskActions.CompletedForCompanyByIU
         ? (actionTrigger as CompanyResponse).name
         : `${(actionTrigger as CopilotUser).givenName} ${(actionTrigger as CopilotUser).familyName}`
 
-    return { senderId, recipientId, recipientIds, actionUser }
+    return { senderId, recipientId, recipientIds, actionUser, companyName }
   }
 }

--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -438,8 +438,8 @@ export class TasksService extends BaseService {
       if (updatedTask.createdById !== updatedTask.assigneeId) {
         const action =
           updatedTask.assigneeType === AssigneeType.company
-            ? NotificationTaskActions.CompletedByCompanyMember
-            : NotificationTaskActions.Completed
+            ? NotificationTaskActions.CompletedForCompanyByIU
+            : NotificationTaskActions.CompletedByIU
         await notificationService.create(action, updatedTask, { email: true })
       }
 


### PR DESCRIPTION
### Tasks

- [OUT-696 | In-product notification content needs to be updated](https://linear.app/copilotplatforms/issue/OUT-696/in-product-notification-content-needs-to-be-updated)

### Changes

- [x] Modify notification helpers to include new fixed copy when IU completes a task

### Testing Criteria

- [x] For individual client, whose task was completed by IU instead
![image](https://github.com/user-attachments/assets/b7414eea-6c5b-4068-990d-1dff5019b833)
- [x] Same, for company
![image](https://github.com/user-attachments/assets/cf9b3e72-90db-4bb5-8dc1-697e119b9fb3)
