### PR TITLE
OUT-797: Fix IU notification scenarios when moving tasks around

### DIFF
--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -15,21 +15,13 @@ import { WorkflowStateUpdatedSchema } from '@api/activity-logs/schemas/WorkflowS
 import { NotificationService } from '@api/notification/notification.service'
 import { LabelMappingService } from '@api/label-mapping/label-mapping.service'
 import { z } from 'zod'
-import {
-  ClientResponse,
-  CompanyResponse,
-  InternalUsers,
-  NotificationCreatedResponseSchema,
-  ScrapImageRequest,
-} from '@/types/common'
+import { ClientResponse, CompanyResponse, InternalUsers, NotificationCreatedResponseSchema } from '@/types/common'
 import { CopilotAPI } from '@/utils/CopilotAPI'
-import { getFilePathFromUrl, replaceImageSrc } from '@/utils/signedUrlReplacer'
+import { replaceImageSrc } from '@/utils/signedUrlReplacer'
 import { SupabaseService } from '../core/services/supabase.service'
 import { supabaseBucket } from '@/config'
-import { AttachmentsService } from '../attachments/attachments.service'
 import { signedUrlTtl } from '@/types/constants'
 import { ScrapImageService } from '@/app/api/scrap-images/scrap-images.service'
-import Bottleneck from 'bottleneck'
 
 type FilterByAssigneeId = {
   assigneeId: string


### PR DESCRIPTION
### Tasks

- [Product notification goes away from CU end when IU changes the company task status](https://linear.app/copilotplatforms/issue/OUT-797/product-notification-goes-away-from-cu-end-when-iu-changes-the-company)

### Changes

- [x] Fix and make notification scenarios around IU updating a task more verbose and linear
- [x] Fix Product notification going away from CU end when IU changes company task status 

### Testing Criteria

- [x] [LOOM](https://www.loom.com/share/48a65d497063448183ff864c48efe0e0?sid=8c43e391-52a8-4743-9afc-6d4bc338f1fc)
