### PR TITLE
OUT-850 Don't show resizing bars for images for Client users

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "react-dnd-touch-backend": "^16.0.1",
     "react-dom": "^18",
     "react-redux": "^9.1.0",
-    "tapwrite": "^1.1.17",
+    "tapwrite": "^1.1.18",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7261,10 +7261,10 @@ tapable@^2.2.0:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"
   integrity sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==
 
-tapwrite@^1.1.17:
-  version "1.1.17"
-  resolved "https://registry.yarnpkg.com/tapwrite/-/tapwrite-1.1.17.tgz#aadce0a22cda6102ac514ea156a6bfc7e52f74a6"
-  integrity sha512-2FFhEUs2YYjMurPE2XDItbLJ7S7OBRTSwyRfhvKewgnrGfEX0ibtaYaiy4YfjhD3G4VtuAaFrZJ6VHANCH7S6w==
+tapwrite@^1.1.18:
+  version "1.1.18"
+  resolved "https://registry.yarnpkg.com/tapwrite/-/tapwrite-1.1.18.tgz#cb0640e19c62156c8444b0a46f235f85ff4e1ddf"
+  integrity sha512-sD0Xiw2RZvCFHUF8s5pAFusTLXmOzy6ZzT0p9a+CAQrLcpaOWvOUfwXPqDUFpgLMctfuJXJ4hROcOAPzwitBXg==
   dependencies:
     re-resizable "^6.10.0"
     tippy.js "^6.3.7"


### PR DESCRIPTION
### Tasks

- [Don't show resizing bars for images for Client users](https://linear.app/copilotplatforms/issue/OUT-850/dont-show-resizing-bars-for-images-for-client-users)

### Changes

- [x] tapwrite update, disabled resizing on readonly. [commit here. ](https://github.com/aatbip/tapwrite/pull/9/commits/d22868f2b1fecc054a8a51b4dcb25bf49838841b)

### Testing Criteria

- [LOOM](https://www.loom.com/share/8e66874a83314051bd4f9b9f68cb306e)

