### PR TITLE
OUT-727 Loader is not centered on Mobile View

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,16 +1,11 @@
 'use client'
 
-import { PrimaryBtn } from '@/components/buttons/PrimaryBtn'
-import { Box, Stack } from '@mui/material'
-import { useRouter } from 'next/navigation'
 import React from 'react'
 
-const ClientErrorBoundary = ({ error, reset }: { error: Error & { digest: string }; reset: () => void }) => {
-  const router = useRouter()
-
+const ClientErrorBoundary = ({ error }: { error: Error & { digest: string } }) => {
   return (
-    <Box
-      sx={{
+    <div
+      style={{
         display: 'flex',
         height: '100vh',
         marginTop: '20vh',
@@ -19,19 +14,8 @@ const ClientErrorBoundary = ({ error, reset }: { error: Error & { digest: string
         fontFamily: 'monospace',
       }}
     >
-      <Stack direction="column" rowGap={3}>
-        {error.message}
-        <Box
-          sx={{
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-          }}
-        >
-          <PrimaryBtn buttonText="Try again" handleClick={() => reset()} />
-        </Box>
-      </Stack>
-    </Box>
+      {error.message}
+    </div>
   )
 }
 

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,11 +1,16 @@
 'use client'
 
+import { PrimaryBtn } from '@/components/buttons/PrimaryBtn'
+import { Box, Stack } from '@mui/material'
+import { useRouter } from 'next/navigation'
 import React from 'react'
 
-const ClientErrorBoundary = ({ error }: { error: Error & { digest: string } }) => {
+const ClientErrorBoundary = ({ error, reset }: { error: Error & { digest: string }; reset: () => void }) => {
+  const router = useRouter()
+
   return (
-    <div
-      style={{
+    <Box
+      sx={{
         display: 'flex',
         height: '100vh',
         marginTop: '20vh',
@@ -14,8 +19,19 @@ const ClientErrorBoundary = ({ error }: { error: Error & { digest: string } }) =
         fontFamily: 'monospace',
       }}
     >
-      {error.message}
-    </div>
+      <Stack direction="column" rowGap={3}>
+        {error.message}
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <PrimaryBtn buttonText="Try again" handleClick={() => reset()} />
+        </Box>
+      </Stack>
+    </Box>
   )
 }
 

--- a/src/components/layouts/Loader.tsx
+++ b/src/components/layouts/Loader.tsx
@@ -2,15 +2,21 @@ import { Box, CircularProgress } from '@mui/material'
 
 const LoaderComponent = () => {
   return (
-    <CircularProgress
+    <Box
       sx={{
         position: 'absolute',
-        top: '45%',
-        left: '50%',
-        color: '#000',
+        top: 0,
+        left: 0,
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        bgcolor: 'transparent',
       }}
-      size={40}
-    />
+    >
+      <CircularProgress color="inherit" size={40} />
+    </Box>
   )
 }
 


### PR DESCRIPTION
### Tasks

- [wrapped a circular progress bar in a Box with styles to center the progress bar](https://linear.app/copilotplatforms/issue/OUT-727/loader-is-not-centered-on-mobile-view)

### Changes

- [x] wrapped a circular progress bar in a Box with styles to center the progress bar

### Testing Criteria

- [LOOM](https://www.loom.com/share/8f5ea143a2b24e8faae6d08d307ec14f)

