### PR TITLE
OUT-990 Attachment button is missing on editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "react-dom": "^18",
     "react-redux": "^9.1.0",
     "swr": "^2.2.5",
-    "tapwrite": "1.1.65",
+    "tapwrite": "1.1.67",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/src/app/detail/ui/TaskEditor.tsx
+++ b/src/app/detail/ui/TaskEditor.tsx
@@ -175,6 +175,7 @@ export const TaskEditor = ({
           }}
           deleteEditorAttachments={(url) => deleteEditorAttachmentsHandler(url, token ?? '', task_id)}
           attachmentLayout={(props) => <AttachmentLayout {...props} />}
+          addAttachmentButton
         />
       </Box>
 

--- a/src/components/AttachmentLayout.tsx
+++ b/src/components/AttachmentLayout.tsx
@@ -19,6 +19,10 @@ interface AttachmentLayoutProps {
 const AttachmentLayout: React.FC<AttachmentLayoutProps> = ({ selected, src, fileName, fileSize, fileType, isUploading }) => {
   const { handleDownload, isDownloading } = useDownloadFile()
 
+  const onDownloadClick = () => {
+    handleDownload(src, fileName)
+  }
+
   const containerStyles: SxProps<Theme> = {
     padding: '4px 8px',
     marginTop: '4px !important',
@@ -84,7 +88,7 @@ const AttachmentLayout: React.FC<AttachmentLayoutProps> = ({ selected, src, file
           </Stack>
         </Stack>
         <Box className="download-btn" sx={downloadBtnStyles}>
-          <IconBtn buttonBackground="#ffffff" handleClick={() => handleDownload(src, fileName)} icon={<DownloadBtn />} />
+          <IconBtn buttonBackground="#ffffff" handleClick={onDownloadClick} icon={<DownloadBtn />} />
         </Box>
       </Stack>
     )

--- a/yarn.lock
+++ b/yarn.lock
@@ -7000,10 +7000,10 @@ tapable@^2.2.0:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"
   integrity sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==
 
-tapwrite@1.1.65:
-  version "1.1.65"
-  resolved "https://registry.yarnpkg.com/tapwrite/-/tapwrite-1.1.65.tgz#5a80bc056263f2b9cddde9b94ec6b44026e0f539"
-  integrity sha512-5TCFKH/nI0SJ5MqNav4nfrwpaalBehGD5v0JI5n6CES+exEA16V+M4vhlsETyk3MN327SkI+QsvtlLIDYnGuHg==
+tapwrite@1.1.67:
+  version "1.1.67"
+  resolved "https://registry.yarnpkg.com/tapwrite/-/tapwrite-1.1.67.tgz#b9a04140d9da5ec0a9a72152c2f0c5ee13c2384c"
+  integrity sha512-TdlrlgbDdXVjLaLpd3QhLC00OZbEmy7UH0DvLl7Vy3sW9j4c7sHI+sI1SbNPrdMEoTUbln3wS26ZN9IAJbsr6g==
   dependencies:
     re-resizable "^6.10.0"
     tippy.js "^6.3.7"


### PR DESCRIPTION
### Tasks

- [Attachment button is missing on editor](https://linear.app/copilotplatforms/issue/OUT-990/attachment-button-is-missing-on-editor)

### Changes

- [x] Added attachment button on the bottom right of the editor on new tapwrite update. 


### Testing Criteria

![image](https://github.com/user-attachments/assets/f668647f-c0e0-44a9-85de-8dcc60361c5a)
Tested on attachments and images. 

