### PR TITLE
OUT-976 | Match CU's profile image when writing a comment

### DIFF
--- a/src/app/detail/ui/ActivityLog.tsx
+++ b/src/app/detail/ui/ActivityLog.tsx
@@ -7,6 +7,8 @@ import { WorkflowStateUpdatedSchema } from '@/app/api/activity-logs/schemas/Work
 import { ActivityType } from '@prisma/client'
 import { useSelector } from 'react-redux'
 import { selectTaskBoard } from '@/redux/features/taskBoardSlice'
+import { CopilotAvatar } from '@/components/atoms/CopilotAvatar'
+import { IAssigneeCombined } from '@/types/interfaces'
 
 interface Prop {
   log: LogResponse
@@ -60,16 +62,26 @@ export const ActivityLog = ({ log }: Prop) => {
   return (
     <Stack direction="row" columnGap={4} position="relative">
       <VerticalLine />
-      <Avatar
-        src={log?.initiator?.avatarImageUrl || 'user'}
-        alt={log?.initiator?.givenName}
+      <CopilotAvatar
+        width="24px"
+        height="24px"
+        fontSize="13px"
+        currentAssignee={log?.initiator as unknown as IAssigneeCombined}
         sx={{
-          width: '25px',
-          height: '25px',
           border: (theme) => `1.1px solid ${theme.color.gray[200]}`,
-          fontSize: '13px',
         }}
       />
+
+      {/* <Avatar */}
+      {/*   src={log?.initiator?.avatarImageUrl || 'user'} */}
+      {/*   alt={log?.initiator?.givenName} */}
+      {/*   sx={{ */}
+      {/*     width: '25px', */}
+      {/*     height: '25px', */}
+      {/*     border: (theme) => `1.1px solid ${theme.color.gray[200]}`, */}
+      {/*     fontSize: '13px', */}
+      {/*   }} */}
+      {/* /> */}
       <TypographyContainer direction="row" columnGap={1}>
         {assignee.find((el) => el.id === log?.initiator?.id) ? (
           <BoldTypography>

--- a/src/app/detail/ui/Comments.tsx
+++ b/src/app/detail/ui/Comments.tsx
@@ -3,6 +3,8 @@ import { VerticalLine } from './styledComponent'
 import { CommentCard } from '@/components/cards/CommentCard'
 import { CreateComment } from '@/types/dto/comment.dto'
 import { LogResponse } from '@/app/api/activity-logs/schemas/LogResponseSchema'
+import { CopilotAvatar } from '@/components/atoms/CopilotAvatar'
+import { IAssigneeCombined } from '@/types/interfaces'
 
 interface Prop {
   comment: LogResponse
@@ -15,17 +17,17 @@ export const Comments = ({ comment, createComment, deleteComment, task_id }: Pro
   return (
     <Stack id={comment.id} direction="row" columnGap={2} position="relative">
       <VerticalLine />
-      <Avatar
-        alt={comment?.initiator?.givenName}
-        src={comment?.initiator?.avatarImageUrl || 'user'}
+      <CopilotAvatar
+        width="24px"
+        height="24px"
+        fontSize="13px"
+        currentAssignee={comment.initiator as unknown as IAssigneeCombined}
         sx={{
-          width: '25px',
-          height: '25px',
-          marginTop: '5px',
           border: (theme) => `1.1px solid ${theme.color.gray[200]}`,
-          fontSize: '13px',
+          marginTop: '5px',
         }}
       />
+
       <CommentCard comment={comment} createComment={createComment} deleteComment={deleteComment} task_id={task_id} />
     </Stack>
   )

--- a/src/components/atoms/CopilotAvatar.tsx
+++ b/src/components/atoms/CopilotAvatar.tsx
@@ -3,6 +3,7 @@ import { copilotTheme } from '@/theme/copilot'
 import { IAssigneeCombined } from '@/types/interfaces'
 import { getAssigneeName } from '@/utils/assignee'
 import { Avatar, SxProps } from '@mui/material'
+import { Theme } from '@mui/material/styles/createTheme'
 
 interface CopilotAvatarProps {
   currentAssignee?: IAssigneeCombined
@@ -11,6 +12,7 @@ interface CopilotAvatarProps {
   height?: string
   isSmall?: boolean
   fontSize?: string
+  sx?: SxProps<any>
 }
 
 export const CopilotAvatar = ({
@@ -20,8 +22,10 @@ export const CopilotAvatar = ({
   height = '20px',
   isSmall = false,
   fontSize = '14px',
+  sx,
 }: CopilotAvatarProps) => {
   const avatarSx: SxProps = {
+    ...sx,
     width,
     height,
     alignItems: 'center',

--- a/src/components/inputs/CommentInput.tsx
+++ b/src/components/inputs/CommentInput.tsx
@@ -1,16 +1,17 @@
 'use client'
 
-import { Avatar, Box, IconButton, InputAdornment, Stack } from '@mui/material'
-import { useState, useEffect } from 'react'
 import { CommentCardContainer } from '@/app/detail/ui/styledComponent'
-import { CreateComment } from '@/types/dto/comment.dto'
-import { useSelector } from 'react-redux'
-import { selectTaskDetails } from '@/redux/features/taskDetailsSlice'
-import { getMentionsList } from '@/utils/getMentionList'
-import { Tapwrite } from 'tapwrite'
-import { ArrowUpward } from '@mui/icons-material'
+import { CopilotAvatar } from '@/components/atoms/CopilotAvatar'
 import { selectAuthDetails } from '@/redux/features/authDetailsSlice'
 import { selectTaskBoard } from '@/redux/features/taskBoardSlice'
+import { selectTaskDetails } from '@/redux/features/taskDetailsSlice'
+import { CreateComment } from '@/types/dto/comment.dto'
+import { getMentionsList } from '@/utils/getMentionList'
+import { ArrowUpward } from '@mui/icons-material'
+import { IconButton, InputAdornment, Stack } from '@mui/material'
+import { useEffect, useState } from 'react'
+import { useSelector } from 'react-redux'
+import { Tapwrite } from 'tapwrite'
 
 interface Prop {
   createComment: (postCommentPayload: CreateComment) => void
@@ -78,16 +79,14 @@ export const CommentInput = ({ createComment, task_id }: Prop) => {
 
   return (
     <Stack direction="row" columnGap={2} alignItems="flex-start">
-      <Avatar
-        alt="user"
-        src={currentUserDetails?.avatarImageUrl}
+      <CopilotAvatar
+        width="24px"
+        height="24px"
+        fontSize="13px"
+        currentAssignee={currentUserDetails}
         sx={{
-          width: '25px',
-          height: '25px',
           border: (theme) => `1.1px solid ${theme.color.gray[200]}`,
-          borderRadius: '9999px',
           marginTop: '5px',
-          fontSize: '13px',
         }}
       />
       <CommentCardContainer


### PR DESCRIPTION
### Changes

- [x] Modify existing `CopilotAvatar` component to make it suitable for rending activity log / comments avatars
- [x] Match CU's profile image when writing a comment for - 1. avatar 2. initials
- [x] Match CU's and IU's fallback color for initials background

### Testing Criteria

- [x] Screenshot with both avatar + initials state:
![image](https://github.com/user-attachments/assets/39a78b15-ed18-4a43-a953-26d60c42192c)
