### PR TITLE
OUT-764, OUT-765-hotfix Some weird arrows coming on autocomplete popper below the loading spinner on loading state

### DIFF
--- a/src/components/inputs/ListComponent.tsx
+++ b/src/components/inputs/ListComponent.tsx
@@ -30,11 +30,9 @@ const ListComponentInternal = forwardRef<Scrollbars, ListComponentProps>((props,
             ...viewProps.style,
             position: 'relative',
             maxHeight: xs ? '175px' : '291px',
-            marginBottom: '-25px',
             inset: '0px',
-            overflow: 'scroll',
-            marginRight: '-20px',
-            paddingBottom: '15px',
+            overflow: 'auto',
+            paddingBottom: xs ? '12px' : '7px',
           }}
         />
       )}

--- a/src/components/inputs/Selector.tsx
+++ b/src/components/inputs/Selector.tsx
@@ -333,15 +333,18 @@ const AssigneeSelectorRenderer = ({ props, option }: { props: HTMLAttributes<HTM
       sx={(theme) => ({
         '&.MuiAutocomplete-option': {
           minHeight: { xs: '32px' },
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
         },
-        overflow: 'hidden',
-        textOverflow: 'ellipsis',
-        whiteSpace: 'nowrap',
-        '&.MuiAutocomplete-option[aria-selected="true"].Mui-focused': {
-          bgcolor: theme.color.gray[150],
+        '&.MuiAutocomplete-option[aria-selected="true"]': {
+          bgcolor: theme.color.base.white,
         },
         '&.MuiAutocomplete-option.Mui-focused': {
-          bgcolor: theme.color.gray[150],
+          bgcolor: theme.color.background.bgHover,
+        },
+        '&.MuiAutocomplete-option:hover': {
+          bgcolor: theme.color.background.bgHover,
         },
       })}
     >

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -77,6 +77,7 @@ export const theme = createTheme({
     background: {
       bgCard: '#DFE1E4',
       bgCallout: '#F8F9FB',
+      bgHover: '#F1F3F8',
     },
     error: '#CC0000',
     muiError: '#D32F2F',

--- a/src/types/theme.d.ts
+++ b/src/types/theme.d.ts
@@ -75,6 +75,7 @@ export declare module '@mui/material/styles' {
       background: {
         bgCard: string
         bgCallout: string
+        bgHover: string
       }
       error: string
       muiError: string
@@ -154,6 +155,7 @@ export declare module '@mui/material/styles' {
       background: {
         bgCard: React.CSSProperties['color']
         bgCallout: React.CSSProperties['color']
+        bgHover: React.CSSProperties['color']
       }
       error: React.CSSProperties['color']
       muiError: React.CSSProperties['color']


### PR DESCRIPTION
### Tasks

- [Some weird arrows coming on autocomplete popper below the loading spinner on loading state](https://linear.app/copilotplatforms/issue/OUT-764/some-weird-arrows-coming-on-autocomplete-popper-below-the-loading)

### Changes

- [x] fixed padding issues 


