### PR TITLE
OUT-858 Image skeletons should have the same size as the image

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "react-dnd-touch-backend": "^16.0.1",
     "react-dom": "^18",
     "react-redux": "^9.1.0",
-    "tapwrite": "^1.1.20",
+    "tapwrite": "^1.1.21",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7261,11 +7261,10 @@ tapable@^2.2.0:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"
   integrity sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==
 
-tapwrite@^1.1.20:
-  version "1.1.20"
-  resolved "https://registry.yarnpkg.com/tapwrite/-/tapwrite-1.1.20.tgz#537472d71b81444f83584b6e6793201f5aad89c0"
-  integrity sha512-SZOdv60U/+4i6t3ufT8FX4qWXyAlVzDZTLKNiHgBnr0BPKXPicziaw4xUZk0bhNIzEXlOS4M2lFz/l/32Tno9A==
-
+tapwrite@^1.1.21:
+  version "1.1.21"
+  resolved "https://registry.yarnpkg.com/tapwrite/-/tapwrite-1.1.21.tgz#0577a1e778c94896961db0e37627e496946c2e2b"
+  integrity sha512-CCyf1ojb90MvXq+z/LConTvQ8f1Kbsj0WESp9z+63uIzcnRIBJJVZv4KE5evodtCgGQdeeKjAJ5BcoUjR1J91Q==
   dependencies:
     re-resizable "^6.10.0"
     tippy.js "^6.3.7"


### PR DESCRIPTION
### Tasks

- [Image skeletons should have the same size as the image](https://linear.app/copilotplatforms/issue/OUT-858/image-skeletons-should-have-the-same-size-as-the-image)

### Changes

- [x] tapwrite update : image placeholder made the same size as the actual image passed. [COMMIT HERE](https://github.com/aatbip/tapwrite/pull/9/commits/354939e171169f8c7797aa02d8736e10992cf2a3)

### Testing Criteria

- [LOOM](https://www.loom.com/share/b15711d005fb4da0bd2de454db07b9fe)
