### PR TITLE
OUT-972, OUT-984 Set up proper Supabase Storage folder structure in SupabaseService

### DIFF
--- a/prisma/migrations/20241107073207_scrap_imagesto_scrap_attachments/migration.sql
+++ b/prisma/migrations/20241107073207_scrap_imagesto_scrap_attachments/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `workspaceId` to the `ScrapImages` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "ScrapImages" ADD COLUMN     "workspaceId" VARCHAR(32) NOT NULL;

--- a/prisma/migrations/20241107081546_scrap_attachments/migration.sql
+++ b/prisma/migrations/20241107081546_scrap_attachments/migration.sql
@@ -1,0 +1,36 @@
+/*
+  Warnings:
+
+  - You are about to drop the `ScrapImages` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "ScrapImages" DROP CONSTRAINT "ScrapImages_taskId_fkey";
+
+-- DropTable
+DROP TABLE "ScrapImages";
+
+-- CreateTable
+CREATE TABLE "ScrapAttachments" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "filePath" TEXT NOT NULL,
+    "taskId" UUID,
+    "createdAt" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMPTZ NOT NULL,
+    "deletedAt" TIMESTAMPTZ,
+    "workspaceId" VARCHAR(32) NOT NULL,
+
+    CONSTRAINT "ScrapAttachments_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ScrapAttachments_filePath_key" ON "ScrapAttachments"("filePath");
+
+-- CreateIndex
+CREATE INDEX "ScrapAttachments_createdAt_idx" ON "ScrapAttachments"("createdAt");
+
+-- CreateIndex
+CREATE INDEX "ScrapAttachments_filePath_idx" ON "ScrapAttachments"("filePath");
+
+-- AddForeignKey
+ALTER TABLE "ScrapAttachments" ADD CONSTRAINT "ScrapAttachments_taskId_fkey" FOREIGN KEY ("taskId") REFERENCES "Tasks"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema/scrapAttachment.prisma
+++ b/prisma/schema/scrapAttachment.prisma
@@ -1,14 +1,17 @@
-model ScrapImage {
+model ScrapAttachment {
   id          String       @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   filePath    String       @unique
-  taskId      String?       @db.Uuid
-  task        Task?         @relation(fields: [taskId], references: [id], onDelete: Cascade)
+  taskId      String?      @db.Uuid
+  task        Task?        @relation(fields: [taskId], references: [id], onDelete: Cascade)
   createdAt   DateTime     @default(now()) @db.Timestamptz()
   updatedAt   DateTime     @updatedAt @db.Timestamptz()
   deletedAt   DateTime?    @db.Timestamptz()
+  workspaceId String       @db.VarChar(32)
+
+
 
   @@index([createdAt])
   @@index([filePath])
-  @@map("ScrapImages")
+  @@map("ScrapAttachments")
 
 }

--- a/prisma/schema/task.prisma
+++ b/prisma/schema/task.prisma
@@ -18,7 +18,7 @@ model Task {
   attachments     Attachment[]
   activityLog     ActivityLog[]
   comments        Comment[]
-  scrapImages     ScrapImage[]
+  scrapAttachments     ScrapAttachment[]
 
   assignedAt               DateTime?
   completedAt              DateTime?

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -53,8 +53,8 @@ export const createMultipleAttachments = async (token: string, attachments: Crea
   })
 }
 
-export async function getSignedUrlUpload(token: string, fileName: string) {
-  const res = await fetch(`${apiUrl}/api/attachments/upload?token=${token}&fileName=${fileName}`)
+export async function getSignedUrlUpload(token: string, filePath: string, fileName: string) {
+  const res = await fetch(`${apiUrl}/api/attachments/upload?token=${token}&fileName=${fileName}&filePath=${filePath}`)
 
   const data = await res.json()
   return data.signedUrl

--- a/src/app/api/attachments/attachments.controller.ts
+++ b/src/app/api/attachments/attachments.controller.ts
@@ -49,12 +49,14 @@ export const deleteAttachment = async (req: NextRequest, { params: { id } }: IdP
 
 export const getSignedUrlUpload = async (req: NextRequest) => {
   const fileName = req.nextUrl.searchParams.get('fileName')
-  if (!fileName) {
-    throw new APIError(httpStatus.BAD_REQUEST, 'fileName is required')
+  const filePath = req.nextUrl.searchParams.get('filePath')
+
+  if (!fileName || !filePath) {
+    throw new APIError(httpStatus.BAD_REQUEST, 'fileName/filePath is required')
   }
   const user = await authenticate(req)
   const attachmentsService = new AttachmentsService(user)
-  const signedUrl = await attachmentsService.signUrlUpload(fileName)
+  const signedUrl = await attachmentsService.signUrlUpload(filePath, fileName)
   return NextResponse.json({ signedUrl })
 }
 

--- a/src/app/api/attachments/attachments.service.ts
+++ b/src/app/api/attachments/attachments.service.ts
@@ -8,6 +8,7 @@ import { supabaseBucket } from '@/config'
 import APIError from '@api/core/exceptions/api'
 import httpStatus from 'http-status'
 import { SupabaseService } from '@api/core/services/supabase.service'
+import { signedUrlTtl } from '@/types/constants'
 
 export class AttachmentsService extends BaseService {
   async getAttachments(taskId: string) {
@@ -62,11 +63,11 @@ export class AttachmentsService extends BaseService {
     return deletedAttachment
   }
 
-  async signUrlUpload(fileName: string) {
+  async signUrlUpload(filePath: string, fileName: string) {
     const policyGate = new PoliciesService(this.user)
     const supabase = new SupabaseService()
     policyGate.authorize(UserAction.Create, Resource.Attachments)
-    const { data, error } = await supabase.supabase.storage.from(supabaseBucket).createSignedUploadUrl(fileName)
+    const { data, error } = await supabase.supabase.storage.from(supabaseBucket + filePath).createSignedUploadUrl(fileName)
     if (error) {
       throw new APIError(httpStatus.BAD_REQUEST)
     }
@@ -77,7 +78,8 @@ export class AttachmentsService extends BaseService {
     const policyGate = new PoliciesService(this.user)
     const supabase = new SupabaseService()
     policyGate.authorize(UserAction.Create, Resource.Attachments)
-    const { data } = await supabase.supabase.storage.from(supabaseBucket).createSignedUrl(filePath, 60) // only 60 seconds expiry time here for testing purposes
+
+    const { data } = await supabase.supabase.storage.from(supabaseBucket).createSignedUrl(filePath, signedUrlTtl)
     return data?.signedUrl
   }
 }

--- a/src/app/api/core/services/policies.service.ts
+++ b/src/app/api/core/services/policies.service.ts
@@ -17,7 +17,7 @@ export class PoliciesService extends BaseService {
       [Resource.Users]: [],
       [Resource.Attachments]: [UserAction.Read],
       [Resource.Comment]: [UserAction.Read, UserAction.Create],
-      [Resource.ScrapImages]: [],
+      [Resource.ScrapAttachments]: [],
       [Resource.Notifications]: [UserAction.Update],
     },
   }

--- a/src/app/api/core/types/api.ts
+++ b/src/app/api/core/types/api.ts
@@ -9,7 +9,7 @@ export enum Resource {
   Users = 'User',
   Attachments = 'Attachments',
   Comment = 'Comments',
-  ScrapImages = 'ScrapImages',
+  ScrapAttachments = 'ScrapAttachments',
   Notifications = 'Notifications',
 }
 

--- a/src/app/api/workers/scrap-images/scrap-images.service.ts
+++ b/src/app/api/workers/scrap-images/scrap-images.service.ts
@@ -1,7 +1,7 @@
 import { subWeeks, isBefore, subMinutes } from 'date-fns'
 import { SupabaseService } from '@/app/api/core/services/supabase.service'
 import { supabaseBucket } from '@/config'
-import { PrismaClient, ScrapImage } from '@prisma/client'
+import { PrismaClient, ScrapAttachment } from '@prisma/client'
 import DBClient from '@/lib/db'
 import APIError from '@/app/api/core/exceptions/api'
 
@@ -10,7 +10,7 @@ export class ScrapImageService {
     const oneWeekAgo = subWeeks(new Date(), 1)
 
     const db: PrismaClient = DBClient.getInstance()
-    const scrapImages = await db.scrapImage.findMany({
+    const scrapImages = await db.scrapAttachment.findMany({
       where: {
         updatedAt: {
           lt: oneWeekAgo, //apply oneWeekAgo. three minutes ago is used for testing
@@ -25,7 +25,7 @@ export class ScrapImageService {
     const tasks = await db.task.findMany({
       where: {
         id: {
-          in: scrapImages.map((image: ScrapImage) => image.taskId).filter((taskId): taskId is string => !taskId),
+          in: scrapImages.map((image: ScrapAttachment) => image.taskId).filter((taskId): taskId is string => !taskId),
         },
       },
     })

--- a/src/app/detail/ui/TaskEditor.tsx
+++ b/src/app/detail/ui/TaskEditor.tsx
@@ -19,7 +19,7 @@ import { generateRandomString } from '@/utils/generateRandomString'
 import { TaskResponse } from '@/types/dto/tasks.dto'
 import { ScrapImageRequest } from '@/types/common'
 
-import { deleteEditorAttachmentsHandler, uploadImageHandler } from '@/utils/inlineImage'
+import { deleteEditorAttachmentsHandler, uploadAttachmentHandler } from '@/utils/inlineAttachment'
 import AttachmentLayout from '@/components/AttachmentLayout'
 
 interface Prop {
@@ -169,7 +169,7 @@ export const TaskEditor = ({
           placeholder="Add description..."
           uploadFn={async (file) => {
             setActiveUploads((prev) => prev + 1)
-            const t = await uploadImageHandler(file, token ?? '', task_id)
+            const t = await uploadAttachmentHandler(file, token ?? '', task.workspaceId, task_id)
             setActiveUploads((prev) => prev - 1)
             return t
           }}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -91,10 +91,6 @@ export default async function Main({ searchParams }: { searchParams: { token: st
         </DndWrapper>
 
         <ModalNewTaskForm
-          getSignedUrlUpload={async (fileName: string) => {
-            'use server'
-            return await getSignedUrlUpload(token, fileName)
-          }}
           handleCreateMultipleAttachments={async (attachments: CreateAttachmentRequest[]) => {
             'use server'
             await createMultipleAttachments(token, attachments)

--- a/src/app/ui/Modal_NewTaskForm.tsx
+++ b/src/app/ui/Modal_NewTaskForm.tsx
@@ -8,7 +8,6 @@ import {
 } from '@/redux/features/createTaskSlice'
 import { selectTaskBoard } from '@/redux/features/taskBoardSlice'
 import store from '@/redux/store'
-import { bulkRemoveAttachments } from '@/utils/bulkRemoveAttachments'
 import { Modal } from '@mui/material'
 import { useSelector } from 'react-redux'
 import { handleCreate } from '../actions'
@@ -19,10 +18,8 @@ import { FilterOptions, ISignedUrlUpload } from '@/types/interfaces'
 import dayjs from 'dayjs'
 
 export const ModalNewTaskForm = ({
-  getSignedUrlUpload,
   handleCreateMultipleAttachments,
 }: {
-  getSignedUrlUpload: (fileName: string) => Promise<ISignedUrlUpload>
   handleCreateMultipleAttachments: (attachments: CreateAttachmentRequest[]) => Promise<void>
 }) => {
   const { token, filterOptions } = useSelector(selectTaskBoard)
@@ -66,7 +63,6 @@ export const ModalNewTaskForm = ({
           }
         }}
         handleClose={handleModalClose}
-        getSignedUrlUpload={getSignedUrlUpload}
       />
     </Modal>
   )

--- a/src/utils/inlineAttachment.ts
+++ b/src/utils/inlineAttachment.ts
@@ -9,14 +9,20 @@ import { getFilePathFromUrl } from '@/utils/signedUrlReplacer'
 
 import { getSignedUrlUpload, getSignedUrlFile } from '@/app/actions'
 
-export const uploadImageHandler = async (file: File, token: string, task_id: string | null): Promise<string | undefined> => {
+export const uploadAttachmentHandler = async (
+  file: File,
+  token: string,
+  workspaceId: string,
+  task_id: string | null,
+): Promise<string | undefined> => {
   const supabaseActions = new SupabaseActions()
-
+  const filePath = `/${workspaceId}${task_id ? `/${task_id}` : ''}`
   const fileName = generateRandomString(file.name)
-  const signedUrl: ISignedUrlUpload = await getSignedUrlUpload(token, fileName)
-  const { filePayload, error } = await supabaseActions.uploadAttachment(file, signedUrl, task_id)
+  const signedUrl: ISignedUrlUpload = await getSignedUrlUpload(token, filePath, fileName)
+  const { filePayload, error } = await supabaseActions.uploadAttachment(file, signedUrl, workspaceId, task_id)
+
   if (filePayload) {
-    const url = await getSignedUrlFile(token ?? '', filePayload?.filePath ?? '')
+    const url = await getSignedUrlFile(token ?? '', `${filePath}/${filePayload.filePath}`)
     return url
   }
 

--- a/src/utils/signedUrlReplacer.ts
+++ b/src/utils/signedUrlReplacer.ts
@@ -1,6 +1,3 @@
-import { Prisma, PrismaClient, StateType, WorkflowState } from '@prisma/client'
-import { DefaultArgs } from '@prisma/client/runtime/library'
-
 export async function replaceImageSrc(htmlString: string, getSignedUrl: (filePath: string) => Promise<string | undefined>) {
   const imgTagRegex = /<img\s+[^>]*src="([^"]+)"[^>]*>/g //expression used to match all img tags in provided HTML string.
   const replacements: { originalSrc: string; newUrl: string }[] = []
@@ -35,6 +32,16 @@ export function getFilePathFromUrl(url: string) {
     return null
   }
 }
+
+export function getAbsoluteFileName(filePath: string): string | null {
+  try {
+    const parts = filePath.split('/')
+    return parts.pop() || null
+  } catch (error) {
+    console.error('Invalid filepath:', error)
+    return null
+  }
+} //utility function to extract fileName from the whole filePath
 
 export const extractImgSrcs = (body: string) => {
   const parser = new DOMParser()


### PR DESCRIPTION
### Tasks

- [Set up proper Supabase Storage folder structure in SupabaseService](https://linear.app/copilotplatforms/issue/OUT-972/set-up-proper-supabase-storage-folder-structure-in-supabaseservice)
- [Code cleaning for m4](https://linear.app/copilotplatforms/issue/OUT-984/code-cleaning-for-m4)

### Changes

- [x] refactored code : removed attachments code from before. (some cleaning still remaining here) .
- [x] supabase folder structure : created a clean supabase folder structure following this pattern in supabase bucket for attachments and inline images : bucketName/workspaceId/taskId/file. Before, every files were stored under bucket
- [x] scrap table name refactored and utility functions refactored which were shared by inline images and attachments. 

### Testing Criteria

![Screenshot from 2024-11-07 18-00-49](https://github.com/user-attachments/assets/63bfc81a-de1c-417e-b342-0c98cc62c2af)


