### PR TITLE
OUT-949 | The initiator of the action shouldn't get a notification (if they are also the recipient)

### DIFF
--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -578,12 +578,16 @@ export class TasksService extends BaseService {
 
     // Case 4
     // --- Handle task moved from completed to incomplete IU logic
+    const isAssignedIU =
+      updatedTask.assigneeType === AssigneeType.internalUser && updatedTask.assigneeId === this.user.internalUserId
     if (
       prevTask.workflowState?.type === StateType.completed &&
       updatedTask.workflowState?.type !== StateType.completed &&
-      updatedTask.assigneeId
+      updatedTask.assigneeId &&
+      !isAssignedIU
     ) {
       // If IU decides to move a task back to an incomplete state, trigger client / company notifications
+      // UNLESS they are moving back an IU task assigned to themselves
       await this.sendTaskCreateNotifications(updatedTask)
     }
   }

--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -578,13 +578,13 @@ export class TasksService extends BaseService {
 
     // Case 4
     // --- Handle task moved from completed to incomplete IU logic
-    const isAssignedIU =
+    const isSelfAssignedIU =
       updatedTask.assigneeType === AssigneeType.internalUser && updatedTask.assigneeId === this.user.internalUserId
     if (
       prevTask.workflowState?.type === StateType.completed &&
       updatedTask.workflowState?.type !== StateType.completed &&
       updatedTask.assigneeId &&
-      !isAssignedIU
+      !isSelfAssignedIU
     ) {
       // If IU decides to move a task back to an incomplete state, trigger client / company notifications
       // UNLESS they are moving back an IU task assigned to themselves


### PR DESCRIPTION
### Changes

- [x] Don't send IU taskCreated notification if they are moving task assigned to themselves to an incomplete state

### Testing Criteria

- [x] Tested with preview notifications
Screencast:
[Screencast from 2024-10-28 20-28-17.webm](https://github.com/user-attachments/assets/aed036b9-04f9-4b1a-bc3a-62543989e58a)
