### PR TITLE
OUT-908 | Delete task for CU and decrement notification badge when the assignee company is deleted

### DIFF
--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -332,6 +332,7 @@ export class TasksService extends BaseService {
       where: { assigneeId, assigneeType, workspaceId: this.user.workspaceId },
     })
     await this.db.label.deleteMany({ where: { label: { in: labels } } })
+    return tasks
   }
 
   async clientUpdateTask(id: string, targetWorkflowStateId?: string | null) {

--- a/src/app/api/webhook/webhook.controller.ts
+++ b/src/app/api/webhook/webhook.controller.ts
@@ -1,7 +1,7 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { ClientUpdatedEventDataSchema, HANDLEABLE_EVENT } from '@/types/webhook'
 import authenticate from '@api/core/utils/authenticate'
 import WebhookService from '@api/webhook/webhook.service'
-import { ClientUpdatedEventDataSchema, HANDLEABLE_EVENT } from '@/types/webhook'
+import { NextRequest, NextResponse } from 'next/server'
 
 export const handleWebhookEvent = async (req: NextRequest) => {
   const user = await authenticate(req)

--- a/src/app/api/webhook/webhook.service.ts
+++ b/src/app/api/webhook/webhook.service.ts
@@ -140,7 +140,6 @@ class WebhookService extends BaseService {
         taskId: { in: taskIds },
       },
     })
-    console.log('c', clientTaskNotifications)
 
     const clientNotificationIds = clientTaskNotifications.map((notification) => notification.notificationId)
     if (clientNotificationIds.length) {


### PR DESCRIPTION
### Changes

- [x] Fix case where deleting company wouldn't decrement client notification

### Testing Criteria

- [x] Tested all webhook methods related to user deletion:

(refreshing to change notification chip count is not needed - it just seems to reflect a bit faster this way)

#### Company assigned
[Screencast from 2024-10-24 14-34-53.webm](https://github.com/user-attachments/assets/1d33d443-2a31-491a-a691-828d46ad1b37)

### Company unassigned
[Screencast from 2024-10-24 14-37-21.webm](https://github.com/user-attachments/assets/219d3d3d-c52d-48a0-8857-907b92964f71)

### Company reassigned
[Screencast from 2024-10-24 14-38-47.webm](https://github.com/user-attachments/assets/76d4dbb5-87d4-4e82-b54d-b65db7f01ff9)

### Company deleted
[Uploading Screencast from 2024-10-24 14-40-01.webm…]()


