### PR TITLE
OUT-861 MaxWidth is not right on images on smaller screen when screen is changed from devtools. Image max width greater in task creation.

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "react-dnd-touch-backend": "^16.0.1",
     "react-dom": "^18",
     "react-redux": "^9.1.0",
-    "tapwrite": "^1.1.46",
+    "tapwrite": "^1.1.47",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "react-dnd-touch-backend": "^16.0.1",
     "react-dom": "^18",
     "react-redux": "^9.1.0",
-    "tapwrite": "^1.1.44",
+    "tapwrite": "^1.1.46",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/src/hoc/ModifiedBackend.ts
+++ b/src/hoc/ModifiedBackend.ts
@@ -3,7 +3,7 @@ import { HTML5Backend } from 'react-dnd-html5-backend'
 import { TouchBackend } from 'react-dnd-touch-backend'
 
 const shouldIgnoreTarget = (target: any) => {
-  return target.closest('.ProseMirror') !== null
+  return target.closest('.tiptap') !== null
 }
 
 const createModifiedBackend = (Backend: BackendFactory, manager?: any, context?: any) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7066,7 +7066,16 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -7155,7 +7164,14 @@ string.prototype.trimstart@^1.0.8:
     define-properties "^1.2.1"
     es-object-atoms "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -7296,11 +7312,10 @@ tapable@^2.2.0:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"
   integrity sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==
 
-tapwrite@^1.1.44:
-  version "1.1.44"
-  resolved "https://registry.yarnpkg.com/tapwrite/-/tapwrite-1.1.44.tgz#84805cc9cbf368bff0b51a310a1781717387f779"
-  integrity sha512-iFuFPH3d/xV/gmCfZFnsbEL3Emng4T9iHAAYoA1njDkQMTorlzmRxt/Hwe5Y2+n981fZ8g50dBWaMzs4RNSLCA==
-
+tapwrite@^1.1.46:
+  version "1.1.46"
+  resolved "https://registry.yarnpkg.com/tapwrite/-/tapwrite-1.1.46.tgz#42ac13fdb299b00aef84df05f1a125f37d718751"
+  integrity sha512-rhdVKT7AoixOVstiKDXSP5GkyvFXWjUqli3jAwihkTfKreUP5fTkqocFPCjnFo5iOMzba6ak5ucrjBWwuQpZxA==
   dependencies:
     re-resizable "^6.10.0"
     tippy.js "^6.3.7"
@@ -7690,7 +7705,16 @@ word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -7312,10 +7312,10 @@ tapable@^2.2.0:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"
   integrity sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==
 
-tapwrite@^1.1.46:
-  version "1.1.46"
-  resolved "https://registry.yarnpkg.com/tapwrite/-/tapwrite-1.1.46.tgz#42ac13fdb299b00aef84df05f1a125f37d718751"
-  integrity sha512-rhdVKT7AoixOVstiKDXSP5GkyvFXWjUqli3jAwihkTfKreUP5fTkqocFPCjnFo5iOMzba6ak5ucrjBWwuQpZxA==
+tapwrite@^1.1.47:
+  version "1.1.47"
+  resolved "https://registry.yarnpkg.com/tapwrite/-/tapwrite-1.1.47.tgz#d9b07cc8e344527f6ca53ad21a3e227148ef2897"
+  integrity sha512-pYQoXnB9aXqG9+bVSprJWz75d/8weGNddXPThkK+fWYBa3fuHrtT1ovYNnyNUqmhdjqa7+yHo/lrBgXt+Eo6aA==
   dependencies:
     re-resizable "^6.10.0"
     tippy.js "^6.3.7"


### PR DESCRIPTION
### Tasks

- [MaxWidth is not right on images on smaller screen when screen is changed from devtools. Image max width greater in task creation.](https://linear.app/copilotplatforms/issue/OUT-861/maxwidth-is-not-right-on-images-on-smaller-screen-when-screen-is)

### Changes

- [x] recalculated maxWidth of images on resize observer too, so that if we insert bigger images then the max width would be calculated without considering the width of the scrollbar that came in task creation modal.
- [COMMIT](https://github.com/aatbip/tapwrite/pull/12/commits/ef819e1214b12e2415a3650ad93e4718074cf117) 

