### PR TITLE
OUT-825, OUT-877 Support drag&drop and pasting images into editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "react-dnd-touch-backend": "^16.0.1",
     "react-dom": "^18",
     "react-redux": "^9.1.0",
-    "tapwrite": "^1.1.32",
+    "tapwrite": "^1.1.40",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "react-dnd-touch-backend": "^16.0.1",
     "react-dom": "^18",
     "react-redux": "^9.1.0",
-    "tapwrite": "^1.1.40",
+    "tapwrite": "^1.1.43",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7261,12 +7261,10 @@ tapable@^2.2.0:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"
   integrity sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==
 
-
-tapwrite@^1.1.32:
-  version "1.1.32"
-  resolved "https://registry.yarnpkg.com/tapwrite/-/tapwrite-1.1.32.tgz#18ca8a92e727605fa3481f5937cd19248340b053"
-  integrity sha512-e+PJW0T2/ieKxihZIWYL6OGT3xGiwkKzp37TLZFAC0wX+I8PgGX7jUiYf0CcDukk69vdUz2UUdQ2FuHMMBKG5w==
-
+tapwrite@^1.1.40:
+  version "1.1.40"
+  resolved "https://registry.yarnpkg.com/tapwrite/-/tapwrite-1.1.40.tgz#c467c8b34f8e9f3fe91e02562f7a7991c2566b65"
+  integrity sha512-wfs5IEb9W1ZUY8gA7uOB7lzE9eJcUUZ+zp/ApNa/h7ccUheUYCi8WmGuM44k4o7aDqaK1fdXRNMf3YPeTUI/8A==
   dependencies:
     re-resizable "^6.10.0"
     tippy.js "^6.3.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7261,10 +7261,10 @@ tapable@^2.2.0:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"
   integrity sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==
 
-tapwrite@^1.1.40:
-  version "1.1.40"
-  resolved "https://registry.yarnpkg.com/tapwrite/-/tapwrite-1.1.40.tgz#c467c8b34f8e9f3fe91e02562f7a7991c2566b65"
-  integrity sha512-wfs5IEb9W1ZUY8gA7uOB7lzE9eJcUUZ+zp/ApNa/h7ccUheUYCi8WmGuM44k4o7aDqaK1fdXRNMf3YPeTUI/8A==
+tapwrite@^1.1.43:
+  version "1.1.43"
+  resolved "https://registry.yarnpkg.com/tapwrite/-/tapwrite-1.1.43.tgz#0e15e3d29ad54ac3ae62b85e87b7574890a2bfbf"
+  integrity sha512-MNIsS0HhJcvdWyeapRrxzRI64kwPqthRb1j3YqKxXCTWD76B0r/ZmoYAjlPWVav2Ahcyo+vcdh3vxT0fbGEaKw==
   dependencies:
     re-resizable "^6.10.0"
     tippy.js "^6.3.7"


### PR DESCRIPTION
### Tasks

- [Support drag&drop and pasting images into editor](https://linear.app/copilotplatforms/issue/OUT-825/support-draganddrop-and-pasting-images-into-editor)
- [Images are not fully left aligned.](https://linear.app/copilotplatforms/issue/OUT-877/images-are-not-fully-left-aligned)

### Changes

- [x] new tapwrite update supporting image updates : [commit here](https://github.com/aatbip/tapwrite/pull/11/commits/0f749ae8e161ebfc51dbaa18194970aa29802e94), [2nd commit](https://github.com/aatbip/tapwrite/pull/11/commits/4b2bd564eb830fc5b46b463cfdd8cbe7c5c1ed14)

