### PR TITLE
OUT-823 | Clients should be shown in drop-down by creation date. Most recent ones first.

### DIFF
--- a/src/app/api/users/users.service.ts
+++ b/src/app/api/users/users.service.ts
@@ -10,6 +10,7 @@ import { CompanyResponse, CopilotListArgs, FilterableUser } from '@/types/common
 import { filterUsersByKeyword } from '@/utils/users'
 import { z } from 'zod'
 import { FilterOptionsKeywords } from '@/types/interfaces'
+import { orderByRecentCreatedAt } from '@/utils/ordering'
 
 class UsersService extends BaseService {
   private copilot: CopilotAPI
@@ -58,7 +59,12 @@ class UsersService extends BaseService {
         : clientsWithCompanyData
     )?.slice(0, limit)
 
-    return { internalUsers: ius.data, clients: accessibleClients, companies: filteredCompanies }
+    return {
+      // CopilotAPI doesn't currently support sorting data, so manually sort them before returning a response
+      internalUsers: orderByRecentCreatedAt(ius.data),
+      clients: orderByRecentCreatedAt(accessibleClients),
+      companies: orderByRecentCreatedAt(filteredCompanies),
+    }
   }
 
   /**

--- a/src/app/api/users/users.service.ts
+++ b/src/app/api/users/users.service.ts
@@ -10,7 +10,7 @@ import { CompanyResponse, CopilotListArgs, FilterableUser } from '@/types/common
 import { filterUsersByKeyword } from '@/utils/users'
 import { z } from 'zod'
 import { FilterOptionsKeywords } from '@/types/interfaces'
-import { orderByRecentCreatedAt } from '@/utils/ordering'
+import { orderByRecentlyCreatedAt } from '@/utils/ordering'
 
 class UsersService extends BaseService {
   private copilot: CopilotAPI
@@ -61,9 +61,9 @@ class UsersService extends BaseService {
 
     return {
       // CopilotAPI doesn't currently support sorting data, so manually sort them before returning a response
-      internalUsers: orderByRecentCreatedAt(ius.data),
-      clients: orderByRecentCreatedAt(accessibleClients),
-      companies: orderByRecentCreatedAt(filteredCompanies),
+      internalUsers: orderByRecentlyCreatedAt(ius.data),
+      clients: orderByRecentlyCreatedAt(accessibleClients),
+      companies: orderByRecentlyCreatedAt(filteredCompanies),
     }
   }
 

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -71,6 +71,7 @@ export const ClientResponseSchema = z.object({
   avatarImageUrl: z.string().nullable(),
   customFields: z.record(z.string(), z.union([z.string(), z.array(z.string())]).nullable()).nullish(),
   fallbackColor: z.string().nullish(),
+  createdAt: z.string().datetime(),
 })
 export type ClientResponse = z.infer<typeof ClientResponseSchema>
 
@@ -85,6 +86,7 @@ export const CompanyResponseSchema = z.object({
   iconImageUrl: z.string().nullable(),
   fallbackColor: z.string().nullish(),
   isPlaceholder: z.boolean(),
+  createdAt: z.string().datetime(),
 })
 export type CompanyResponse = z.infer<typeof CompanyResponseSchema>
 
@@ -143,6 +145,7 @@ export const InternalUsersSchema = z.object({
   isClientAccessLimited: z.boolean(),
   companyAccessList: z.array(z.string()).nullable(),
   fallbackColor: z.string().nullish(),
+  createdAt: z.string().datetime(),
 })
 export type InternalUsers = z.infer<typeof InternalUsersSchema>
 

--- a/src/utils/ordering.ts
+++ b/src/utils/ordering.ts
@@ -1,0 +1,10 @@
+interface CreatedAtOrderable {
+  createdAt: string
+}
+
+export const orderByRecentCreatedAt = <T extends CreatedAtOrderable>(data: T[]) =>
+  data.sort((a: CreatedAtOrderable, b: CreatedAtOrderable) => {
+    const dateA = new Date(a.createdAt).getTime()
+    const dateB = new Date(b.createdAt).getTime()
+    return dateB - dateA
+  })

--- a/src/utils/ordering.ts
+++ b/src/utils/ordering.ts
@@ -2,7 +2,7 @@ interface CreatedAtOrderable {
   createdAt: string
 }
 
-export const orderByRecentCreatedAt = <T extends CreatedAtOrderable>(data: T[]) =>
+export const orderByRecentlyCreatedAt = <T extends CreatedAtOrderable>(data: T[]): T[] =>
   data.sort((a: CreatedAtOrderable, b: CreatedAtOrderable) => {
     const dateA = new Date(a.createdAt).getTime()
     const dateB = new Date(b.createdAt).getTime()


### PR DESCRIPTION
### Tasks

- [OUT-823 | Clients should be shown in drop-down by creation date. Most recent ones first.](https://linear.app/copilotplatforms/issue/OUT-823/clients-should-be-shown-in-drop-down-by-creation-date-most-recent-ones)

### Changes

- [x] Add reusable util to order items by created date
- [x] Implement orderByRecentCreatedAt for assignees in users API 

### Testing Criteria

- [x] 
![image](https://github.com/user-attachments/assets/989379e5-69f5-4dcf-9815-bd30f0fa73c5)

