### PR TITLE
OUT-764, OUT-765 Some weird arrows coming on autocomplete popper below the loading spinner on loading state, Last item shown in the drop-down is cut-off

### DIFF
--- a/src/components/inputs/ListComponent.tsx
+++ b/src/components/inputs/ListComponent.tsx
@@ -23,8 +23,18 @@ const ListComponentInternal = forwardRef<Scrollbars, ListComponentProps>((props,
           }}
         />
       )}
-      autoHeight
-      autoHeightMax={xs ? '175px' : '291px'}
+      renderView={(viewProps) => (
+        <div
+          style={{
+            position: 'relative',
+            maxHeight: '291px',
+            marginBottom: '-25px',
+            inset: '0px',
+            overflow: 'scroll',
+            marginRight: '-20px',
+          }}
+        />
+      )}
       autoHide
       autoHideTimeout={500}
       autoHideDuration={500}


### PR DESCRIPTION
### Tasks

- [Some weird arrows coming on autocomplete popper below the loading spinner on loading state](https://linear.app/copilotplatforms/issue/OUT-764/some-weird-arrows-coming-on-autocomplete-popper-below-the-loading)
- [Last item shown in the drop-down is cut-off](https://linear.app/copilotplatforms/issue/OUT-765/last-item-shown-in-the-drop-down-is-cut-off)

### Changes

- [x] fixed overflow arrows showing on x axis on selector after the implementation of custom scrollbar
- [x] fixed Some x axis overflow arrows coming on autocomplete popper below the loading spinner on loading state 

### Testing Criteria

- [LOOM](https://www.loom.com/share/79719226ed28497daae143090293a12f)