### PR TITLE
OUT-800 "+ New Task" button shouldn't appear for clients if task board is empty

### DIFF
--- a/src/components/layouts/EmptyState/DashboardEmptyState.tsx
+++ b/src/components/layouts/EmptyState/DashboardEmptyState.tsx
@@ -8,8 +8,11 @@ import store from '@/redux/store'
 import { UserType } from '@/types/interfaces'
 import { SxCenter } from '@/utils/mui'
 import { Box, Stack, Typography } from '@mui/material'
+import { usePathname } from 'next/navigation'
 
 const DashboardEmptyState = ({ userType }: { userType: UserType }) => {
+  const pathname = usePathname()
+  console.log(pathname.includes('client'))
   return (
     <>
       <AppMargin size={SizeofAppMargin.LARGE} py="20px">
@@ -44,7 +47,7 @@ const DashboardEmptyState = ({ userType }: { userType: UserType }) => {
                   : 'Tasks will show here once they’ve been assigned to you. '}
               </Typography>
             </Stack>
-            {userType == UserType.INTERNAL_USER && (
+            {userType === UserType.INTERNAL_USER && !!!pathname.includes('client') && (
               <Box>
                 <PrimaryBtn
                   startIcon={<AddIcon />}

--- a/src/components/layouts/EmptyState/DashboardEmptyState.tsx
+++ b/src/components/layouts/EmptyState/DashboardEmptyState.tsx
@@ -12,7 +12,6 @@ import { usePathname } from 'next/navigation'
 
 const DashboardEmptyState = ({ userType }: { userType: UserType }) => {
   const pathname = usePathname()
-  console.log(pathname.includes('client'))
   return (
     <>
       <AppMargin size={SizeofAppMargin.LARGE} py="20px">


### PR DESCRIPTION
### Changes

- [x] Adds strict check for "New Task" button

### Testing Criteria

- [LOOM](https://www.loom.com/share/d34059d35b8d4222b06e713c1bf813a7?sid=4e180309-3fa7-497b-bb12-fc0a2c44261f)