### PR TITLE
OUT-754 When selected assignee in Filter by drop-down is deleted, Board/List view shows blank until I click the tab

### DIFF
--- a/src/redux/features/taskBoardSlice.tsx
+++ b/src/redux/features/taskBoardSlice.tsx
@@ -4,7 +4,7 @@ import { WorkflowStateResponse } from '@/types/dto/workflowStates.dto'
 import { TaskResponse } from '@/types/dto/tasks.dto'
 import { AssigneeType, FilterByOptions, FilterOptions, IAssigneeCombined, IFilterOptions, View } from '@/types/interfaces'
 import { ViewMode } from '@prisma/client'
-import { CreateViewSettingsDTO } from '@/types/dto/viewSettings.dto'
+import { CreateViewSettingsDTO, FilterOptionsType } from '@/types/dto/viewSettings.dto'
 import { sortTaskByDescendingOrder } from '@/utils/sortTask'
 
 interface IInitialState {
@@ -70,14 +70,9 @@ const taskBoardSlice = createSlice({
       state.filteredAssigneeList = action.payload
     },
     setViewSettings: (state, action: { payload: CreateViewSettingsDTO }) => {
-      state.view = action.payload.viewMode
-      if (action.payload.filterOptions.assignee) {
-        const assigneeCheck = state.assignee.find((assignee) => assignee.id == action.payload.filterOptions.assignee)
-        if (!assigneeCheck) {
-          action.payload.filterOptions.assignee = ''
-        }
-      }
-      state.filterOptions = action.payload.filterOptions
+      const { viewMode, filterOptions } = action.payload
+      state.view = viewMode
+      taskBoardSlice.caseReducers.updateFilterOption(state, { payload: { filterOptions } })
     },
     setFilterOptions: (state, action: { payload: { optionType: FilterOptions; newValue: string | null } }) => {
       state.filterOptions = {
@@ -99,6 +94,16 @@ const taskBoardSlice = createSlice({
         state.filteredAssigneeList = state.assignee
       }
     },
+    updateFilterOption: (state, action: { payload: { filterOptions: FilterOptionsType } }) => {
+      const { filterOptions } = action.payload
+      if (filterOptions.assignee) {
+        const assigneeCheck = state.assignee.find((assignee) => assignee.id == filterOptions.assignee)
+        if (!assigneeCheck) {
+          filterOptions.assignee = ''
+        }
+      }
+      state.filterOptions = action.payload.filterOptions
+    }, //updates filters according to viewSettings
   },
 })
 

--- a/src/redux/features/taskBoardSlice.tsx
+++ b/src/redux/features/taskBoardSlice.tsx
@@ -71,6 +71,12 @@ const taskBoardSlice = createSlice({
     },
     setViewSettings: (state, action: { payload: CreateViewSettingsDTO }) => {
       state.view = action.payload.viewMode
+      if (action.payload.filterOptions.assignee) {
+        const assigneeCheck = state.assignee.find((assignee) => assignee.id == action.payload.filterOptions.assignee)
+        if (!assigneeCheck) {
+          action.payload.filterOptions.assignee = ''
+        }
+      }
       state.filterOptions = action.payload.filterOptions
     },
     setFilterOptions: (state, action: { payload: { optionType: FilterOptions; newValue: string | null } }) => {


### PR DESCRIPTION
### Tasks

- [When selected assignee in Filter by drop-down is deleted, Board/List view shows blank until I click the tab](https://linear.app/copilotplatforms/issue/OUT-754/when-selected-assignee-in-filter-by-drop-down-is-deleted-boardlist)

### Changes

- [x] added a check if client was deleted while updating view settings

### Testing Criteria

- [LOOM](https://www.loom.com/share/f4a7650571f14ea7beb254d4b506f739)
