### PR TITLE
OUT-837 | OUT-836 | Add retry & delay mechanism to CopilotAPI

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "immutability-helper": "^3.1.1",
     "next": "14.2.6",
     "nextjs-progressloader": "^1.2.0",
+    "p-retry": "^6.2.0",
     "prisma": "^5.19.0",
     "react": "18.3.1",
     "react-custom-scrollbars": "^4.2.1",

--- a/src/app/api/core/utils/authenticate.ts
+++ b/src/app/api/core/utils/authenticate.ts
@@ -5,8 +5,9 @@ import { z } from 'zod'
 import { TokenSchema } from '@/types/common'
 import APIError from '@api/core/exceptions/api'
 import httpStatus from 'http-status'
+import { withRetry } from './withRetry'
 
-export const authenticateWithToken = async (token: string, customApiKey?: string) => {
+export const _authenticateWithToken = async (token: string, customApiKey?: string): Promise<User> => {
   const copilotClient = new CopilotAPI(token, customApiKey)
   const payload = TokenSchema.safeParse(await copilotClient.getTokenPayload())
 
@@ -16,6 +17,7 @@ export const authenticateWithToken = async (token: string, customApiKey?: string
 
   return new User(token, payload.data)
 }
+export const authenticateWithToken = (...args: unknown[]) => withRetry(_authenticateWithToken, args)
 
 /**
  * Token parser and authentication util

--- a/src/app/api/core/utils/withErrorHandler.ts
+++ b/src/app/api/core/utils/withErrorHandler.ts
@@ -1,18 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { ZodError, ZodFormattedError, ZodIssue } from 'zod'
-import { CopilotApiError } from '@/types/CopilotApiError'
+import { CopilotApiError, MessagableError, StatusableError } from '@/types/CopilotApiError'
 import APIError from '@api/core/exceptions/api'
 import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library'
 import httpStatus from 'http-status'
-
-interface StatusableError {
-  status: number
-}
-interface MessageableError {
-  body?: {
-    message: string
-  }
-}
 
 type RequestHandler = (req: NextRequest, params: any) => Promise<NextResponse>
 
@@ -49,7 +40,7 @@ export const withErrorHandler = (handler: RequestHandler): RequestHandler => {
 
       // Default staus and message for JSON error response
       let status: number = (error as StatusableError).status || httpStatus.BAD_REQUEST
-      let message: string | ZodFormattedError<string> = (error as MessageableError).body?.message || 'Something went wrong'
+      let message: string | ZodFormattedError<string> = (error as MessagableError).body?.message || 'Something went wrong'
       let errors: unknown[] | undefined = undefined
 
       // Build a proper response based on the type of Error encountered

--- a/src/app/api/core/utils/withErrorHandler.ts
+++ b/src/app/api/core/utils/withErrorHandler.ts
@@ -1,9 +1,9 @@
-import { NextRequest, NextResponse } from 'next/server'
-import { ZodError, ZodFormattedError, ZodIssue } from 'zod'
 import { CopilotApiError, MessagableError, StatusableError } from '@/types/CopilotApiError'
 import APIError from '@api/core/exceptions/api'
 import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library'
 import httpStatus from 'http-status'
+import { NextRequest, NextResponse } from 'next/server'
+import { ZodError, ZodFormattedError } from 'zod'
 
 type RequestHandler = (req: NextRequest, params: any) => Promise<NextResponse>
 

--- a/src/app/api/core/utils/withErrorHandler.ts
+++ b/src/app/api/core/utils/withErrorHandler.ts
@@ -5,6 +5,15 @@ import APIError from '@api/core/exceptions/api'
 import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library'
 import httpStatus from 'http-status'
 
+interface StatusableError {
+  status: number
+}
+interface MessageableError {
+  body?: {
+    message: string
+  }
+}
+
 type RequestHandler = (req: NextRequest, params: any) => Promise<NextResponse>
 
 /**
@@ -39,8 +48,8 @@ export const withErrorHandler = (handler: RequestHandler): RequestHandler => {
       console.error(formattedError)
 
       // Default staus and message for JSON error response
-      let status: number = httpStatus.BAD_REQUEST
-      let message: string | ZodFormattedError<string> = 'Something went wrong'
+      let status: number = (error as StatusableError).status || httpStatus.BAD_REQUEST
+      let message: string | ZodFormattedError<string> = (error as MessageableError).body?.message || 'Something went wrong'
       let errors: unknown[] | undefined = undefined
 
       // Build a proper response based on the type of Error encountered

--- a/src/app/api/core/utils/withRetry.ts
+++ b/src/app/api/core/utils/withRetry.ts
@@ -1,7 +1,7 @@
 import pRetry, { FailedAttemptError } from 'p-retry'
 
-export const withRetry = <T>(fn: (...args: any[]) => Promise<T>, args: any[]): Promise<T> => {
-  return pRetry(() => fn(...args), {
+export const withRetry = async <T>(fn: (...args: any[]) => Promise<T>, args: any[]): Promise<T> => {
+  return await pRetry(async () => await fn(...args), {
     retries: 3,
     minTimeout: 500,
     maxTimeout: 500,
@@ -9,7 +9,7 @@ export const withRetry = <T>(fn: (...args: any[]) => Promise<T>, args: any[]): P
 
     onFailedAttempt: (error: FailedAttemptError) => {
       console.error(
-        `CopilotAPI#withRetry - Attempt ${error.attemptNumber} failed. There are ${error.retriesLeft} retries left. Error:`,
+        `CopilotAPI#withRetry | Attempt ${error.attemptNumber} failed. There are ${error.retriesLeft} retries left. Error:`,
         error,
       )
     },

--- a/src/app/api/core/utils/withRetry.ts
+++ b/src/app/api/core/utils/withRetry.ts
@@ -1,24 +1,46 @@
+import { StatusableError } from '@/types/CopilotApiError'
 import pRetry, { FailedAttemptError } from 'p-retry'
+import * as Sentry from '@sentry/nextjs'
 
 export const withRetry = async <T>(fn: (...args: any[]) => Promise<T>, args: any[]): Promise<T> => {
-  return await pRetry(async () => await fn(...args), {
-    retries: 3,
-    minTimeout: 500,
-    maxTimeout: 500,
-    factor: 2, // Exponential factor for timeout delay. Tweak this if issues still persist
-
-    onFailedAttempt: (error: FailedAttemptError) => {
-      console.error(
-        `CopilotAPI#withRetry | Attempt ${error.attemptNumber} failed. There are ${error.retriesLeft} retries left. Error:`,
-        error,
-      )
+  return await pRetry(
+    async () => {
+      try {
+        return await fn(...args)
+      } catch (error) {
+        // Hopefully now sentry doesn't report retry errors as well. We have enough triage issues as it is
+        Sentry.withScope((scope) => {
+          scope.addEventProcessor((event) => {
+            if (event.level === 'error' && event.message && event.message.includes('An error occurred during retry')) {
+              return null // Discard the event as it occured during retry
+            }
+            return event
+          })
+          // Log the error without triggering Sentry
+          console.error('An error occurred during retry, but it will be retried:', error)
+        })
+        // Rethrow the error so pRetry can rety
+        throw error
+      }
     },
 
-    shouldRetry: (error: any) => {
-      // Typecasting because Copilot doesn't export an error class
-      const err = error as { status?: number }
-      // Retry only if statusCode === 429
-      return err.status === 429
+    {
+      retries: 3,
+      minTimeout: 500,
+      maxTimeout: 500,
+      factor: 2, // Exponential factor for timeout delay. Tweak this if issues still persist
+      onFailedAttempt: (error: FailedAttemptError) => {
+        console.warn(
+          `CopilotAPI#withRetry | Attempt ${error.attemptNumber} failed. There are ${error.retriesLeft} retries left. Error:`,
+          error,
+        )
+      },
+      shouldRetry: (error: any) => {
+        // Typecasting because Copilot doesn't export an error class
+        const err = error as StatusableError
+        // Retry only if statusCode === 429
+        return err.status === 429
+      },
     },
-  })
+  )
 }

--- a/src/app/api/core/utils/withRetry.ts
+++ b/src/app/api/core/utils/withRetry.ts
@@ -3,7 +3,7 @@ import pRetry, { FailedAttemptError } from 'p-retry'
 import * as Sentry from '@sentry/nextjs'
 
 export const withRetry = async <T>(fn: (...args: any[]) => Promise<T>, args: any[]): Promise<T> => {
-  let isEventProcessorRegisterd = false
+  let isEventProcessorRegistered = false
 
   return await pRetry(
     async () => {
@@ -12,9 +12,9 @@ export const withRetry = async <T>(fn: (...args: any[]) => Promise<T>, args: any
       } catch (error) {
         // Hopefully now sentry doesn't report retry errors as well. We have enough triage issues as it is
         Sentry.withScope((scope) => {
-          if (isEventProcessorRegisterd) return
+          if (isEventProcessorRegistered) return
 
-          isEventProcessorRegisterd = true
+          isEventProcessorRegistered = true
           scope.addEventProcessor((event) => {
             if (event.level === 'error' && event.message && event.message.includes('An error occurred during retry')) {
               return null // Discard the event as it occured during retry
@@ -30,7 +30,7 @@ export const withRetry = async <T>(fn: (...args: any[]) => Promise<T>, args: any
     {
       retries: 3,
       minTimeout: 500,
-      maxTimeout: 500,
+      maxTimeout: 2000,
       factor: 2, // Exponential factor for timeout delay. Tweak this if issues still persist
       onFailedAttempt: (error: FailedAttemptError) => {
         console.warn(

--- a/src/app/api/core/utils/withRetry.ts
+++ b/src/app/api/core/utils/withRetry.ts
@@ -1,0 +1,22 @@
+import pRetry, { FailedAttemptError } from 'p-retry'
+
+export const withRetry = <T>(fn: (...args: any[]) => Promise<T>, args: any[]): Promise<T> => {
+  return pRetry(() => fn(...args), {
+    retries: 3,
+    minTimeout: 500,
+    maxTimeout: 500,
+    factor: 1, // No exponential delays for now
+    onFailedAttempt: (error: FailedAttemptError) => {
+      console.error(
+        `CopilotAPI#withRetry - Attempt ${error.attemptNumber} failed. There are ${error.retriesLeft} retries left. Error:`,
+        error,
+      )
+    },
+    shouldRetry: (error: any) => {
+      // Typecasting because Copilot doesn't export an error class
+      const err = error as { status?: number }
+      // Retry only if statusCode === 429
+      return err.status === 429
+    },
+  })
+}

--- a/src/app/api/core/utils/withRetry.ts
+++ b/src/app/api/core/utils/withRetry.ts
@@ -6,12 +6,14 @@ export const withRetry = <T>(fn: (...args: any[]) => Promise<T>, args: any[]): P
     minTimeout: 500,
     maxTimeout: 500,
     factor: 1, // No exponential delays for now
+
     onFailedAttempt: (error: FailedAttemptError) => {
       console.error(
         `CopilotAPI#withRetry - Attempt ${error.attemptNumber} failed. There are ${error.retriesLeft} retries left. Error:`,
         error,
       )
     },
+
     shouldRetry: (error: any) => {
       // Typecasting because Copilot doesn't export an error class
       const err = error as { status?: number }

--- a/src/app/api/core/utils/withRetry.ts
+++ b/src/app/api/core/utils/withRetry.ts
@@ -16,8 +16,6 @@ export const withRetry = async <T>(fn: (...args: any[]) => Promise<T>, args: any
             }
             return event
           })
-          // Log the error without triggering Sentry
-          console.error('An error occurred during retry, but it will be retried:', error)
         })
         // Rethrow the error so pRetry can rety
         throw error

--- a/src/app/api/core/utils/withRetry.ts
+++ b/src/app/api/core/utils/withRetry.ts
@@ -5,7 +5,7 @@ export const withRetry = async <T>(fn: (...args: any[]) => Promise<T>, args: any
     retries: 3,
     minTimeout: 500,
     maxTimeout: 500,
-    factor: 1, // No exponential delays for now
+    factor: 2, // Exponential factor for timeout delay. Tweak this if issues still persist
 
     onFailedAttempt: (error: FailedAttemptError) => {
       console.error(

--- a/src/types/CopilotApiError.ts
+++ b/src/types/CopilotApiError.ts
@@ -3,7 +3,7 @@ export interface StatusableError extends Error {
   status: number
 }
 
-export interface MessageableError extends Error {
+export interface MessagableError extends Error {
   body?: {
     message: string
   }

--- a/src/types/CopilotApiError.ts
+++ b/src/types/CopilotApiError.ts
@@ -1,3 +1,14 @@
+// Interfaces that implement a particular behavior of CopilotApiError
+export interface StatusableError extends Error {
+  status: number
+}
+
+export interface MessageableError extends Error {
+  body?: {
+    message: string
+  }
+}
+
 export class CopilotApiError extends Error {
   readonly status: number
   readonly body: {

--- a/src/utils/CopilotAPI.ts
+++ b/src/utils/CopilotAPI.ts
@@ -175,44 +175,29 @@ export class CopilotAPI {
     await this.copilot.deleteNotification({ id })
   }
 
+  private wrapWithRetry<Args extends unknown[], R>(fn: (...args: Args) => Promise<R>): (...args: Args) => Promise<R> {
+    return (...args: Args): Promise<R> => withRetry(fn.bind(this), args)
+  }
+
   // Methods wrapped with retry
-  getTokenPayload = async (...args: unknown[]) => await withRetry(this._getTokenPayload.bind(this), args)
-
-  me = async (...args: unknown[]) => await withRetry(this._me.bind(this), args)
-
-  getWorkspace = async (...args: unknown[]) => await withRetry(this._getWorkspace.bind(this), args)
-
-  getClientTokenPayload = async (...args: unknown[]) => await withRetry(this._getClientTokenPayload.bind(this), args)
-
-  getIUTokenPayload = async (...args: unknown[]) => await withRetry(this._getIUTokenPayload.bind(this), args)
-
-  createClient = async (...args: unknown[]) => await withRetry(this._createClient.bind(this), args)
-
-  getClient = async (...args: unknown[]) => await withRetry(this._getClient.bind(this), args)
-
-  getClients = async (...args: unknown[]) => await withRetry(this._getClients.bind(this), args)
-
-  updateClient = async (...args: unknown[]) => await withRetry(this._updateClient.bind(this), args)
-
-  deleteClient = async (...args: unknown[]) => await withRetry(this._deleteClient.bind(this), args)
-
-  createCompany = async (...args: unknown[]) => await withRetry(this._createCompany.bind(this), args)
-
-  getCompany = async (...args: unknown[]) => await withRetry(this._getCompany.bind(this), args)
-
-  getCompanies = async (...args: unknown[]) => await withRetry(this._getCompanies.bind(this), args)
-
-  getCompanyClients = async (...args: unknown[]) => await withRetry(this._getCompanyClients.bind(this), args)
-
-  getCustomFields = async (...args: unknown[]) => await withRetry(this._getCustomFields.bind(this), args)
-
-  getInternalUsers = async (...args: unknown[]) => await withRetry(this._getInternalUsers.bind(this), args)
-
-  getInternalUser = async (...args: unknown[]) => await withRetry(this._getInternalUser.bind(this), args)
-
-  createNotification = async (...args: unknown[]) => await withRetry(this._createNotification.bind(this), args)
-
-  markNotificationAsRead = async (...args: unknown[]) => await withRetry(this._markNotificationAsRead.bind(this), args)
-
-  deleteNotification = async (...args: unknown[]) => await withRetry(this._deleteNotification.bind(this), args)
+  getTokenPayload = this.wrapWithRetry(this._getTokenPayload)
+  me = this.wrapWithRetry(this._me)
+  getWorkspace = this.wrapWithRetry(this._getWorkspace)
+  getClientTokenPayload = this.wrapWithRetry(this._getClientTokenPayload)
+  getIUTokenPayload = this.wrapWithRetry(this._getIUTokenPayload)
+  createClient = this.wrapWithRetry(this._createClient)
+  getClient = this.wrapWithRetry(this._getClient)
+  getClients = this.wrapWithRetry(this._getClients)
+  updateClient = this.wrapWithRetry(this._updateClient)
+  deleteClient = this.wrapWithRetry(this._deleteClient)
+  createCompany = this.wrapWithRetry(this._createCompany)
+  getCompany = this.wrapWithRetry(this._getCompany)
+  getCompanies = this.wrapWithRetry(this._getCompanies)
+  getCompanyClients = this.wrapWithRetry(this._getCompanyClients)
+  getCustomFields = this.wrapWithRetry(this._getCustomFields)
+  getInternalUsers = this.wrapWithRetry(this._getInternalUsers)
+  getInternalUser = this.wrapWithRetry(this._getInternalUser)
+  createNotification = this.wrapWithRetry(this._createNotification)
+  markNotificationAsRead = this.wrapWithRetry(this._markNotificationAsRead)
+  deleteNotification = this.wrapWithRetry(this._deleteNotification)
 }

--- a/src/utils/CopilotAPI.ts
+++ b/src/utils/CopilotAPI.ts
@@ -1,3 +1,4 @@
+import { withRetry } from '@/app/api/core/utils/withRetry'
 import { copilotAPIKey as apiKey } from '@/config'
 import {
   ClientRequest,
@@ -43,7 +44,11 @@ export class CopilotAPI {
     this.copilot = copilotApi({ apiKey: customApiKey ?? apiKey, token })
   }
 
-  async getTokenPayload(): Promise<Token | null> {
+  // NOTE: Any method prefixed with _ is a API method that doesn't implement retry & delay
+  // NOTE: Any normal API method name implements `withRetry` with default config
+
+  // Get Token Payload from copilot request token
+  async _getTokenPayload(): Promise<Token | null> {
     console.info('CopilotAPI#getTokenPayload | token =', this.token)
     const getTokenPayload = this.copilot.getTokenPayload
     if (!getTokenPayload) {
@@ -54,7 +59,7 @@ export class CopilotAPI {
     return TokenSchema.parse(await getTokenPayload())
   }
 
-  async me(): Promise<MeResponse | null> {
+  async _me(): Promise<MeResponse | null> {
     console.info('CopilotAPI#me | token =', this.token)
     const tokenPayload = await this.getTokenPayload()
     const id = tokenPayload?.internalUserId || tokenPayload?.clientId
@@ -68,12 +73,12 @@ export class CopilotAPI {
     return MeResponseSchema.parse(currentUserInfo)
   }
 
-  async getWorkspace(): Promise<WorkspaceResponse> {
+  async _getWorkspace(): Promise<WorkspaceResponse> {
     console.info('CopilotAPI#getWorkspace | token =', this.token)
     return WorkspaceResponseSchema.parse(await this.copilot.retrieveWorkspace())
   }
 
-  async getClientTokenPayload(): Promise<ClientToken | null> {
+  async _getClientTokenPayload(): Promise<ClientToken | null> {
     console.info('CopilotAPI#getClientTokenPayload | token =', this.token)
     const tokenPayload = await this.getTokenPayload()
     if (!tokenPayload) return null
@@ -81,7 +86,7 @@ export class CopilotAPI {
     return ClientTokenSchema.parse(tokenPayload)
   }
 
-  async getIUTokenPayload(): Promise<IUToken | null> {
+  async _getIUTokenPayload(): Promise<IUToken | null> {
     console.info('CopilotAPI#getIUTokenPayload | token =', this.token)
     const tokenPayload = await this.getTokenPayload()
     if (!tokenPayload) return null
@@ -89,68 +94,69 @@ export class CopilotAPI {
     return IUTokenSchema.parse(tokenPayload)
   }
 
-  async createClient(requestBody: ClientRequest, sendInvite: boolean = false): Promise<ClientResponse> {
+  async _createClient(requestBody: ClientRequest, sendInvite: boolean = false): Promise<ClientResponse> {
     console.info('CopilotAPI#createClient | token =', this.token)
     return ClientResponseSchema.parse(await this.copilot.createClient({ sendInvite, requestBody }))
   }
 
-  async getClient(id: string): Promise<ClientResponse> {
+  async _getClient(id: string): Promise<ClientResponse> {
     console.info('CopilotAPI#getClient | token =', this.token)
     return ClientResponseSchema.parse(await this.copilot.retrieveClient({ id }))
   }
 
-  async getClients(args: CopilotListArgs & { companyId?: string } = {}) {
+  async _getClients(args: CopilotListArgs & { companyId?: string } = {}) {
     console.info('CopilotAPI#getClients | token =', this.token)
     return ClientsResponseSchema.parse(await this.copilot.listClients(args))
   }
 
-  async updateClient(id: string, requestBody: ClientRequest): Promise<ClientResponse> {
+  async _updateClient(id: string, requestBody: ClientRequest): Promise<ClientResponse> {
     console.info('CopilotAPI#updateClient | token =', this.token)
     // @ts-ignore
     return ClientResponseSchema.parse(await this.copilot.updateClient({ id, requestBody }))
   }
 
-  async deleteClient(id: string) {
+  async _deleteClient(id: string) {
     console.info('CopilotAPI#deleteClient | token =', this.token)
     return await this.copilot.deleteClient({ id })
   }
 
-  async createCompany(requestBody: CompanyCreateRequest) {
+  async _createCompany(requestBody: CompanyCreateRequest) {
     console.info('CopilotAPI#createCompany | token =', this.token)
     return CompanyResponseSchema.parse(await this.copilot.createCompany({ requestBody }))
   }
 
-  async getCompany(id: string): Promise<CompanyResponse> {
+  async _getCompany(id: string): Promise<CompanyResponse> {
     console.info('CopilotAPI#getCompany | token =', this.token)
     return CompanyResponseSchema.parse(await this.copilot.retrieveCompany({ id }))
   }
 
-  async getCompanies(args: CopilotListArgs = {}): Promise<CompaniesResponse> {
+  async _getCompanies(args: CopilotListArgs = {}): Promise<CompaniesResponse> {
     console.info('CopilotAPI#getCompanies | token =', this.token)
     return CompaniesResponseSchema.parse(await this.copilot.listCompanies(args))
   }
 
-  async getCompanyClients(companyId: string): Promise<ClientResponse[]> {
+  async _getCompanyClients(companyId: string): Promise<ClientResponse[]> {
     console.info('CopilotAPI#getCompanyClients | token =', this.token)
     return (await this.getClients({ limit: 10000, companyId })).data || []
   }
 
-  async getCustomFields(): Promise<CustomFieldResponse> {
+  async _getCustomFields(): Promise<CustomFieldResponse> {
     console.info('CopilotAPI#getCustomFields | token =', this.token)
     return CustomFieldResponseSchema.parse(await this.copilot.listCustomFields())
   }
 
-  async getInternalUsers(args: CopilotListArgs = {}): Promise<InternalUsersResponse> {
+  async _getInternalUsers(args: CopilotListArgs = {}): Promise<InternalUsersResponse> {
+    console.log('token', this?.token)
     console.info('CopilotAPI#getInternalUsers | token =', this.token)
     return InternalUsersResponseSchema.parse(await this.copilot.listInternalUsers(args))
   }
 
-  async getInternalUser(id: string): Promise<InternalUsers> {
+  async _getInternalUser(id: string): Promise<InternalUsers> {
     console.info('CopilotAPI#getInternalUser | token =', this.token)
     return InternalUsersSchema.parse(await this.copilot.retrieveInternalUser({ id }))
   }
 
-  async createNotification(requestBody: NotificationRequestBody): Promise<NotificationCreatedResponse> {
+  async _createNotification(requestBody: NotificationRequestBody): Promise<NotificationCreatedResponse> {
     console.info('CopilotAPI#createNotification | token =', this.token)
     return NotificationCreatedResponseSchema.parse(
       await this.copilot.createNotification({
@@ -159,13 +165,54 @@ export class CopilotAPI {
     )
   }
 
-  async markNotificationAsRead(id: string): Promise<void> {
+  async _markNotificationAsRead(id: string): Promise<void> {
     console.info('CopilotAPI#markNotificationAsRead | token =', this.token)
     await this.copilot.markNotificationRead({ id })
   }
 
-  async deleteNotification(id: string): Promise<void> {
+  async _deleteNotification(id: string): Promise<void> {
     console.info('CopilotAPI#deleteNotification | token =', this.token)
     await this.copilot.deleteNotification({ id })
   }
+
+  // Methods wrapped with retry
+  getTokenPayload = async (...args: unknown[]) => await withRetry(this._getTokenPayload.bind(this), args)
+
+  me = async (...args: unknown[]) => await withRetry(this._me.bind(this), args)
+
+  getWorkspace = async (...args: unknown[]) => await withRetry(this._getWorkspace.bind(this), args)
+
+  getClientTokenPayload = async (...args: unknown[]) => await withRetry(this._getClientTokenPayload.bind(this), args)
+
+  getIUTokenPayload = async (...args: unknown[]) => await withRetry(this._getIUTokenPayload.bind(this), args)
+
+  createClient = async (...args: unknown[]) => await withRetry(this._createClient.bind(this), args)
+
+  getClient = async (...args: unknown[]) => await withRetry(this._getClient.bind(this), args)
+
+  getClients = async (...args: unknown[]) => await withRetry(this._getClients.bind(this), args)
+
+  updateClient = async (...args: unknown[]) => await withRetry(this._updateClient.bind(this), args)
+
+  deleteClient = async (...args: unknown[]) => await withRetry(this._deleteClient.bind(this), args)
+
+  createCompany = async (...args: unknown[]) => await withRetry(this._createCompany.bind(this), args)
+
+  getCompany = async (...args: unknown[]) => await withRetry(this._getCompany.bind(this), args)
+
+  getCompanies = async (...args: unknown[]) => await withRetry(this._getCompanies.bind(this), args)
+
+  getCompanyClients = async (...args: unknown[]) => await withRetry(this._getCompanyClients.bind(this), args)
+
+  getCustomFields = async (...args: unknown[]) => await withRetry(this._getCustomFields.bind(this), args)
+
+  getInternalUsers = async (...args: unknown[]) => await withRetry(this._getInternalUsers.bind(this), args)
+
+  getInternalUser = async (...args: unknown[]) => await withRetry(this._getInternalUser.bind(this), args)
+
+  createNotification = async (...args: unknown[]) => await withRetry(this._createNotification.bind(this), args)
+
+  markNotificationAsRead = async (...args: unknown[]) => await withRetry(this._markNotificationAsRead.bind(this), args)
+
+  deleteNotification = async (...args: unknown[]) => await withRetry(this._deleteNotification.bind(this), args)
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2787,6 +2787,11 @@
     "@types/prop-types" "*"
     csstype "^3.0.2"
 
+"@types/retry@0.12.2":
+  version "0.12.2"
+  resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.2.tgz#ed279a64fa438bb69f2480eda44937912bb7480a"
+  integrity sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==
+
 "@types/shimmer@^1.0.2":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@types/shimmer/-/shimmer-1.2.0.tgz#9b706af96fa06416828842397a70dfbbf1c14ded"
@@ -4983,6 +4988,11 @@ is-negative-zero@^2.0.3:
   resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.3.tgz#ced903a027aca6381b777a5743069d7376a49747"
   integrity sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==
 
+is-network-error@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-network-error/-/is-network-error-1.1.0.tgz#d26a760e3770226d11c169052f266a4803d9c997"
+  integrity sha512-tUdRRAnhT+OtCZR/LxZelH/C7QtjtFrTu5tXCA8pl55eTUElUHT+GPYV8MBMBvea/j+NxQqVt3LbWMRir7Gx9g==
+
 is-number-object@^1.0.4:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/is-number-object/-/is-number-object-1.0.7.tgz#59d50ada4c45251784e9904f5246c742f07a42fc"
@@ -6173,6 +6183,15 @@ p-locate@^5.0.0:
   dependencies:
     p-limit "^3.0.2"
 
+p-retry@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/p-retry/-/p-retry-6.2.0.tgz#8d6df01af298750009691ce2f9b3ad2d5968f3bd"
+  integrity sha512-JA6nkq6hKyWLLasXQXUrO4z8BUZGUt/LjlJxx8Gb2+2ntodU/SS63YZ8b0LUTbQ8ZB9iwOfhEPhg4ykKnn2KsA==
+  dependencies:
+    "@types/retry" "0.12.2"
+    is-network-error "^1.0.0"
+    retry "^0.13.1"
+
 p-try@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
@@ -6759,7 +6778,7 @@ restore-cursor@^5.0.0:
     onetime "^7.0.0"
     signal-exit "^4.1.0"
 
-retry@0.13.1:
+retry@0.13.1, retry@^0.13.1:
   version "0.13.1"
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.13.1.tgz#185b1587acf67919d63b357349e03537b2484658"
   integrity sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==


### PR DESCRIPTION
### Tasks

- [OUT-836 | TypeError: fetch failed](https://linear.app/copilotplatforms/issue/OUT-836/typeerror-fetch-failed)
- [OUT-837 | TypeError: fetch failed](https://linear.app/copilotplatforms/issue/OUT-837)
- And other tasks in the past regarding rate-limits / 500 response from CopilotAPI

### Changes

- [x] Implement `withRetry` HOF utils for flexible promise retries & delay
- [x] Implement `withRetry` on each CopilotAPI method
- [x] Clean up withErrorHandler to better detect and respond to Copilot API errors 

### Testing Criteria

- [x] General testing of Tasks App where data is fetched from / added to Copilot API
- [x] Stress testing retry mechanism: [LOOM](https://www.loom.com/share/f27f600e17d64e9683d1fa4f082f2916?sid=a3e46150-1a8b-400b-83fb-0f13db577a5e)

