### PR TITLE
OUT-914 | Add single quotes around taskName in comment email notification body

### DIFF
--- a/src/app/api/notification/notification.helpers.ts
+++ b/src/app/api/notification/notification.helpers.ts
@@ -62,12 +62,12 @@ export const getInProductNotificationDetails = (
     },
     [NotificationTaskActions.Commented]: {
       title: 'A comment was added',
-      body: `${actionUser} left a comment on the task ${task?.title}.`,
+      body: `${actionUser} left a comment on the task ‘${task?.title}’.`,
       ctaParams,
     },
     [NotificationTaskActions.Mentioned]: {
       title: 'You were mentioned in a task comment',
-      body: `You were mentioned in a comment on task ${task?.title} by ${actionUser}. To see details about the task, navigate to the Tasks App below. `,
+      body: `You were mentioned in a comment on task ‘${task?.title}’ by ${actionUser}. To see details about the task, navigate to the Tasks App below. `,
       ctaParams,
     },
   }
@@ -128,14 +128,14 @@ export const getEmailDetails = (
     [NotificationTaskActions.Commented]: {
       subject: 'A comment was added',
       header: 'A comment was added',
-      body: `${actionUser} left a comment on the task ${task?.title}. To view the comment, open the task below.`,
+      body: `${actionUser} left a comment on the task ‘${task?.title}’. To view the comment, open the task below.`,
       title: 'View Comment',
       ctaParams,
     },
     [NotificationTaskActions.Mentioned]: {
       subject: 'You were mentioned in a task comment',
       header: 'You were mentioned in a task comment',
-      body: `You were mentioned in a comment on task ${task?.title} by ${actionUser}. To see details about the task, navigate to the Tasks App below. `,
+      body: `You were mentioned in a comment on task ‘${task?.title}’ by ${actionUser}. To see details about the task, navigate to the Tasks App below. `,
       title: 'View task',
       ctaParams,
     },


### PR DESCRIPTION
### Tasks

- [OUT-914 | Add single quotes around taskName in comment email notification body](https://linear.app/copilotplatforms/issue/OUT-914/add-single-quotes-around-taskname-in-comment-email-notification-body)

### Changes

- [x] Add single colons to taskName 

### Testing Criteria

- [x] Added to email and in-product copy

### Notes
