### PR TITLE
OUT-677 | In-product notification & Task do not disappear from client end when company is deleted/unassigned

### DIFF
--- a/prisma/migrations/20240815014449_remove_uq_for_label_deleted_at_for_tasks/migration.sql
+++ b/prisma/migrations/20240815014449_remove_uq_for_label_deleted_at_for_tasks/migration.sql
@@ -1,0 +1,2 @@
+-- DropIndex
+DROP INDEX "Tasks_label_deletedAt_key";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -66,7 +66,6 @@ model Task {
   deletedAt          DateTime?
   ClientNotification ClientNotification[]
 
-  @@unique([label, deletedAt], name: "UQ_Tablename_label_deletedAt")
   @@map("Tasks")
 }
 

--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -275,12 +275,10 @@ export class TasksService extends BaseService {
     }
     const labels = tasks.map((task) => task.label)
 
-    await this.db.$transaction([
-      this.db.task.deleteMany({
-        where: { assigneeId, assigneeType, workspaceId: this.user.workspaceId },
-      }),
-      this.db.label.deleteMany({ where: { label: { in: labels } } }),
-    ])
+    await this.db.task.deleteMany({
+      where: { assigneeId, assigneeType, workspaceId: this.user.workspaceId },
+    })
+    await this.db.label.deleteMany({ where: { label: { in: labels } } })
   }
 
   async clientUpdateTask(id: string, targetWorkflowStateId?: string | null) {

--- a/src/app/api/webhook/webhook.controller.ts
+++ b/src/app/api/webhook/webhook.controller.ts
@@ -1,7 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server'
 import authenticate from '@api/core/utils/authenticate'
 import WebhookService from '@api/webhook/webhook.service'
-import { TasksService } from '../tasks/tasks.service'
+import { TasksService } from '@api/tasks/tasks.service'
+import { NotificationService } from '@api/notification/notification.service'
 
 export const handleWebhookEvent = async (req: NextRequest) => {
   const user = await authenticate(req)
@@ -15,9 +16,14 @@ export const handleWebhookEvent = async (req: NextRequest) => {
   }
   const { assigneeId, assigneeType } = webhookService.parseAssigneeData(webhookEvent, eventType)
 
+  // Delete corresponding tasks
   const tasksService = new TasksService(user)
   console.info(`Deleting all tasks for ${assigneeType} ${assigneeId}`)
   await tasksService.deleteAllAssigneeTasks(assigneeId, assigneeType)
+
+  // Delete corresponding notifications
+  const notificationService = new NotificationService(user)
+  await notificationService.readAllUserNotifications(assigneeId, assigneeType)
 
   return NextResponse.json({ message: 'Webhook request handled successfully' })
 }

--- a/src/cmd/load-testing/deleteClients.ts
+++ b/src/cmd/load-testing/deleteClients.ts
@@ -14,7 +14,6 @@ const run = async () => {
   const apiKey = z.string().parse(process.env.COPILOT_API_KEY)
   const copilot = new CopilotAPI(token, apiKey)
   const clients = await copilot.getClients({ limit: 10_000 })
-  console.log('Clients:', clients.data?.length)
 
   if (!clients.data) {
     throw new Error('No clients to delete')


### PR DESCRIPTION
### Tasks

- [OUT-677 | In-product notification & Task do not disappear from client end when company is deleted/unassigned](https://linear.app/copilotplatforms/issue/OUT-677/in-product-notification-and-task-do-not-disappear-from-client-end-when)

### Changes

- [x] Add core logic in Notification Service to bulk read notifications for a client / company
- [x] Add core logic in Tasks Service to bulk delete all tasks for a particular client / IU / company 
- [x] Implement bulk delete and mass notification read in webhook event for `entity.deleted`
- [x] Remove transacation from tasks.service because it was throwing a cryptic error occasionally 

### Testing Criteria

- [x] [LOOM](https://www.loom.com/share/88d0a2f1fdfd44dc9df420623550c2af?sid=85122500-c63c-40c7-a979-6d21d0819700)