### PR TITLE
OUT-752 | Clean Zod errors so we can debug in prod

### DIFF
--- a/src/app/api/core/utils/withErrorHandler.ts
+++ b/src/app/api/core/utils/withErrorHandler.ts
@@ -34,7 +34,7 @@ export const withErrorHandler = (handler: RequestHandler): RequestHandler => {
       // Format error in a readable way
       let formattedError = error
       if (error instanceof ZodError) {
-        formattedError = error.format() as ZodFormattedError<string, unknown>
+        formattedError = error.format() as ZodFormattedError<string>
       }
       console.error(formattedError)
 
@@ -46,7 +46,7 @@ export const withErrorHandler = (handler: RequestHandler): RequestHandler => {
       // Build a proper response based on the type of Error encountered
       if (error instanceof ZodError) {
         status = httpStatus.UNPROCESSABLE_ENTITY
-        message = formattedError as ZodFormattedError<string, unknown>
+        message = formattedError as ZodFormattedError<string>
       } else if (error instanceof CopilotApiError) {
         status = error.status || status
         message = error.body.message || message

--- a/src/app/api/core/utils/withErrorHandler.ts
+++ b/src/app/api/core/utils/withErrorHandler.ts
@@ -34,7 +34,7 @@ export const withErrorHandler = (handler: RequestHandler): RequestHandler => {
       // Format error in a readable way
       let formattedError = error
       if (error instanceof ZodError) {
-        formattedError = error.format() as ZodFormattedError<unknown>
+        formattedError = error.format() as ZodFormattedError<string, unknown>
       }
       console.error(formattedError)
 
@@ -46,7 +46,7 @@ export const withErrorHandler = (handler: RequestHandler): RequestHandler => {
       // Build a proper response based on the type of Error encountered
       if (error instanceof ZodError) {
         status = httpStatus.UNPROCESSABLE_ENTITY
-        message = formattedError as ZodFormattedError<unknown>
+        message = formattedError as ZodFormattedError<string, unknown>
       } else if (error instanceof CopilotApiError) {
         status = error.status || status
         message = error.body.message || message


### PR DESCRIPTION
### Tasks

- [OUT-752 | Improved Zod Error messages](https://linear.app/copilotplatforms/issue/OUT-752/improved-zod-error-messages)

### Changes

- [x] Currently our errors for Zod are a deeply nested object and sometimes outright unusable. This simple fix error logs ZodError in a much more readable way

### Testing Criteria

- [x] Error in ZodFormattedError format with zod field in object key and `_errors` for meta errors
