### PR TITLE
OUT-950 | OUT-923 | OUT-912 | OUT-911 | Notification Fixes for Tasks main

### DIFF
--- a/src/app/api/tasks/[id]/client/route.ts
+++ b/src/app/api/tasks/[id]/client/route.ts
@@ -1,4 +1,6 @@
 import { withErrorHandler } from '@/app/api/core/utils/withErrorHandler'
 import { clientUpdateTask } from '@/app/api/tasks/tasks.controller'
 
+export const maxDuration = 300
+
 export const PATCH = withErrorHandler(clientUpdateTask)

--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -379,9 +379,15 @@ export class TasksService extends BaseService {
     // --------------------------
     // --- Notifications Logic
     // --------------------------
+
+    // Cases:
+    // 1. Task has been moved back to a non-complete state from completed for client task
+    // 2. Task has been moved back to a non-complete state from completed for company task
+    // 3. Task has been moved to complete state for client task
+    // 4. Task has been moved to complete state for company task
     const notificationService = new NotificationService(this.user)
 
-    // If task has been moved back to another non-completed state from Completed
+    // Case 1 & 2 | If task has been moved back to another non-completed state from Completed
     if (
       updatedWorkflowState &&
       updatedWorkflowState.type !== StateType.completed &&
@@ -391,7 +397,7 @@ export class TasksService extends BaseService {
       await this.sendTaskCreateNotifications({ ...updatedTask, workflowState: updatedWorkflowState })
     }
 
-    // If task has been moved to completed from a non-complete state, remove all notification counts
+    // Case 3 & 4 | If task has been moved to completed from a non-complete state, remove all notification counts
     if (updatedWorkflowState?.type === StateType.completed && prevTask.workflowState.type !== StateType.completed) {
       if (updatedTask.assigneeType === AssigneeType.company) {
         const copilot = new CopilotAPI(this.user.token)


### PR DESCRIPTION
### Changes

- [x] Fix issue where product notification does not decrement for CU when IU completes a task
- [x] Fix issue with short-circuited IU notifications logic, which was blocking in-product notification creation  

### Testing Criteria

- [x] Screencast for OUT-923 | 
[Screencast from 2024-10-23 17-37-26.webm](https://github.com/user-attachments/assets/1ae67d5b-c790-4380-a706-368fef24007d)

- [x] Screencast for OUT-912 | 
[Screencast from 2024-10-23 17-34-35.webm](https://github.com/user-attachments/assets/ee7ff441-bf0b-4247-8be2-245965a167e2)

- [x] Screencast for OUT-911 | 
[Screencast from 2024-10-23 17-30-58.webm](https://github.com/user-attachments/assets/7e0cfcc1-cd3f-49bc-adcf-e6e61798c780)

- [x] Also tested most of the surface area for other regressions here