### PR TITLE
OUT-890 | IU/Client can see the tasks that are assigned to another IU/client in real-time

### DIFF
--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -128,7 +128,6 @@ export class TasksService extends BaseService {
       },
       include: { workflowState: true },
     })
-    console.log('qqq new task', newTask)
 
     if (newTask) {
       // @todo move this logic to any pub/sub service like event bus
@@ -148,10 +147,8 @@ export class TasksService extends BaseService {
       )
       newTask.body && (await scrapImageService.updateTaskIdOfScrapImagesAfterCreation(newTask.body, newTask.id))
     }
-    console.log('qqq activity and scrap')
 
     await this.sendTaskCreateNotifications(newTask)
-    console.log('qqq create task notifications')
     return newTask
   }
 
@@ -473,7 +470,6 @@ export class TasksService extends BaseService {
 
   async sendTaskCreateNotifications(task: Task & { workflowState: WorkflowState }, isReassigned = false) {
     // If task is unassigned, there's nobody to send notifications to
-    console.log('debug:', task, isReassigned)
     if (!task.assigneeId) return
 
     // If task is assigned to the same person that created it, no need to notify yourself

--- a/src/hoc/RealTime.tsx
+++ b/src/hoc/RealTime.tsx
@@ -90,7 +90,17 @@ export const RealTime = ({ children, task }: { children: ReactNode; task?: TaskR
         'postgres_changes',
         // Because of the way supabase realtime is architected for postgres_changes, it can only apply one filter at a time.
         // Ref: https://github.com/supabase/realtime-js/issues/97
-        { event: '*', schema: 'public', table: 'Tasks', filter: `assigneeId=eq.${userId}` },
+        {
+          event: '*',
+          schema: 'public',
+          table: 'Tasks',
+          filter:
+            userRole === AssigneeType.internalUser
+              ? `workspaceId=eq.${tokenPayload?.workspaceId}`
+              : // The reason we are explicitly using an assigneeId filter for clients is so they are not streamed
+                // tasks they don't have access to in the first place.
+                `assigneeId=eq.${userId}`,
+        },
         handleTaskRealTimeUpdates,
       )
       .subscribe()

--- a/src/hoc/RealTime.tsx
+++ b/src/hoc/RealTime.tsx
@@ -84,6 +84,11 @@ export const RealTime = ({ children, task }: { children: ReactNode; task?: TaskR
   }
 
   useEffect(() => {
+    if (!userId || !userRole) {
+      // Don't try to open a connection with `undefined` parameters
+      return
+    }
+
     const channel = supabase
       .channel('realtime tasks')
       .on(


### PR DESCRIPTION
### Tasks

- [OUT-890 | IU/Client can see the tasks that are assigned to another IU/client in real-time](https://linear.app/copilotplatforms/issue/OUT-890/iuclient-can-see-the-tasks-that-are-assigned-to-another-iuclient-in)

### Changes

- [x] Filter out tasks that a client does not have access to in real-time
- [x] Change single real-time filter for clients to filter by assigneeId instead of workspaceId because:

1. Client users aren't streamed tasks that belong to the workspace but are not assigned to them, so it is more secure.
2. There are a LOT less change events to listen and react to.

### Testing Criteria

- [x] Screencast:
[Screencast from 2024-10-17 17-50-04.webm](https://github.com/user-attachments/assets/c9843358-a74f-4c9d-bd42-1cda6344c2d6)
