### PR TITLE
OUT-766 | Opening task from notification center shows blank task details

### DIFF
--- a/src/app/detail/[task_id]/[user_type]/DetailStateUpdate.tsx
+++ b/src/app/detail/[task_id]/[user_type]/DetailStateUpdate.tsx
@@ -9,7 +9,7 @@ interface DetailStateUpdateProps {
   children: React.ReactNode
 }
 
-export const DetailStateUpdate = async ({ isRedirect, token, tokenPayload, children }: any) => {
+export const DetailStateUpdate = async ({ isRedirect, token, tokenPayload, children }: DetailStateUpdateProps) => {
   if (!isRedirect) {
     return (
       <ClientSideStateUpdate token={token} tokenPayload={tokenPayload}>

--- a/src/app/detail/[task_id]/[user_type]/DetailStateUpdate.tsx
+++ b/src/app/detail/[task_id]/[user_type]/DetailStateUpdate.tsx
@@ -3,7 +3,7 @@ import { getAllTasks, getAllWorkflowStates, getViewSettings } from '@/app/page'
 import { Token } from '@/types/common'
 
 interface DetailStateUpdateProps {
-  isRedirect?: 'true'
+  isRedirect?: boolean
   token: string
   tokenPayload: Token | null
   children: React.ReactNode

--- a/src/app/detail/[task_id]/[user_type]/DetailStateUpdate.tsx
+++ b/src/app/detail/[task_id]/[user_type]/DetailStateUpdate.tsx
@@ -1,0 +1,31 @@
+import { ClientSideStateUpdate } from '@/hoc/ClientSideStateUpdate'
+import { getAllTasks, getAllWorkflowStates, getViewSettings } from '@/app/page'
+
+export const DetailStateUpdate = async ({ isRedirect, token, tokenPayload, children }: any) => {
+  if (!isRedirect) {
+    return (
+      <ClientSideStateUpdate token={token} tokenPayload={tokenPayload}>
+        {children}
+      </ClientSideStateUpdate>
+    )
+  }
+
+  // If flow has been redirected from notifications CTA button directly,
+  // we must context for tasks, workflowStates and viewSettings
+  const [workflowStates, tasks, viewSettings] = await Promise.all([
+    getAllWorkflowStates(token),
+    getAllTasks(token),
+    getViewSettings(token),
+  ])
+  return (
+    <ClientSideStateUpdate
+      workflowStates={workflowStates}
+      tasks={tasks}
+      token={token}
+      viewSettings={viewSettings}
+      tokenPayload={tokenPayload}
+    >
+      {children}
+    </ClientSideStateUpdate>
+  )
+}

--- a/src/app/detail/[task_id]/[user_type]/DetailStateUpdate.tsx
+++ b/src/app/detail/[task_id]/[user_type]/DetailStateUpdate.tsx
@@ -1,5 +1,13 @@
 import { ClientSideStateUpdate } from '@/hoc/ClientSideStateUpdate'
 import { getAllTasks, getAllWorkflowStates, getViewSettings } from '@/app/page'
+import { Token } from '@/types/common'
+
+interface DetailStateUpdateProps {
+  isRedirect?: 'true'
+  token: string
+  tokenPayload: Token | null
+  children: React.ReactNode
+}
 
 export const DetailStateUpdate = async ({ isRedirect, token, tokenPayload, children }: any) => {
   if (!isRedirect) {

--- a/src/app/detail/[task_id]/[user_type]/DetailStateUpdate.tsx
+++ b/src/app/detail/[task_id]/[user_type]/DetailStateUpdate.tsx
@@ -11,7 +11,7 @@ export const DetailStateUpdate = async ({ isRedirect, token, tokenPayload, child
   }
 
   // If flow has been redirected from notifications CTA button directly,
-  // we must context for tasks, workflowStates and viewSettings
+  // we must first get context for tasks, workflowStates and viewSettings
   const [workflowStates, tasks, viewSettings] = await Promise.all([
     getAllWorkflowStates(token),
     getAllTasks(token),

--- a/src/app/detail/[task_id]/[user_type]/page.tsx
+++ b/src/app/detail/[task_id]/[user_type]/page.tsx
@@ -14,8 +14,6 @@ import {
   StyledTiptapDescriptionWrapper,
   StyledTypography,
 } from '@/app/detail/ui/styledComponent'
-import Link from 'next/link'
-import { ClientSideStateUpdate } from '@/hoc/ClientSideStateUpdate'
 import {
   clientUpdateTask,
   deleteAttachment,
@@ -37,7 +35,7 @@ import { Suspense } from 'react'
 import { WorkflowStateFetcher } from '@/app/_fetchers/WorkflowStateFetcher'
 import { AssigneeFetcher } from '@/app/_fetchers/AssigneeFetcher'
 import { CustomLink } from '@/hoc/CustomLink'
-import { TasksFetcher } from '@/app/_fetchers/TasksFetcher'
+import { DetailStateUpdate } from '@/app/detail/[task_id]/[user_type]/DetailStateUpdate'
 
 async function getOneTask(token: string, taskId: string): Promise<TaskResponse> {
   const res = await fetch(`${apiUrl}/api/tasks/${taskId}?token=${token}`, {
@@ -60,14 +58,13 @@ export default async function TaskDetailPage({
   searchParams,
 }: {
   params: { task_id: string; task_name: string; user_type: UserType }
-  searchParams: { token: string }
+  searchParams: { token: string; isRedirect?: 'true' }
 }) {
   const { token } = searchParams
   const { task_id } = params
   const copilotClient = new CopilotAPI(token)
 
   const [task, tokenPayload] = await Promise.all([getOneTask(token, task_id), copilotClient.getTokenPayload()])
-
   // Basic validation
   if (!tokenPayload) {
     throw new Error('Token cannot be found')
@@ -76,7 +73,12 @@ export default async function TaskDetailPage({
   redirectIfResourceNotFound(searchParams, task, !!tokenPayload.internalUserId)
 
   return (
-    <ClientSideStateUpdate token={token} tokenPayload={tokenPayload}>
+    <DetailStateUpdate
+      isRedirect={searchParams.isRedirect}
+      searchParams={searchParams}
+      token={token}
+      tokenPayload={tokenPayload}
+    >
       <RealTime>
         <EscapeHandler />
         <Stack direction="row" sx={{ height: '100vh' }}>
@@ -219,6 +221,6 @@ export default async function TaskDetailPage({
           </Box>
         </Stack>
       </RealTime>
-    </ClientSideStateUpdate>
+    </DetailStateUpdate>
   )
 }

--- a/src/app/detail/[task_id]/[user_type]/page.tsx
+++ b/src/app/detail/[task_id]/[user_type]/page.tsx
@@ -58,7 +58,7 @@ export default async function TaskDetailPage({
   searchParams,
 }: {
   params: { task_id: string; task_name: string; user_type: UserType }
-  searchParams: { token: string; isRedirect?: 'true' }
+  searchParams: { token: string; isRedirect?: boolean }
 }) {
   const { token } = searchParams
   const { task_id } = params

--- a/src/app/detail/[task_id]/[user_type]/page.tsx
+++ b/src/app/detail/[task_id]/[user_type]/page.tsx
@@ -58,7 +58,7 @@ export default async function TaskDetailPage({
   searchParams,
 }: {
   params: { task_id: string; task_name: string; user_type: UserType }
-  searchParams: { token: string; isRedirect?: boolean }
+  searchParams: { token: string; isRedirect?: string }
 }) {
   const { token } = searchParams
   const { task_id } = params
@@ -73,7 +73,7 @@ export default async function TaskDetailPage({
   redirectIfResourceNotFound(searchParams, task, !!tokenPayload.internalUserId)
 
   return (
-    <DetailStateUpdate isRedirect={searchParams.isRedirect} token={token} tokenPayload={tokenPayload}>
+    <DetailStateUpdate isRedirect={!!searchParams.isRedirect} token={token} tokenPayload={tokenPayload}>
       <RealTime>
         <EscapeHandler />
         <Stack direction="row" sx={{ height: '100vh' }}>

--- a/src/app/detail/[task_id]/[user_type]/page.tsx
+++ b/src/app/detail/[task_id]/[user_type]/page.tsx
@@ -73,12 +73,7 @@ export default async function TaskDetailPage({
   redirectIfResourceNotFound(searchParams, task, !!tokenPayload.internalUserId)
 
   return (
-    <DetailStateUpdate
-      isRedirect={searchParams.isRedirect}
-      searchParams={searchParams}
-      token={token}
-      tokenPayload={tokenPayload}
-    >
+    <DetailStateUpdate isRedirect={searchParams.isRedirect} token={token} tokenPayload={tokenPayload}>
       <RealTime>
         <EscapeHandler />
         <Stack direction="row" sx={{ height: '100vh' }}>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -19,7 +19,7 @@ import { redirectIfTaskCta } from '@/utils/redirect'
 import { Suspense } from 'react'
 import { AssigneeFetcher } from './_fetchers/AssigneeFetcher'
 
-async function getAllWorkflowStates(token: string): Promise<WorkflowStateResponse[]> {
+export async function getAllWorkflowStates(token: string): Promise<WorkflowStateResponse[]> {
   const res = await fetch(`${apiUrl}/api/workflow-states?token=${token}`, {
     next: { tags: ['getAllWorkflowStates'] },
   })
@@ -29,7 +29,7 @@ async function getAllWorkflowStates(token: string): Promise<WorkflowStateRespons
   return data.workflowStates
 }
 
-async function getAllTasks(token: string): Promise<TaskResponse[]> {
+export async function getAllTasks(token: string): Promise<TaskResponse[]> {
   const res = await fetch(`${apiUrl}/api/tasks?token=${token}`, {
     next: { tags: ['getTasks'] },
   })
@@ -39,13 +39,13 @@ async function getAllTasks(token: string): Promise<TaskResponse[]> {
   return data.tasks
 }
 
-async function getTokenPayload(token: string): Promise<Token> {
+export async function getTokenPayload(token: string): Promise<Token> {
   const copilotClient = new CopilotAPI(token)
   const payload = TokenSchema.parse(await copilotClient.getTokenPayload())
   return payload as Token
 }
 
-async function getViewSettings(token: string): Promise<CreateViewSettingsDTO> {
+export async function getViewSettings(token: string): Promise<CreateViewSettingsDTO> {
   const res = await fetch(`${apiUrl}/api/view-settings?token=${token}`, {
     next: { tags: ['getViewSettings'] },
   })

--- a/src/utils/redirect.ts
+++ b/src/utils/redirect.ts
@@ -6,7 +6,7 @@ import { UserType } from '@/types/interfaces'
 export const redirectIfTaskCta = (searchParams: Record<string, string>) => {
   const taskId = z.string().safeParse(searchParams.taskId)
   if (taskId.data) {
-    redirect(`${apiUrl}/detail/${taskId.data}/iu?token=${z.string().parse(searchParams.token)}&isRedirect`)
+    redirect(`${apiUrl}/detail/${taskId.data}/iu?token=${z.string().parse(searchParams.token)}&isRedirect=1`)
   }
 }
 

--- a/src/utils/redirect.ts
+++ b/src/utils/redirect.ts
@@ -6,7 +6,7 @@ import { UserType } from '@/types/interfaces'
 export const redirectIfTaskCta = (searchParams: Record<string, string>) => {
   const taskId = z.string().safeParse(searchParams.taskId)
   if (taskId.data) {
-    redirect(`${apiUrl}/detail/${taskId.data}/iu?token=${z.string().parse(searchParams.token)}&isRedirect=true`)
+    redirect(`${apiUrl}/detail/${taskId.data}/iu?token=${z.string().parse(searchParams.token)}&isRedirect`)
   }
 }
 
@@ -16,7 +16,7 @@ export const RESOURCE_NOT_FOUND_REDIRECT_PATHS = {
 }
 
 export const redirectIfResourceNotFound = <R>(
-  searchParams: Record<string, string>,
+  searchParams: Record<string, string | boolean>,
   resource: R,
   isInternalUser: boolean,
 ): void => {

--- a/src/utils/redirect.ts
+++ b/src/utils/redirect.ts
@@ -16,7 +16,7 @@ export const RESOURCE_NOT_FOUND_REDIRECT_PATHS = {
 }
 
 export const redirectIfResourceNotFound = <R>(
-  searchParams: Record<string, string | boolean>,
+  searchParams: Record<string, string>,
   resource: R,
   isInternalUser: boolean,
 ): void => {

--- a/src/utils/redirect.ts
+++ b/src/utils/redirect.ts
@@ -6,7 +6,7 @@ import { UserType } from '@/types/interfaces'
 export const redirectIfTaskCta = (searchParams: Record<string, string>) => {
   const taskId = z.string().safeParse(searchParams.taskId)
   if (taskId.data) {
-    redirect(`${apiUrl}/detail/${taskId.data}/iu?token=${z.string().parse(searchParams.token)}`)
+    redirect(`${apiUrl}/detail/${taskId.data}/iu?token=${z.string().parse(searchParams.token)}&isRedirect=true`)
   }
 }
 


### PR DESCRIPTION
### Tasks

- [OUT-766 | Opening task from notification center shows blank task details](https://linear.app/copilotplatforms/issue/OUT-766/opening-task-from-notification-center-shows-blank-task-details)

### Changes

- [x] Add `DetailStateUpdate` component to fetch context when redirected from notifications CTA button
- [x] Implement `DetailStateUpdate` instead of normal `ClientStateUpdate` for details page. 

### Testing Criteria

- [x] [LOOM](https://www.loom.com/share/d21b7e6d9e7d4d74b9976e232440aac5?sid=f74fab6d-8cd3-41d1-936a-7c8d4a7217b9)