### PR TITLE
OUT-995, OUT-997 Remove white space between task description and activity feed

### DIFF
--- a/src/app/detail/ui/TaskEditor.tsx
+++ b/src/app/detail/ui/TaskEditor.tsx
@@ -165,7 +165,7 @@ export const TaskEditor = ({
           content={updateDetail}
           getContent={handleDetailChange}
           readonly={userType === UserType.CLIENT_USER}
-          editorClass="tapwrite-details-page"
+          editorClass=""
           placeholder="Add description..."
           uploadFn={async (file) => {
             setActiveUploads((prev) => prev + 1)

--- a/src/app/detail/ui/styledComponent.tsx
+++ b/src/app/detail/ui/styledComponent.tsx
@@ -40,7 +40,7 @@ export const StyledTiptapDescriptionWrapper = styled(Box)(({ theme }) => ({
   borderBottom: `1px solid ${theme.color.borders.borderDisabled}`,
   width: '100%',
   //the min height is set here to avoid flickering issue of the activity log which loads before Tapwrite
-  minHeight: '20vh',
+  // minHeight: '15vh',
   '.tiptap *': {
     color: theme.color.gray[500],
   },

--- a/src/app/detail/ui/styledComponent.tsx
+++ b/src/app/detail/ui/styledComponent.tsx
@@ -39,8 +39,6 @@ export const StyledBox = styled(Box)(({ theme }) => ({
 export const StyledTiptapDescriptionWrapper = styled(Box)(({ theme }) => ({
   borderBottom: `1px solid ${theme.color.borders.borderDisabled}`,
   width: '100%',
-  //the min height is set here to avoid flickering issue of the activity log which loads before Tapwrite
-  // minHeight: '15vh',
   '.tiptap *': {
     color: theme.color.gray[500],
   },

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,10 +4,6 @@
   box-sizing: border-box;
 }
 
-.tapwrite-details-page {
-  min-height: 20vh;
-}
-
 a {
   text-decoration: none;
 }

--- a/src/components/AttachmentLayout.tsx
+++ b/src/components/AttachmentLayout.tsx
@@ -24,7 +24,7 @@ const AttachmentLayout: React.FC<AttachmentLayoutProps> = ({ selected, src, file
   }
 
   const containerStyles: SxProps<Theme> = {
-    padding: '4px 8px',
+    padding: { sm: '4px 8px', md: '4px 12px 4px 8px' },
     marginTop: '4px !important',
     marginBottom: '4px',
     maxWidth: '100%',


### PR DESCRIPTION
### Tasks

- [Remove white space between task description and activity feed](https://linear.app/copilotplatforms/issue/OUT-995/remove-white-space-between-task-description-and-activity-feed)
- [Update the right padding on Desktop for an attachment card from 8px to 12px](https://linear.app/copilotplatforms/issue/OUT-997/update-the-right-padding-on-desktop-for-an-attachment-card-from-8px-to)

### Changes

- [x] removed min height set on task description's detail section 
- [x] added right padding of 12 px for attachment card on desktop devices 

### Testing Criteria

- [LOOM](https://www.loom.com/share/ca32ff53e23b46d7ae243ac9885b5106)

