### PR TITLE
OUT-821 | Opening "Filter by assignee" drop-down for second time shows incorrect assignees

### DIFF
--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -128,7 +128,6 @@ export class TasksService extends BaseService {
       },
       include: { workflowState: true },
     })
-    console.log('qqq new task', newTask)
 
     if (newTask) {
       // @todo move this logic to any pub/sub service like event bus
@@ -148,10 +147,8 @@ export class TasksService extends BaseService {
       )
       newTask.body && (await scrapImageService.updateTaskIdOfScrapImagesAfterCreation(newTask.body, newTask.id))
     }
-    console.log('qqq activity and scrap')
 
     await this.sendTaskCreateNotifications(newTask)
-    console.log('qqq create task notifications')
     return newTask
   }
 
@@ -473,7 +470,6 @@ export class TasksService extends BaseService {
 
   async sendTaskCreateNotifications(task: Task & { workflowState: WorkflowState }, isReassigned = false) {
     // If task is unassigned, there's nobody to send notifications to
-    console.log('debug:', task, isReassigned)
     if (!task.assigneeId) return
 
     // If task is assigned to the same person that created it, no need to notify yourself

--- a/src/app/detail/ui/Sidebar.tsx
+++ b/src/app/detail/ui/Sidebar.tsx
@@ -55,6 +55,7 @@ export const Sidebar = ({
   const [activeDebounceTimeoutId, setActiveDebounceTimeoutId] = useState<NodeJS.Timeout | null>(null)
   const [loading, setLoading] = useState(false)
   const [dueDate, setDueDate] = useState<Date | string | undefined>()
+  const [inputStatusValue, setInputStatusValue] = useState('')
 
   const { renderingItem: _statusValue, updateRenderingItem: updateStatusValue } = useHandleSelectorComponent({
     // item: selectedWorkflowState,
@@ -140,6 +141,8 @@ export const Sidebar = ({
             Assignee
           </StyledText>
           <Selector
+            inputStatusValue={inputStatusValue}
+            setInputStatusValue={setInputStatusValue}
             buttonWidth="100%"
             placeholder="Change assignee"
             getSelectedValue={(newValue) => {

--- a/src/app/ui/NewTaskForm.tsx
+++ b/src/app/ui/NewTaskForm.tsx
@@ -93,6 +93,8 @@ export const NewTaskForm = ({ handleCreate, handleClose, getSignedUrlUpload }: N
   // use temp state pattern so that we don't fall into an infinite loop of assigneeValue set -> trigger -> set
   const [tempAssignee, setTempAssignee] = useState<IAssigneeCombined | null>(assigneeValue)
 
+  const [inputStatusValue, setInputStatusValue] = useState('')
+
   const handleCreateWithAssignee = () => {
     if (!!tempAssignee?.id && !assignee.find((assignee) => assignee.id === tempAssignee.id)) {
       store.dispatch(setAssigneeList([...assignee, tempAssignee]))
@@ -125,6 +127,8 @@ export const NewTaskForm = ({ handleCreate, handleClose, getSignedUrlUpload }: N
             <Box>
               {advancedFeatureFlag && (
                 <Selector
+                  inputStatusValue={inputStatusValue}
+                  setInputStatusValue={setInputStatusValue}
                   getSelectedValue={(_newValue) => {
                     const newValue = _newValue as ITemplate
                     updateTemplateValue(newValue)
@@ -197,6 +201,8 @@ export const NewTaskForm = ({ handleCreate, handleClose, getSignedUrlUpload }: N
           </Box>
           <Stack alignSelf="flex-start">
             <Selector
+              inputStatusValue={inputStatusValue}
+              setInputStatusValue={setInputStatusValue}
               placeholder="Set assignee"
               getSelectedValue={(_newValue) => {
                 store.dispatch(setErrors({ key: CreateTaskErrors.ASSIGNEE, value: false }))

--- a/src/components/cards/ListViewTaskCard.tsx
+++ b/src/components/cards/ListViewTaskCard.tsx
@@ -31,6 +31,7 @@ export const ListViewTaskCard = ({
   const { assignee } = useSelector(selectTaskBoard)
 
   const [currentAssignee, setCurrentAssignee] = useState<IAssigneeCombined | undefined>(undefined)
+  const [inputStatusValue, setInputStatusValue] = useState('')
 
   useEffect(() => {
     if (assignee.length > 0) {
@@ -105,6 +106,8 @@ export const ListViewTaskCard = ({
 
             {currentAssignee ? (
               <Selector
+                inputStatusValue={inputStatusValue}
+                setInputStatusValue={setInputStatusValue}
                 placeholder="Change assignee"
                 disableOutline
                 disabled

--- a/src/components/inputs/Selector.tsx
+++ b/src/components/inputs/Selector.tsx
@@ -1,4 +1,4 @@
-import { Avatar, Box, Button, Popper, Stack, Typography } from '@mui/material'
+import { Box, Button, Popper, Stack, Typography } from '@mui/material'
 import { StyledAutocomplete } from '@/components/inputs/Autocomplete'
 import { statusIcons } from '@/utils/iconMatcher'
 import { useFocusableInput } from '@/hooks/useFocusableInput'
@@ -7,7 +7,6 @@ import { StyledTextField } from './TextField'
 import { WorkflowStateResponse } from '@/types/dto/workflowStates.dto'
 import { IAssigneeCombined, IExtraOption, ITemplate, UserTypesName } from '@/types/interfaces'
 import { TruncateMaxNumber } from '@/types/constants'
-
 import { truncateText } from '@/utils/truncateText'
 import { CopilotAvatar } from '@/components/atoms/CopilotAvatar'
 import { getAssigneeName } from '@/utils/assignee'
@@ -28,6 +27,8 @@ interface Prop {
   selectorType: SelectorType
   options: unknown[]
   buttonContent: ReactNode
+  inputStatusValue: string
+  setInputStatusValue: React.Dispatch<React.SetStateAction<string>>
   disabled?: boolean
   placeholder?: string
   extraOption?: IExtraOption
@@ -57,6 +58,8 @@ export default function Selector({
   buttonContent,
   disabled,
   placeholder = 'Change status...',
+  inputStatusValue,
+  setInputStatusValue,
   extraOption,
   extraOptionRenderer,
   disableOutline,
@@ -81,8 +84,6 @@ export default function Selector({
 
   const open = Boolean(anchorEl)
   const id = open ? 'autocomplete-popper' : ''
-
-  const [inputStatusValue, setInputStatusValue] = useState('')
 
   const setSelectorRef = useFocusableInput(open)
 

--- a/src/components/layouts/FilterBar.tsx
+++ b/src/components/layouts/FilterBar.tsx
@@ -54,21 +54,15 @@ export const FilterBar = ({ mode, updateViewModeSetting }: FilterBarProps) => {
 
   useEffect(() => {
     // Base these initial values off of first fetch of filteredAssignee
-    initialAssignees.length === 0 && setInitialAssignees(filteredAssignee)
-  }, [initialAssignees, filteredAssignee])
-
-  useEffect(() => {
+    if (!initialAssignees.length) {
+      setInitialAssignees(filteredAssignee)
+    }
     // When focus is taken away from selector, make sure that assignee search results are replaced
     if (filteredAssignee.length && initialAssignees.length && !inputStatusValue) {
+      loading && setLoading(false)
       setFilteredAssignee(initialAssignees)
     }
-  }, [filteredAssignee, initialAssignees, inputStatusValue])
-
-  useEffect(() => {
-    if (!inputStatusValue) {
-      loading && setLoading(false)
-    }
-  }, [inputStatusValue])
+  }, [initialAssignees, filteredAssignee, inputStatusValue])
 
   const handleFilterOptionsChange = async (optionType: FilterOptions, newValue: string | null) => {
     store.dispatch(setFilterOptions({ optionType, newValue }))

--- a/src/components/layouts/FilterBar.tsx
+++ b/src/components/layouts/FilterBar.tsx
@@ -68,7 +68,6 @@ export const FilterBar = ({ mode, updateViewModeSetting }: FilterBarProps) => {
     if (!inputStatusValue) {
       loading && setLoading(false)
     }
-    console.log('qqq input status value', inputStatusValue)
   }, [inputStatusValue])
 
   const handleFilterOptionsChange = async (optionType: FilterOptions, newValue: string | null) => {
@@ -242,7 +241,6 @@ export const FilterBar = ({ mode, updateViewModeSetting }: FilterBarProps) => {
                       buttonContent={<FilterByAssigneeBtn assigneeValue={assigneeValue} />}
                       padding="2px 10px 2px 10px"
                       handleInputChange={async (newInputValue: string) => {
-                        console.log('qqq', newInputValue)
                         if (!newInputValue) {
                           setFilteredAssignee(initialAssignees)
                           return


### PR DESCRIPTION
### Tasks

- [OUT-821 | Opening "Filter by assignee" drop-down for econd time shows incorrect assignees](https://linear.app/copilotplatforms/issue/OUT-821/opening-filter-by-assignee-drop-down-for-second-time-shows-incorrect)

### Changes

- [x] Fix issue where changing filter option for second time showed incorrect assignee state array 
- [x] Fixed another pending issue where pending fetch updates our assignee list, even after the selector is clicked away from / unfocused
- [x]  Remove few unused imports and minor refactors

### Testing Criteria

- [x] Video:
[Screencast from 2024-09-24 13-43-24.webm](https://github.com/user-attachments/assets/1f913fc1-6d17-4662-a6f4-6a366ea4ab2b)
