### PR TITLE
OUT-769 Filter dropdown search input persists until I click somewhere on the page

### DIFF
--- a/src/components/inputs/Selector.tsx
+++ b/src/components/inputs/Selector.tsx
@@ -198,6 +198,7 @@ export default function Selector({
             if (newValue) {
               getSelectedValue(newValue)
               setAnchorEl(null)
+              setInputStatusValue('')
             }
           }}
           ListboxComponent={ListComponent}


### PR DESCRIPTION
### Changes

- [x] Resets the selector input state after selector's value is changed

### Testing Criteria

- [LOOM](https://www.loom.com/share/8db69e3ac61e43369567ef4bbc192b95?sid=ba909322-057b-4839-a20f-0b62eef38672)

