### PR TITLE
Hotfix/out 800 "+ New Task" button shouldn't appear for clients if task board is empty

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -18,6 +18,7 @@ import { redirectIfTaskCta } from '@/utils/redirect'
 import { Suspense } from 'react'
 import { AssigneeFetcher } from './_fetchers/AssigneeFetcher'
 import { SilentError } from '@/components/templates/SilentError'
+import { UserRole } from './api/core/types/user'
 
 export async function getAllWorkflowStates(token: string): Promise<WorkflowStateResponse[]> {
   const res = await fetch(`${apiUrl}/api/workflow-states?token=${token}`, {
@@ -86,7 +87,7 @@ export default async function Main({ searchParams }: { searchParams: { token: st
       </Suspense>
       <RealTime>
         <DndWrapper>
-          <TaskBoard />
+          <TaskBoard mode={UserRole.IU} />
         </DndWrapper>
 
         <ModalNewTaskForm

--- a/src/app/ui/TaskBoard.tsx
+++ b/src/app/ui/TaskBoard.tsx
@@ -25,9 +25,9 @@ import { UserRole } from '@api/core/types/user'
 import { clientUpdateTask } from '@/app/detail/[task_id]/[user_type]/actions'
 
 interface TaskBoardProps {
-  mode?: UserRole
+  mode: UserRole
 }
-export const TaskBoard = ({ mode = UserRole.IU }: TaskBoardProps) => {
+export const TaskBoard = ({ mode }: TaskBoardProps) => {
   const { workflowStates, tasks, token, filteredTasks, view, viewSettingsTemp, filterOptions } = useSelector(selectTaskBoard)
 
   const onDropItem = useCallback(
@@ -68,7 +68,7 @@ export const TaskBoard = ({ mode = UserRole.IU }: TaskBoardProps) => {
   }
 
   if (tasks && tasks.length === 0) {
-    return <DashboardEmptyState userType={UserType.INTERNAL_USER} />
+    return <DashboardEmptyState userType={mode} />
   }
   const viewBoardSettings = viewSettingsTemp ? viewSettingsTemp.viewMode : view
   const getCardHref = (task: { id: string }) => `/detail/${task.id}/${mode === UserRole.IU ? 'iu' : 'cu'}`

--- a/src/components/layouts/EmptyState/DashboardEmptyState.tsx
+++ b/src/components/layouts/EmptyState/DashboardEmptyState.tsx
@@ -1,15 +1,15 @@
 'use client'
 
+import { UserRole } from '@/app/api/core/types/user'
 import { PrimaryBtn } from '@/components/buttons/PrimaryBtn'
 import { AppMargin, SizeofAppMargin } from '@/hoc/AppMargin'
 import { AddIcon, TasksListIcon } from '@/icons'
 import { setShowModal } from '@/redux/features/createTaskSlice'
 import store from '@/redux/store'
-import { UserType } from '@/types/interfaces'
 import { SxCenter } from '@/utils/mui'
 import { Box, Stack, Typography } from '@mui/material'
 
-const DashboardEmptyState = ({ userType }: { userType: UserType }) => {
+const DashboardEmptyState = ({ userType }: { userType: UserRole }) => {
   return (
     <>
       <AppMargin size={SizeofAppMargin.LARGE} py="20px">
@@ -36,15 +36,15 @@ const DashboardEmptyState = ({ userType }: { userType: UserType }) => {
               </Box>
 
               <Typography variant="2xl" lineHeight={'32px'}>
-                {userType == UserType.INTERNAL_USER ? " You don't have any tasks yet" : 'No tasks assigned'}
+                {userType == UserRole.IU ? " You don't have any tasks yet" : 'No tasks assigned'}
               </Typography>
               <Typography variant="bodyLg" sx={{ color: (theme) => theme.color.gray[500] }}>
-                {userType == UserType.INTERNAL_USER
+                {userType == UserRole.Client
                   ? 'Tasks will be shown here after they’re created. You can create a new task below.'
                   : 'Tasks will show here once they’ve been assigned to you. '}
               </Typography>
             </Stack>
-            {userType == UserType.INTERNAL_USER && (
+            {userType == UserRole.IU && (
               <Box>
                 <PrimaryBtn
                   startIcon={<AddIcon />}


### PR DESCRIPTION
### Changes

- [x] Passes `userType` on `DashboardEmptyState`

### Testing Criteria

[Screencast from 05-09-24 02:33:30 PM +0545.webm](https://github.com/user-attachments/assets/bf993f1e-43f8-4388-ac15-d50ebc077fb2)

