### PR TITLE
OUT-817 Fix DnD - browser globe icon follows cursor when moving a task to a different status

### DIFF
--- a/src/hoc/DragDropHandler.tsx
+++ b/src/hoc/DragDropHandler.tsx
@@ -67,7 +67,9 @@ export const DragDropHandler = ({
     if (window) {
       //we only need custom drag preview in the list view
       if (draggable) {
-        preview(new Image()) // This sets an empty drag preview
+        const EMPTY_IMAGE = new Image(1, 1)
+        EMPTY_IMAGE.src = 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==' //1x1 transparent GIF image encoded in Base64
+        preview(EMPTY_IMAGE) // This sets an empty drag preview
       }
     }
   }, [preview, draggable])

--- a/src/hoc/DragDropHandler.tsx
+++ b/src/hoc/DragDropHandler.tsx
@@ -53,9 +53,7 @@ export const DragDropHandler = ({
 
   const [{ isDragging }, drag, preview] = useDrag({
     type: accept,
-    item: () => {
-      return { task: task }
-    },
+    item: { task: task },
     collect: (monitor) => ({
       isDragging: monitor.isDragging(),
     }),

--- a/src/redux/features/taskBoardSlice.tsx
+++ b/src/redux/features/taskBoardSlice.tsx
@@ -97,7 +97,7 @@ const taskBoardSlice = createSlice({
     },
     updateFilterOption: (state, action: { payload: { filterOptions: FilterOptionsType } }) => {
       const { filterOptions } = action.payload
-      if (filterOptions.assignee) {
+      if (filterOptions?.assignee) {
         const assigneeCheck = state.assignee.find((assignee) => assignee.id == filterOptions.assignee)
         if (!assigneeCheck) {
           filterOptions.assignee = ''


### PR DESCRIPTION
### Changes

- [x] Removes the globe icon appearing in Chrome/Arc browsers on MacOS during the drag and drop operations