### PR TITLE
OUT 945 Text in comment input box wraps mid word without including a hyphen

### DIFF
--- a/src/components/inputs/CommentInput.tsx
+++ b/src/components/inputs/CommentInput.tsx
@@ -74,7 +74,7 @@ export const CommentInput = ({ createComment, task_id }: Prop) => {
       <CommentCardContainer
         sx={{
           backgroundColor: (theme) => `${theme.color.base.white}`,
-          wordBreak: 'break-all',
+          wordBreak: 'break-word',
         }}
       >
         <Tapwrite


### PR DESCRIPTION
### Changes

- [x] Changes the work break css for comment input
