### PR TITLE
OUT-753 Dont let users break line for title in Details page (ref : Linear)

### DIFF
--- a/src/app/detail/ui/TaskEditor.tsx
+++ b/src/app/detail/ui/TaskEditor.tsx
@@ -170,6 +170,11 @@ export const TaskEditor = ({
             disabled={!isEditable}
             padding="0px"
             onBlur={handleTitleBlur}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault() //prevent users from breaking line
+              }
+            }}
           />
 
           <Box mt="12px" sx={{ height: '100%' }}>


### PR DESCRIPTION
### Tasks

- [Dont let users break line for title in Details page (ref : Linear)](https://linear.app/copilotplatforms/issue/OUT-753/dont-let-users-break-line-for-title-in-details-page-ref-linear)

### Changes

- [x] prevented users from breaking line using onKeyDown function

### Testing Criteria

- [LOOM](https://www.loom.com/share/648fd74e76b8478db478690dfbe6a7cf)
