### PR TITLE
OUT-996, OUT-993 Inconsistent focus states for images and attachments

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "react-dom": "^18",
     "react-redux": "^9.1.0",
     "swr": "^2.2.5",
-    "tapwrite": "1.1.67",
+    "tapwrite": "1.1.70",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7000,10 +7000,10 @@ tapable@^2.2.0:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"
   integrity sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==
 
-tapwrite@1.1.67:
-  version "1.1.67"
-  resolved "https://registry.yarnpkg.com/tapwrite/-/tapwrite-1.1.67.tgz#b9a04140d9da5ec0a9a72152c2f0c5ee13c2384c"
-  integrity sha512-TdlrlgbDdXVjLaLpd3QhLC00OZbEmy7UH0DvLl7Vy3sW9j4c7sHI+sI1SbNPrdMEoTUbln3wS26ZN9IAJbsr6g==
+tapwrite@1.1.70:
+  version "1.1.70"
+  resolved "https://registry.yarnpkg.com/tapwrite/-/tapwrite-1.1.70.tgz#587c10755ec7f7447402d256bcee52b55fd2d232"
+  integrity sha512-zSwsIxe0O4IPXfo8jR141LECRQj3VGqzv3PPLr7K6sTy6wafw7/0U80UPWkAoGoSkEiAXday8rCq/axfZhboIA==
   dependencies:
     re-resizable "^6.10.0"
     tippy.js "^6.3.7"


### PR DESCRIPTION
### Tasks

- [Images and attachments should not show a selected state for CUs](https://linear.app/copilotplatforms/issue/OUT-993/images-and-attachments-should-not-show-a-selected-state-for-cus)
- [Inconsistent focus states for images and attachments](https://linear.app/copilotplatforms/issue/OUT-996/inconsistent-focus-states-for-images-and-attachments)

### Changes

- [x] disabled selection of images and attachments for CUs.
- [x] Kept consistent selection borders for attachments and images.


### Testing Criteria

- [LOOM](https://www.loom.com/share/a0cf9b798f6e4f00971ab49445b3cd7e) 


