### PR TITLE
OUT-899 | IU should not receive in-product notifications when they complete the task assigned to companies

### DIFF
--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -534,7 +534,12 @@ export class TasksService extends BaseService {
       updatedTask?.workflowState?.type === StateType.completed &&
       updatedTask.assigneeId
     ) {
-      if (updatedTask.assigneeType === AssigneeType.internalUser && updatedTask.assigneeId !== this.user.internalUserId) {
+      // Don't send task notifications if the IU created the task themselves
+      if (updatedTask.createdById === this.user.internalUserId) {
+        return
+      }
+
+      if (updatedTask.assigneeType === AssigneeType.internalUser) {
         await notificationService.create(NotificationTaskActions.CompletedByIU, updatedTask, { email: true })
         // TODO: Clean code and handle notification center notification deletions here instead
       } else if (updatedTask.assigneeType === AssigneeType.company) {


### PR DESCRIPTION
### Tasks

- [OUT-899 | IU should not receive in-product notifications when they complete the task assigned to companies](https://linear.app/copilotplatforms/issue/OUT-899/iu-should-not-receive-in-product-notifications-when-they-complete-the)

### Changes

- [x] Fix edge case where self-created check was not added to company task

### Testing Criteria

- [x] Screencast:
[Screencast from 2024-10-21 17-22-26.webm](https://github.com/user-attachments/assets/8d5bb8b9-2e11-45a8-a721-afe1159fed7d)

