### PR TITLE
OUT-742 | Handle notification side-effects when Client's company is updated

### DIFF
--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -264,9 +264,10 @@ export class TasksService extends BaseService {
     return await this.db.task.delete({ where: { id } })
   }
 
-  async getUnfilteredTasksForUser(assigneeId: string): Promise<(Task & { workflowState: WorkflowState })[]> {
+  async getIncompleteTasksForCompany(assigneeId: string): Promise<(Task & { workflowState: WorkflowState })[]> {
+    // This works across workspaces
     return await this.db.task.findMany({
-      where: { assigneeId },
+      where: { assigneeId, assigneeType: AssigneeType.company, workflowState: { type: { not: StateType.completed } } },
       include: { workflowState: true },
     })
   }

--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -264,6 +264,13 @@ export class TasksService extends BaseService {
     return await this.db.task.delete({ where: { id } })
   }
 
+  async getUnfilteredTasksForUser(assigneeId: string): Promise<(Task & { workflowState: WorkflowState })[]> {
+    return await this.db.task.findMany({
+      where: { assigneeId },
+      include: { workflowState: true },
+    })
+  }
+
   async deleteAllAssigneeTasks(assigneeId: string, assigneeType: AssigneeType) {
     // Policies validation shouldn't be required here because token is from a webhook event
     const tasks = await this.db.task.findMany({
@@ -413,7 +420,7 @@ export class TasksService extends BaseService {
     }
   }
 
-  private async sendTaskCreateNotifications(task: Task & { workflowState: WorkflowState }, isReassigned = false) {
+  async sendTaskCreateNotifications(task: Task & { workflowState: WorkflowState }, isReassigned = false) {
     // If task is unassigned, there's nobody to send notifications to
     if (!task.assigneeId) return
 

--- a/src/app/api/webhook/route.ts
+++ b/src/app/api/webhook/route.ts
@@ -1,4 +1,6 @@
 import { withErrorHandler } from '@api/core/utils/withErrorHandler'
 import { handleWebhookEvent } from '@api/webhook/webhook.controller'
 
+export const maxDuration = 300
+
 export const POST = withErrorHandler(handleWebhookEvent)

--- a/src/app/api/webhook/webhook.controller.ts
+++ b/src/app/api/webhook/webhook.controller.ts
@@ -3,6 +3,13 @@ import authenticate from '@api/core/utils/authenticate'
 import WebhookService from '@api/webhook/webhook.service'
 import { TasksService } from '@api/tasks/tasks.service'
 import { NotificationService } from '@api/notification/notification.service'
+import { HANDLEABLE_EVENT } from '@/types/webhook'
+import Bottleneck from 'bottleneck'
+import { CopilotAPI } from '@/utils/CopilotAPI'
+import { getInProductNotificationDetails } from '../notification/notification.helpers'
+import { NotificationTaskActions } from '../core/types/tasks'
+import APIError from '../core/exceptions/api'
+import httpStatus from 'http-status'
 
 export const handleWebhookEvent = async (req: NextRequest) => {
   const user = await authenticate(req)
@@ -16,8 +23,54 @@ export const handleWebhookEvent = async (req: NextRequest) => {
   }
   const { assigneeId, assigneeType } = webhookService.parseAssigneeData(webhookEvent, eventType)
 
-  // Delete corresponding tasks
   const tasksService = new TasksService(user)
+
+  if (eventType === HANDLEABLE_EVENT.ClientCreated) {
+    // First fetch all the current non-complete tasks for client's company, if exists
+    const copilot = new CopilotAPI(user.token)
+    const client = await copilot.getClient(assigneeId)
+    const company = await copilot.getCompany(client.companyId)
+    if (company.name === '') {
+      // Client does not have a fixed company!
+      return NextResponse.json({})
+    }
+
+    const tasks = await tasksService.getUnfilteredTasksForUser(company.id)
+    // Then trigger appropriate notifications
+    const bottleneck = new Bottleneck({ minTime: 250, maxConcurrent: 2 })
+    const createNotificationPromises = []
+
+    const internalUsers = (await copilot.getInternalUsers()).data
+
+    for (let task of tasks) {
+      const actionUser = internalUsers.find((iu) => iu.id === task.createdById)
+      if (!actionUser) {
+        throw new APIError(
+          httpStatus.INTERNAL_SERVER_ERROR,
+          `webhookController :: could not get action user for company task ${task.id}`,
+        )
+      }
+
+      const actionUserName = `${actionUser.givenName} ${actionUser.familyName}`
+      const inProduct = getInProductNotificationDetails(actionUserName, task, company.name)[
+        NotificationTaskActions.AssignedToCompany
+      ]
+      const notificationDetails = {
+        senderId: task.createdById,
+        recipientId: assigneeId,
+        // If any of the given action is not present in details obj, that type of notification is not sent
+        deliveryTargets: { inProduct },
+      }
+      console.log('inProduct', inProduct)
+      console.log('recip', assigneeId)
+      createNotificationPromises.push(bottleneck.schedule(() => copilot.createNotification(notificationDetails)))
+    }
+
+    await Promise.all(createNotificationPromises)
+    return NextResponse.json({ message: 'client.created webhook handled successfully' })
+  }
+
+  // Delete corresponding tasks
   console.info(`Deleting all tasks for ${assigneeType} ${assigneeId}`)
   await tasksService.deleteAllAssigneeTasks(assigneeId, assigneeType)
 

--- a/src/app/api/webhook/webhook.controller.ts
+++ b/src/app/api/webhook/webhook.controller.ts
@@ -1,15 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import authenticate from '@api/core/utils/authenticate'
 import WebhookService from '@api/webhook/webhook.service'
-import { TasksService } from '@api/tasks/tasks.service'
-import { NotificationService } from '@api/notification/notification.service'
-import { HANDLEABLE_EVENT } from '@/types/webhook'
-import Bottleneck from 'bottleneck'
-import { CopilotAPI } from '@/utils/CopilotAPI'
-import { getInProductNotificationDetails } from '../notification/notification.helpers'
-import { NotificationTaskActions } from '../core/types/tasks'
-import APIError from '../core/exceptions/api'
-import httpStatus from 'http-status'
+import { ClientUpdatedEventDataSchema, HANDLEABLE_EVENT } from '@/types/webhook'
 
 export const handleWebhookEvent = async (req: NextRequest) => {
   const user = await authenticate(req)
@@ -23,60 +15,16 @@ export const handleWebhookEvent = async (req: NextRequest) => {
   }
   const { assigneeId, assigneeType } = webhookService.parseAssigneeData(webhookEvent, eventType)
 
-  const tasksService = new TasksService(user)
-
-  if (eventType === HANDLEABLE_EVENT.ClientCreated) {
-    // First fetch all the current non-complete tasks for client's company, if exists
-    const copilot = new CopilotAPI(user.token)
-    const client = await copilot.getClient(assigneeId)
-    const company = await copilot.getCompany(client.companyId)
-    if (company.name === '') {
-      // Client does not have a fixed company!
-      return NextResponse.json({})
-    }
-
-    const tasks = await tasksService.getUnfilteredTasksForUser(company.id)
-    // Then trigger appropriate notifications
-    const bottleneck = new Bottleneck({ minTime: 250, maxConcurrent: 2 })
-    const createNotificationPromises = []
-
-    const internalUsers = (await copilot.getInternalUsers()).data
-
-    for (let task of tasks) {
-      const actionUser = internalUsers.find((iu) => iu.id === task.createdById)
-      if (!actionUser) {
-        throw new APIError(
-          httpStatus.INTERNAL_SERVER_ERROR,
-          `webhookController :: could not get action user for company task ${task.id}`,
-        )
-      }
-
-      const actionUserName = `${actionUser.givenName} ${actionUser.familyName}`
-      const inProduct = getInProductNotificationDetails(actionUserName, task, company.name)[
-        NotificationTaskActions.AssignedToCompany
-      ]
-      const notificationDetails = {
-        senderId: task.createdById,
-        recipientId: assigneeId,
-        // If any of the given action is not present in details obj, that type of notification is not sent
-        deliveryTargets: { inProduct },
-      }
-      console.log('inProduct', inProduct)
-      console.log('recip', assigneeId)
-      createNotificationPromises.push(bottleneck.schedule(() => copilot.createNotification(notificationDetails)))
-    }
-
-    await Promise.all(createNotificationPromises)
-    return NextResponse.json({ message: 'client.created webhook handled successfully' })
+  switch (eventType) {
+    case HANDLEABLE_EVENT.ClientCreated:
+      await webhookService.handleClientCreated(assigneeId)
+      break
+    case HANDLEABLE_EVENT.ClientUpdated:
+      await webhookService.handleClientUpdated(ClientUpdatedEventDataSchema.parse(webhookEvent.data))
+      break
+    default:
+      await webhookService.handleUserDeleted(assigneeId, assigneeType)
   }
 
-  // Delete corresponding tasks
-  console.info(`Deleting all tasks for ${assigneeType} ${assigneeId}`)
-  await tasksService.deleteAllAssigneeTasks(assigneeId, assigneeType)
-
-  // Delete corresponding notifications
-  const notificationService = new NotificationService(user)
-  await notificationService.readAllUserNotifications(assigneeId, assigneeType)
-
-  return NextResponse.json({ message: 'Webhook request handled successfully' })
+  return NextResponse.json({ message: `${eventType} webhook request handled successfully` })
 }

--- a/src/app/api/webhook/webhook.service.ts
+++ b/src/app/api/webhook/webhook.service.ts
@@ -18,6 +18,7 @@ class WebhookService extends BaseService {
     const eventType = webhookEvent.eventType as HANDLEABLE_EVENT
     const isValidWebhook = [
       HANDLEABLE_EVENT.InternalUserDeleted,
+      HANDLEABLE_EVENT.ClientCreated,
       HANDLEABLE_EVENT.ClientDeleted,
       HANDLEABLE_EVENT.CompanyDeleted,
     ].includes(eventType)
@@ -29,6 +30,7 @@ class WebhookService extends BaseService {
     const assigneeId = deletedEntity.id
     const assigneeType = {
       [HANDLEABLE_EVENT.InternalUserDeleted]: AssigneeType.internalUser,
+      [HANDLEABLE_EVENT.ClientCreated]: AssigneeType.client,
       [HANDLEABLE_EVENT.ClientDeleted]: AssigneeType.client,
       [HANDLEABLE_EVENT.CompanyDeleted]: AssigneeType.company,
     }[eventType]

--- a/src/app/api/webhook/webhook.service.ts
+++ b/src/app/api/webhook/webhook.service.ts
@@ -1,9 +1,15 @@
-import { HANDLEABLE_EVENT, WebhookEntitySchema, WebhookEvent, WebhookSchema } from '@/types/webhook'
+import { ClientUpdatedEventData, HANDLEABLE_EVENT, WebhookEntitySchema, WebhookEvent, WebhookSchema } from '@/types/webhook'
 import { BaseService } from '@api/core/services/base.service'
 import { NextRequest } from 'next/server'
 import APIError from '@api/core/exceptions/api'
 import httpStatus from 'http-status'
-import { AssigneeType } from '@prisma/client'
+import { AssigneeType, StateType } from '@prisma/client'
+import { CopilotAPI } from '@/utils/CopilotAPI'
+import { TasksService } from '@api/tasks/tasks.service'
+import Bottleneck from 'bottleneck'
+import { getInProductNotificationDetails } from '@api/notification/notification.helpers'
+import { NotificationTaskActions } from '@api/core/types/tasks'
+import { NotificationService } from '@api/notification/notification.service'
 
 class WebhookService extends BaseService {
   async parseWebhook(req: NextRequest): Promise<WebhookEvent> {
@@ -19,6 +25,7 @@ class WebhookService extends BaseService {
     const isValidWebhook = [
       HANDLEABLE_EVENT.InternalUserDeleted,
       HANDLEABLE_EVENT.ClientCreated,
+      HANDLEABLE_EVENT.ClientUpdated,
       HANDLEABLE_EVENT.ClientDeleted,
       HANDLEABLE_EVENT.CompanyDeleted,
     ].includes(eventType)
@@ -31,11 +38,132 @@ class WebhookService extends BaseService {
     const assigneeType = {
       [HANDLEABLE_EVENT.InternalUserDeleted]: AssigneeType.internalUser,
       [HANDLEABLE_EVENT.ClientCreated]: AssigneeType.client,
+      [HANDLEABLE_EVENT.ClientUpdated]: AssigneeType.client,
       [HANDLEABLE_EVENT.ClientDeleted]: AssigneeType.client,
       [HANDLEABLE_EVENT.CompanyDeleted]: AssigneeType.company,
     }[eventType]
 
     return { assigneeId, assigneeType }
+  }
+
+  async handleClientCreated(assigneeId: string) {
+    // First fetch all the current non-complete tasks for client's company, if exists
+    const copilot = new CopilotAPI(this.user.token)
+    const client = await copilot.getClient(assigneeId)
+    const company = await copilot.getCompany(client.companyId)
+    if (company.name === '') {
+      // Client does not have a fixed company!
+      return
+    }
+
+    const tasksService = new TasksService(this.user)
+    const tasks = await tasksService.getIncompleteTasksForCompany(company.id)
+    if (!tasks.length) return
+
+    // Then trigger appropriate notifications
+    const bottleneck = new Bottleneck({ minTime: 250, maxConcurrent: 2 })
+    const createNotificationPromises = []
+
+    const internalUsers = (await copilot.getInternalUsers()).data
+
+    for (let task of tasks) {
+      const actionUser = internalUsers.find((iu) => iu.id === task.createdById)
+      if (!actionUser) {
+        throw new APIError(
+          httpStatus.INTERNAL_SERVER_ERROR,
+          `webhookController :: could not get action user for company task ${task.id}`,
+        )
+      }
+
+      const actionUserName = `${actionUser.givenName} ${actionUser.familyName}`
+      const inProduct = getInProductNotificationDetails(actionUserName, task, company.name)[
+        NotificationTaskActions.AssignedToCompany
+      ]
+      const notificationDetails = {
+        senderId: task.createdById,
+        recipientId: assigneeId,
+        // If any of the given action is not present in details obj, that type of notification is not sent
+        deliveryTargets: { inProduct },
+      }
+      createNotificationPromises.push(bottleneck.schedule(() => copilot.createNotification(notificationDetails)))
+    }
+    const notifications = await Promise.all(createNotificationPromises)
+
+    // Now add appropriate records to our ClientNotifications table
+    const insertBottleneck = new Bottleneck({ minTime: 100, maxConcurrent: 4 })
+    const insertPromises = []
+    const notificationService = new NotificationService(this.user)
+    for (let i = 0; i < notifications.length; i++) {
+      insertPromises.push(
+        // This is assuming a 1:1 map for tasks and notifications
+        insertBottleneck.schedule(() => notificationService.addToClientNotifications(tasks[i], notifications[i])),
+      )
+    }
+    await Promise.all(insertPromises)
+  }
+
+  async handleUserDeleted(assigneeId: string, assigneeType: AssigneeType) {
+    const tasksService = new TasksService(this.user)
+    // Delete corresponding tasks
+    console.info(`Deleting all tasks for ${assigneeType} ${assigneeId}`)
+    await tasksService.deleteAllAssigneeTasks(assigneeId, assigneeType)
+
+    // Delete corresponding notifications
+    const notificationService = new NotificationService(this.user)
+    await notificationService.readAllUserNotifications(assigneeId, assigneeType)
+  }
+
+  async handleClientUpdated(data: ClientUpdatedEventData) {
+    const {
+      id: clientId,
+      companyId: newCompanyId,
+      previousAttributes: { companyId: prevCompanyId },
+    } = data
+    // If company hasn't been changed - don't bother with any of this
+    if (!prevCompanyId) return
+
+    // First find all tasks related to previous company
+    const prevCompanyTasks = await this.db.task.findMany({
+      where: {
+        assigneeId: prevCompanyId,
+        assigneeType: AssigneeType.company,
+        workflowState: {
+          type: { not: StateType.completed },
+        },
+      },
+    })
+    // NOTE: workspaceId filter is not used because:
+    // (i) Webhook request doesn't provide workspaceId
+    // (ii) Company is not shared across workspaces
+    const prevCompanyTaskIds = prevCompanyTasks.map((task) => task.id)
+
+    // Find all triggered notifications for this client, on behalf of prev company
+    const prevCompanyNotifications = await this.db.clientNotification.findMany({
+      where: {
+        taskId: { in: prevCompanyTaskIds },
+        clientId,
+      },
+    })
+    const notificationIds = prevCompanyNotifications.map((notification) => notification.id)
+
+    // Delete all task notifications triggered for client for previous company
+    const deletePromises = []
+    const copilot = new CopilotAPI(this.user.token)
+    const bottleneck = new Bottleneck({ minTime: 250, maxConcurrent: 2 })
+
+    for (let notification of prevCompanyNotifications) {
+      deletePromises.push(
+        bottleneck.schedule(() => {
+          return copilot.markNotificationAsRead(notification.notificationId)
+        }),
+      )
+    }
+    await Promise.all(deletePromises)
+    await this.db.clientNotification.deleteMany({ where: { id: { in: notificationIds } } })
+
+    // Trigger new notifications for new company's tasks (if exists)
+    if (!newCompanyId) return
+    await this.handleClientCreated(clientId)
   }
 }
 

--- a/src/types/webhook.ts
+++ b/src/types/webhook.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 
 export enum HANDLEABLE_EVENT {
   InternalUserDeleted = 'internalUser.deleted',
+  ClientCreated = 'client.created',
   ClientDeleted = 'client.deleted',
   CompanyDeleted = 'company.deleted',
 }

--- a/src/types/webhook.ts
+++ b/src/types/webhook.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 export enum HANDLEABLE_EVENT {
   InternalUserDeleted = 'internalUser.deleted',
   ClientCreated = 'client.created',
+  ClientUpdated = 'client.updated',
   ClientDeleted = 'client.deleted',
   CompanyDeleted = 'company.deleted',
 }
@@ -14,6 +15,15 @@ export const WebhookSchema = z.object({
   data: z.unknown(),
 })
 export type WebhookEvent = z.infer<typeof WebhookSchema>
+
+export const ClientUpdatedEventDataSchema = z.object({
+  id: z.string(),
+  companyId: z.string(),
+  previousAttributes: z.object({
+    companyId: z.string().optional(),
+  }),
+})
+export type ClientUpdatedEventData = z.infer<typeof ClientUpdatedEventDataSchema>
 
 export const WebhookEntitySchema = z.object({
   id: z.string(),


### PR DESCRIPTION
### Tasks

- [OUT-742 | Handle notification side-effects when Client's company is updated](https://linear.app/copilotplatforms/issue/OUT-742/handle-notification-side-effects-when-clients-company-is-updated)

### Changes

- [x] Add support for client.updated webhook
- [x] Check for `previousAttributes` to see if client's company has changed
- [x] Remove old company's notifications, and add new company tasks' notifications  

### Testing Criteria

- [x] [LOOM](https://www.loom.com/share/62ffccb7a3a44a2b8e355e2b82f75f9c?sid=8c0f8704-f9f0-4cd1-8c13-aa2a74091479)

### Notes
- Depends on https://github.com/copilot-platforms/tasks-app/pull/254
- While testing this, you need to change this webhook URL to point to the preview deployment TEMPORARILY. *Add this webhook to app config, and not workspace setting, since this can trigger multiple notifications to clients*
![image](https://github.com/user-attachments/assets/01990bc2-dcc4-40f7-9f4f-6fd235119996)
