### PR TITLE
OUT-821 | Opening "Filter by assignee" drop-down for second time shows incorrect assignees

### DIFF
--- a/src/components/layouts/FilterBar.tsx
+++ b/src/components/layouts/FilterBar.tsx
@@ -17,7 +17,7 @@ import { FilterOptions, FilterOptionsKeywords, IAssigneeCombined, IFilterOptions
 import { filterOptionsToAssigneeMap, filterTypeToButtonIndexMap } from '@/types/objectMaps'
 import { checkAssignee } from '@/utils/assignee'
 import { NoAssigneeExtraOptions } from '@/utils/noAssignee'
-import { setDebouncedFilteredAssignees } from '@/utils/users'
+import { getDebouncedFilteredAssignees, setDebouncedFilteredAssignees } from '@/utils/users'
 import { Box, IconButton, Stack } from '@mui/material'
 import { useEffect, useState } from 'react'
 import { useSelector } from 'react-redux'
@@ -44,6 +44,10 @@ export const FilterBar = ({ mode, updateViewModeSetting }: FilterBarProps) => {
   useEffect(() => {
     initialAssignees.length === 0 && setInitialAssignees(filteredAssignee)
   }, [initialAssignees.length, filteredAssignee])
+
+  useEffect(() => {
+    console.log('aaa load', loading)
+  }, [loading])
 
   const handleFilterOptionsChange = async (optionType: FilterOptions, newValue: string | null) => {
     store.dispatch(setFilterOptions({ optionType, newValue }))
@@ -210,20 +214,23 @@ export const FilterBar = ({ mode, updateViewModeSetting }: FilterBarProps) => {
                       buttonContent={<FilterByAssigneeBtn assigneeValue={assigneeValue} />}
                       padding="2px 10px 2px 10px"
                       handleInputChange={async (newInputValue: string) => {
-                        if (!newInputValue) {
+                        if (newInputValue) {
+                          setLoading(true)
+                          const newAssignees = await getDebouncedFilteredAssignees(
+                            activeDebounceTimeoutId,
+                            setActiveDebounceTimeoutId,
+                            z.string().parse(token),
+                            newInputValue,
+                            filterOptions.type,
+                          )
+                          console.log('aaa handling fetch', loading)
+                          loading && setFilteredAssignee(newAssignees)
+                          setLoading(false)
+                        } else {
+                          setLoading(false)
                           setFilteredAssignee(initialAssignees)
                           return
                         }
-
-                        setDebouncedFilteredAssignees(
-                          activeDebounceTimeoutId,
-                          setActiveDebounceTimeoutId,
-                          setLoading,
-                          setFilteredAssignee,
-                          z.string().parse(token),
-                          newInputValue,
-                          filterOptions.type,
-                        )
                       }}
                       filterOption={(x: unknown) => x}
                     />

--- a/src/components/layouts/FilterBar.tsx
+++ b/src/components/layouts/FilterBar.tsx
@@ -33,6 +33,7 @@ export const FilterBar = ({ mode, updateViewModeSetting }: FilterBarProps) => {
   const { view, filteredAssigneeList, filterOptions, assignee, token, viewSettingsTemp } = useSelector(selectTaskBoard)
   const [filteredAssignee, setFilteredAssignee] = useState(filteredAssigneeList)
   const [loading, setLoading] = useState(false)
+  const [initialAssignees, setInitialAssignees] = useState(filteredAssignee)
   const viewMode = viewSettingsTemp ? viewSettingsTemp.viewMode : view
   const viewModeFilterOptions = viewSettingsTemp ? (viewSettingsTemp.filterOptions as IFilterOptions) : filterOptions //ViewSettingsTemp used to apply temp values of viewSettings in filterOptions and viewMode because clientSideUpdate applies outdated cached values to original view and filterOptions if navigated
 
@@ -40,11 +41,17 @@ export const FilterBar = ({ mode, updateViewModeSetting }: FilterBarProps) => {
     setFilteredAssignee(filteredAssigneeList)
   }, [filteredAssigneeList]) //to prevent filteredAssignee not updating when filteredAssigneeList changes when fetching assignee is delayed
 
+  useEffect(() => {
+    initialAssignees.length === 0 && setInitialAssignees(filteredAssignee)
+  }, [initialAssignees.length, filteredAssignee])
+
   const handleFilterOptionsChange = async (optionType: FilterOptions, newValue: string | null) => {
     store.dispatch(setFilterOptions({ optionType, newValue }))
     if (optionType === FilterOptions.TYPE) {
       const filterFunction = filterOptionsToAssigneeMap[newValue as string] || filterOptionsToAssigneeMap.default
-      setFilteredAssignee(filterFunction(assignee))
+      const newAssignees = filterFunction(assignee)
+      setFilteredAssignee(newAssignees)
+      setInitialAssignees(newAssignees)
     }
     //FilteredAssignee is also updated in the component's state and used in Selector's autocomplete to mitigate the time taken to update the store and fetch values to the Selector's autocomplete.
     const updatedFilterOptions = viewSettingsTemp
@@ -204,7 +211,7 @@ export const FilterBar = ({ mode, updateViewModeSetting }: FilterBarProps) => {
                       padding="2px 10px 2px 10px"
                       handleInputChange={async (newInputValue: string) => {
                         if (!newInputValue) {
-                          setFilteredAssignee(filteredAssigneeList)
+                          setFilteredAssignee(initialAssignees)
                           return
                         }
 
@@ -313,7 +320,7 @@ export const FilterBar = ({ mode, updateViewModeSetting }: FilterBarProps) => {
                   padding="2px 10px 2px 10px"
                   handleInputChange={async (newInputValue: string) => {
                     if (!newInputValue) {
-                      setFilteredAssignee(filteredAssigneeList)
+                      setFilteredAssignee(initialAssignees)
                       return
                     }
 

--- a/src/components/layouts/FilterBar.tsx
+++ b/src/components/layouts/FilterBar.tsx
@@ -1,43 +1,33 @@
-'use client'
-
-import { Box, CircularProgress, IconButton, Stack } from '@mui/material'
-import { AppMargin, SizeofAppMargin } from '@/hoc/AppMargin'
-import { useEffect, useState } from 'react'
-import store from '@/redux/store'
-import { setFilterOptions, setViewSettingsTemp, setViewSettings } from '@/redux/features/taskBoardSlice'
-import SearchBar from '@/components/searchBar'
-import Selector, { SelectorType } from '@/components/inputs/Selector'
-import { useHandleSelectorComponent } from '@/hooks/useHandleSelectorComponent'
-import { selectTaskBoard } from '@/redux/features/taskBoardSlice'
-import { useSelector } from 'react-redux'
-import {
-  FilterByOptions,
-  FilterOptions,
-  FilterOptionsKeywords,
-  IAssigneeCombined,
-  IFilterOptions,
-  View,
-} from '@/types/interfaces'
-import { CrossIcon, FilterByAsigneeIcon } from '@/icons'
-import { ViewModeSelector } from '../inputs/ViewModeSelector'
-import { FilterByAssigneeBtn } from '../buttons/FilterByAssigneeBtn'
-import FilterButtonGroup from '@/components/buttonsGroup/FilterButtonsGroup'
-import { selectAuthDetails } from '@/redux/features/authDetailsSlice'
-import { useFilter } from '@/hooks/useFilter'
-import { IUTokenSchema } from '@/types/common'
-import { NoAssigneeExtraOptions } from '@/utils/noAssignee'
-import { CreateViewSettingsDTO } from '@/types/dto/viewSettings.dto'
-import { z } from 'zod'
-import { setDebouncedFilteredAssignees } from '@/utils/users'
-import { MiniLoader } from '@/components/atoms/MiniLoader'
-import { checkAssignee } from '@/utils/assignee'
-import { filterOptionsToAssigneeMap, filterTypeToButtonIndexMap } from '@/types/objectMaps'
 import { UserRole } from '@/app/api/core/types/user'
+import { MiniLoader } from '@/components/atoms/MiniLoader'
+import { FilterByAssigneeBtn } from '@/components/buttons/FilterByAssigneeBtn'
+import FilterButtonGroup from '@/components/buttonsGroup/FilterButtonsGroup'
+import Selector, { SelectorType } from '@/components/inputs/Selector'
+import { ViewModeSelector } from '@/components/inputs/ViewModeSelector'
+import SearchBar from '@/components/searchBar'
+import { useFilter } from '@/hooks/useFilter'
+import { useHandleSelectorComponent } from '@/hooks/useHandleSelectorComponent'
+import { CrossIcon, FilterByAsigneeIcon } from '@/icons'
+import { selectAuthDetails } from '@/redux/features/authDetailsSlice'
+import { selectTaskBoard, setFilterOptions, setViewSettings, setViewSettingsTemp } from '@/redux/features/taskBoardSlice'
+import store from '@/redux/store'
+import { IUTokenSchema } from '@/types/common'
+import { CreateViewSettingsDTO } from '@/types/dto/viewSettings.dto'
+import { FilterOptions, FilterOptionsKeywords, IAssigneeCombined, IFilterOptions } from '@/types/interfaces'
+import { filterOptionsToAssigneeMap, filterTypeToButtonIndexMap } from '@/types/objectMaps'
+import { checkAssignee } from '@/utils/assignee'
+import { NoAssigneeExtraOptions } from '@/utils/noAssignee'
+import { setDebouncedFilteredAssignees } from '@/utils/users'
+import { Box, IconButton, Stack } from '@mui/material'
+import { useEffect, useState } from 'react'
+import { useSelector } from 'react-redux'
+import { z } from 'zod'
 
 interface FilterBarProps {
   mode: UserRole
   updateViewModeSetting: (payload: CreateViewSettingsDTO) => void
 }
+
 export const FilterBar = ({ mode, updateViewModeSetting }: FilterBarProps) => {
   const [activeDebounceTimeoutId, setActiveDebounceTimeoutId] = useState<NodeJS.Timeout | null>(null)
   const { view, filteredAssigneeList, filterOptions, assignee, token, viewSettingsTemp } = useSelector(selectTaskBoard)

--- a/src/components/layouts/FilterBar.tsx
+++ b/src/components/layouts/FilterBar.tsx
@@ -49,9 +49,7 @@ export const FilterBar = ({ mode, updateViewModeSetting }: FilterBarProps) => {
   }, [initialAssignees, latestFetchResults, filteredAssignee])
 
   useEffect(() => {
-    if (loading) {
-      setFilteredAssignee(latestFetchResults)
-    }
+    loading && setFilteredAssignee(latestFetchResults)
   }, [latestFetchResults, loading])
 
   const handleSelectInputChange = async (newInputValue: string) => {
@@ -64,13 +62,16 @@ export const FilterBar = ({ mode, updateViewModeSetting }: FilterBarProps) => {
         newInputValue,
         filterOptions.type,
       )
+      // Lets an effect handle the latest fetch update instead based on loading state
       setLatestFetchResults(newAssignees)
       setLoading(false)
-    } else {
-      setLoading(false)
-      setFilteredAssignee(initialAssignees)
       return
     }
+
+    // If the selector is clicked away from, set loading state to false right away
+    setLoading(false)
+    // Reset selector to have initial assignee list. DO NOT use filteredAssignee as it can cause inconsistencies after filteroption is changed
+    setFilteredAssignee(initialAssignees)
   }
 
   const handleFilterOptionsChange = async (optionType: FilterOptions, newValue: string | null) => {

--- a/src/utils/users.ts
+++ b/src/utils/users.ts
@@ -43,6 +43,27 @@ export const filterUsersByKeyword = (users: FilterableUser[], keyword: string): 
   return uniqueUsers
 }
 
+export const getDebouncedFilteredAssignees = (
+  activeDebounceTimeoutId: NodeJS.Timeout | null,
+  setActiveDebounceTimeoutId: Dispatch<SetStateAction<NodeJS.Timeout | null>>,
+  token: string,
+  newInputValue: string,
+  filterOptions?: string,
+): Promise<IAssigneeCombined[]> => {
+  if (activeDebounceTimeoutId) {
+    clearTimeout(activeDebounceTimeoutId)
+  }
+
+  return new Promise((resolve) => {
+    const newTimeoutId = setTimeout(async () => {
+      const newAssignees = await getAssigneeList(z.string().parse(token), newInputValue, 10000, '0', filterOptions)
+      const updatedAssignees = addTypeToAssignee(newAssignees)
+      resolve(updatedAssignees) // Resolve promise with result
+    }, 200)
+
+    setActiveDebounceTimeoutId(newTimeoutId)
+  })
+}
 export const setDebouncedFilteredAssignees = (
   activeDebounceTimeoutId: NodeJS.Timeout | null,
   setActiveDebounceTimeoutId: Dispatch<SetStateAction<NodeJS.Timeout | null>>,

--- a/src/utils/users.ts
+++ b/src/utils/users.ts
@@ -58,6 +58,7 @@ export const getDebouncedFilteredAssignees = (
     const newTimeoutId = setTimeout(async () => {
       const newAssignees = await getAssigneeList(z.string().parse(token), newInputValue, 10000, '0', filterOptions)
       const updatedAssignees = addTypeToAssignee(newAssignees)
+
       resolve(updatedAssignees) // Resolve promise with result
     }, 200)
 


### PR DESCRIPTION
### Tasks

- [OUT-821 | Opening "Filter by assignee" drop-down for second time shows incorrect assignees](https://linear.app/copilotplatforms/issue/OUT-821/opening-filter-by-assignee-drop-down-for-second-time-shows-incorrect)

### Changes

- [x] Fix issue where changing filter option for second time showed incorrect assignee state array 
- [x]  Remove unused imports & Organize imports via TS lsp
- [x] Fixed another pending issue where pending fetch updates our assignee list, even after the selector is clicked away from / unfocused 

### Testing Criteria

- [x] Video:
[Screencast from 2024-09-24 13-43-24.webm](https://github.com/user-attachments/assets/1f913fc1-6d17-4662-a6f4-6a366ea4ab2b)
