### PR TITLE
OUT-898 | Task is not being set in Redux on redirects

### DIFF
--- a/src/app/detail/[task_id]/[user_type]/DetailStateUpdate.tsx
+++ b/src/app/detail/[task_id]/[user_type]/DetailStateUpdate.tsx
@@ -34,7 +34,6 @@ export const DetailStateUpdate = async ({ isRedirect, token, tokenPayload, task,
       token={token}
       viewSettings={viewSettings}
       tokenPayload={tokenPayload}
-      task={task}
     >
       {children}
     </ClientSideStateUpdate>


### PR DESCRIPTION
### Tasks

- [OUT-898 | Task is not being set in Redux on redirects](https://linear.app/copilotplatforms/issue/OUT-898/task-is-not-being-set-in-redux-on-redirects)

### Changes

- [x] Fix `task` state overwriting and removing entire `tasks` list in redux slice

### Testing Criteria

- [x] `isRedirect` is working fine now. SS:
![image](https://github.com/user-attachments/assets/ebd66000-7589-457b-82b4-b0acf41d7885)
- [x] Checked for regressions in normal task load - everything is working fine