### PR TITLE
OUT-736 | When a new client is created for a company, trigger previous task notifications for it

### DIFF
--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -264,6 +264,13 @@ export class TasksService extends BaseService {
     return await this.db.task.delete({ where: { id } })
   }
 
+  async getUnfilteredTasksForUser(assigneeId: string): Promise<(Task & { workflowState: WorkflowState })[]> {
+    return await this.db.task.findMany({
+      where: { assigneeId },
+      include: { workflowState: true },
+    })
+  }
+
   async deleteAllAssigneeTasks(assigneeId: string, assigneeType: AssigneeType) {
     // Policies validation shouldn't be required here because token is from a webhook event
     const tasks = await this.db.task.findMany({
@@ -413,7 +420,7 @@ export class TasksService extends BaseService {
     }
   }
 
-  private async sendTaskCreateNotifications(task: Task & { workflowState: WorkflowState }, isReassigned = false) {
+  async sendTaskCreateNotifications(task: Task & { workflowState: WorkflowState }, isReassigned = false) {
     // If task is unassigned, there's nobody to send notifications to
     if (!task.assigneeId) return
 

--- a/src/app/api/webhook/route.ts
+++ b/src/app/api/webhook/route.ts
@@ -1,4 +1,6 @@
 import { withErrorHandler } from '@api/core/utils/withErrorHandler'
 import { handleWebhookEvent } from '@api/webhook/webhook.controller'
 
+export const maxDuration = 300
+
 export const POST = withErrorHandler(handleWebhookEvent)

--- a/src/app/api/webhook/webhook.controller.ts
+++ b/src/app/api/webhook/webhook.controller.ts
@@ -3,6 +3,13 @@ import authenticate from '@api/core/utils/authenticate'
 import WebhookService from '@api/webhook/webhook.service'
 import { TasksService } from '@api/tasks/tasks.service'
 import { NotificationService } from '@api/notification/notification.service'
+import { HANDLEABLE_EVENT } from '@/types/webhook'
+import Bottleneck from 'bottleneck'
+import { CopilotAPI } from '@/utils/CopilotAPI'
+import { getInProductNotificationDetails } from '../notification/notification.helpers'
+import { NotificationTaskActions } from '../core/types/tasks'
+import APIError from '../core/exceptions/api'
+import httpStatus from 'http-status'
 
 export const handleWebhookEvent = async (req: NextRequest) => {
   const user = await authenticate(req)
@@ -16,8 +23,54 @@ export const handleWebhookEvent = async (req: NextRequest) => {
   }
   const { assigneeId, assigneeType } = webhookService.parseAssigneeData(webhookEvent, eventType)
 
-  // Delete corresponding tasks
   const tasksService = new TasksService(user)
+
+  if (eventType === HANDLEABLE_EVENT.ClientCreated) {
+    // First fetch all the current non-complete tasks for client's company, if exists
+    const copilot = new CopilotAPI(user.token)
+    const client = await copilot.getClient(assigneeId)
+    const company = await copilot.getCompany(client.companyId)
+    if (company.name === '') {
+      // Client does not have a fixed company!
+      return NextResponse.json({})
+    }
+
+    const tasks = await tasksService.getUnfilteredTasksForUser(company.id)
+    // Then trigger appropriate notifications
+    const bottleneck = new Bottleneck({ minTime: 250, maxConcurrent: 2 })
+    const createNotificationPromises = []
+
+    const internalUsers = (await copilot.getInternalUsers()).data
+
+    for (let task of tasks) {
+      const actionUser = internalUsers.find((iu) => iu.id === task.createdById)
+      if (!actionUser) {
+        throw new APIError(
+          httpStatus.INTERNAL_SERVER_ERROR,
+          `webhookController :: could not get action user for company task ${task.id}`,
+        )
+      }
+
+      const actionUserName = `${actionUser.givenName} ${actionUser.familyName}`
+      const inProduct = getInProductNotificationDetails(actionUserName, task, company.name)[
+        NotificationTaskActions.AssignedToCompany
+      ]
+      const notificationDetails = {
+        senderId: task.createdById,
+        recipientId: assigneeId,
+        // If any of the given action is not present in details obj, that type of notification is not sent
+        deliveryTargets: { inProduct },
+      }
+      console.log('inProduct', inProduct)
+      console.log('recip', assigneeId)
+      createNotificationPromises.push(bottleneck.schedule(() => copilot.createNotification(notificationDetails)))
+    }
+
+    await Promise.all(createNotificationPromises)
+    return NextResponse.json({ message: 'client.created webhook handled successfully' })
+  }
+
+  // Delete corresponding tasks
   console.info(`Deleting all tasks for ${assigneeType} ${assigneeId}`)
   await tasksService.deleteAllAssigneeTasks(assigneeId, assigneeType)
 

--- a/src/app/api/webhook/webhook.service.ts
+++ b/src/app/api/webhook/webhook.service.ts
@@ -18,6 +18,7 @@ class WebhookService extends BaseService {
     const eventType = webhookEvent.eventType as HANDLEABLE_EVENT
     const isValidWebhook = [
       HANDLEABLE_EVENT.InternalUserDeleted,
+      HANDLEABLE_EVENT.ClientCreated,
       HANDLEABLE_EVENT.ClientDeleted,
       HANDLEABLE_EVENT.CompanyDeleted,
     ].includes(eventType)
@@ -29,6 +30,7 @@ class WebhookService extends BaseService {
     const assigneeId = deletedEntity.id
     const assigneeType = {
       [HANDLEABLE_EVENT.InternalUserDeleted]: AssigneeType.internalUser,
+      [HANDLEABLE_EVENT.ClientCreated]: AssigneeType.client,
       [HANDLEABLE_EVENT.ClientDeleted]: AssigneeType.client,
       [HANDLEABLE_EVENT.CompanyDeleted]: AssigneeType.company,
     }[eventType]

--- a/src/types/webhook.ts
+++ b/src/types/webhook.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 
 export enum HANDLEABLE_EVENT {
   InternalUserDeleted = 'internalUser.deleted',
+  ClientCreated = 'client.created',
   ClientDeleted = 'client.deleted',
   CompanyDeleted = 'company.deleted',
 }


### PR DESCRIPTION
### Tasks

- [OUT-736 | When a new client is created for a company, trigger previous task notifications for it](https://linear.app/copilotplatforms/issue/OUT-736/when-a-new-client-is-created-for-a-company-trigger-previous-task)

### Changes

- [x] Add notification trigger logic for `client.created`

### Testing Criteria

- [x] Added required number of comment notifications to client dashboard. New client's company had 12 distinct tasks here.
![image](https://github.com/user-attachments/assets/0f5fa2dc-fb09-48eb-a13f-11878cd8981b)
