### PR TITLE
OUT-851 Image is broken when IU changes the task status from properties sidebar

### DIFF
--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -176,9 +176,14 @@ export class TasksService extends BaseService {
       },
     })
     if (!task) throw new APIError(httpStatus.NOT_FOUND, 'The requested task was not found')
+    const updatedTask = await this.db.task.update({
+      where: { id: task.id },
+      data: {
+        body: task.body && (await replaceImageSrc(task.body, this.getSignedUrl)),
+      },
+    })
 
-    task.body = task.body && (await replaceImageSrc(task.body, this.getSignedUrl))
-    return task
+    return updatedTask
   }
 
   async getTaskAssignee(task: Task): Promise<InternalUsers | ClientResponse | CompanyResponse | undefined> {
@@ -224,7 +229,6 @@ export class TasksService extends BaseService {
       where: { id },
       data: {
         ...data,
-
         assigneeId: data.assigneeId === '' ? null : data.assigneeId,
         label,
         ...(await getTaskTimestamps('update', this.user, data, prevTask)),

--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -224,6 +224,7 @@ export class TasksService extends BaseService {
       where: { id },
       data: {
         ...data,
+
         assigneeId: data.assigneeId === '' ? null : data.assigneeId,
         label,
         ...(await getTaskTimestamps('update', this.user, data, prevTask)),

--- a/src/app/detail/[task_id]/[user_type]/page.tsx
+++ b/src/app/detail/[task_id]/[user_type]/page.tsx
@@ -41,10 +41,11 @@ import { DetailStateUpdate } from '@/app/detail/[task_id]/[user_type]/DetailStat
 import { SilentError } from '@/components/templates/SilentError'
 import { z } from 'zod'
 import { ScrapImageRequest } from '@/types/common'
+import { signedUrlTtl } from '@/types/constants'
 
 async function getOneTask(token: string, taskId: string): Promise<TaskResponse> {
   const res = await fetch(`${apiUrl}/api/tasks/${taskId}?token=${token}`, {
-    next: { tags: ['getOneTask'] },
+    next: { tags: ['getOneTask'], revalidate: signedUrlTtl },
   })
 
   const data = await res.json()

--- a/src/app/detail/ui/Sidebar.tsx
+++ b/src/app/detail/ui/Sidebar.tsx
@@ -73,6 +73,7 @@ export const Sidebar = ({
       const currentTask = tasks.find((el) => el.id === task_id)
       const currentWorkflowState = workflowStates.find((el) => el?.id === currentTask?.workflowStateId)
       const currentAssigneeId = currentTask?.assigneeId
+      console.log(currentTask)
       updateStatusValue(currentWorkflowState)
       updateAssigneeValue(currentAssigneeId ? assignee.find((el) => el.id === currentAssigneeId) : NoAssignee)
       setDueDate(currentTask?.dueDate)

--- a/src/hoc/RealTime.tsx
+++ b/src/hoc/RealTime.tsx
@@ -46,6 +46,7 @@ export const RealTime = ({ children }: { children: ReactNode }) => {
           }
           //if the task is updated
         } else {
+          console.log('realtime updatedTask', updatedTask)
           const newTaskArr = [...tasks.filter((task) => task.id !== updatedTask.id), updatedTask]
           store.dispatch(setTasks(newTaskArr))
         }

--- a/src/hoc/RealTime.tsx
+++ b/src/hoc/RealTime.tsx
@@ -15,7 +15,7 @@ interface RealTimeTaskResponse extends TaskResponse {
   deletedAt: string
 }
 
-export const RealTime = ({ children }: { children: ReactNode }) => {
+export const RealTime = ({ children, task }: { children: ReactNode; task?: TaskResponse }) => {
   const { tasks, token } = useSelector(selectTaskBoard)
   const { tokenPayload } = useSelector(selectAuthDetails)
   const pathname = usePathname()
@@ -29,6 +29,7 @@ export const RealTime = ({ children }: { children: ReactNode }) => {
       }
     }
     if (payload.eventType === 'UPDATE') {
+      console.log(payload)
       const updatedTask = payload.new
       //check if the new task in this event belongs to the same workspaceId
       if (payload.new.workspaceId === tokenPayload?.workspaceId) {


### PR DESCRIPTION
### Tasks

- [Image is broken when IU changes the task status from properties sidebar](https://linear.app/copilotplatforms/issue/OUT-851/image-is-broken-when-iu-changes-the-task-status-from-properties)

### Changes

- [x] updated tasks on getOneTask with signedUrl which revalidates in 60 minutes. This causes the realtime updates to set fresh data with fresh signed url on the store.

### Testing Criteria

- [LOOM](https://www.loom.com/share/ea6b78278936421eb47aa1fd9731dc92)


