### PR TITLE
OUT-1000 When using /upload or the upload button, the image files should show as attachment

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "react-dom": "^18",
     "react-redux": "^9.1.0",
     "swr": "^2.2.5",
-    "tapwrite": "1.1.70",
+    "tapwrite": "1.1.72",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "react-dom": "^18",
     "react-redux": "^9.1.0",
     "swr": "^2.2.5",
-    "tapwrite": "1.1.72",
+    "tapwrite": "1.1.73",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/src/app/detail/ui/TaskEditor.tsx
+++ b/src/app/detail/ui/TaskEditor.tsx
@@ -21,6 +21,7 @@ import { ScrapImageRequest } from '@/types/common'
 
 import { deleteEditorAttachmentsHandler, uploadImageHandler } from '@/utils/inlineImage'
 import AttachmentLayout from '@/components/AttachmentLayout'
+import { MAX_UPLOAD_LIMIT } from '@/constants/attachments'
 
 interface Prop {
   task_id: string
@@ -176,6 +177,7 @@ export const TaskEditor = ({
           deleteEditorAttachments={(url) => deleteEditorAttachmentsHandler(url, token ?? '', task_id)}
           attachmentLayout={AttachmentLayout}
           addAttachmentButton
+          maxUploadLimit={MAX_UPLOAD_LIMIT}
         />
       </Box>
 

--- a/src/app/ui/NewTaskForm.tsx
+++ b/src/app/ui/NewTaskForm.tsx
@@ -48,6 +48,7 @@ import { MiniLoader } from '@/components/atoms/MiniLoader'
 import { getAssigneeName } from '@/utils/assignee'
 import { deleteEditorAttachmentsHandler, uploadImageHandler } from '@/utils/inlineImage'
 import AttachmentLayout from '@/components/AttachmentLayout'
+import { MAX_UPLOAD_LIMIT } from '@/constants/attachments'
 
 const supabaseActions = new SupabaseActions()
 
@@ -346,6 +347,7 @@ const NewTaskFormInputs = () => {
           uploadFn={(file) => uploadImageHandler(file, token ?? '', null)}
           deleteEditorAttachments={(url) => deleteEditorAttachmentsHandler(url, token ?? '', null)}
           attachmentLayout={AttachmentLayout}
+          maxUploadLimit={MAX_UPLOAD_LIMIT}
         />
       </Stack>
     </>

--- a/src/components/AttachmentLayout.tsx
+++ b/src/components/AttachmentLayout.tsx
@@ -24,13 +24,14 @@ const AttachmentLayout: React.FC<AttachmentLayoutProps> = ({ selected, src, file
   }
 
   const containerStyles: SxProps<Theme> = {
-    padding: { sm: '4px 8px', md: '4px 12px 4px 8px' },
+    padding: { xs: '4px 8px', md: '4px 12px 4px 8px' },
     marginTop: '4px !important',
     marginBottom: '4px',
     maxWidth: '100%',
     borderRadius: '4px',
     background: '#fff',
     boxShadow: '0px 0px 24px 0px rgba(0, 0, 0, 0.07)',
+    border: (theme) => `1px solid ${theme.color.gray[selected ? 600 : 150]}`,
 
     '@media (max-width: 600px)': {
       '&:active': {

--- a/src/constants/attachments.ts
+++ b/src/constants/attachments.ts
@@ -1,0 +1,1 @@
+export const MAX_UPLOAD_LIMIT = 100 * 1024 * 1024

--- a/yarn.lock
+++ b/yarn.lock
@@ -7000,10 +7000,10 @@ tapable@^2.2.0:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"
   integrity sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==
 
-tapwrite@1.1.72:
-  version "1.1.72"
-  resolved "https://registry.yarnpkg.com/tapwrite/-/tapwrite-1.1.72.tgz#8abb70d90f8d8f7cf6d31a58fbf049ea6c40bec7"
-  integrity sha512-fNiB4PpaZrpX9GvFlHoiEWpSk589b5C/g58dAtjsdiVtT2VoCjf+5UQGUIWbo+ccGH1g6SQ44iHEssDzKd92iA==
+tapwrite@1.1.73:
+  version "1.1.73"
+  resolved "https://registry.yarnpkg.com/tapwrite/-/tapwrite-1.1.73.tgz#b5079cadb95f50c8d776d0a1c76819db698c36c6"
+  integrity sha512-paS516xj42h9RI/IUE8iLTosn6eRu1/LiZQicvnQC+kCV78p86F9Xtwno5FZ3yQO2QjktkBRzp69hbEuEawRVg==
   dependencies:
     re-resizable "^6.10.0"
     tippy.js "^6.3.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7000,10 +7000,10 @@ tapable@^2.2.0:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"
   integrity sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==
 
-tapwrite@1.1.70:
-  version "1.1.70"
-  resolved "https://registry.yarnpkg.com/tapwrite/-/tapwrite-1.1.70.tgz#587c10755ec7f7447402d256bcee52b55fd2d232"
-  integrity sha512-zSwsIxe0O4IPXfo8jR141LECRQj3VGqzv3PPLr7K6sTy6wafw7/0U80UPWkAoGoSkEiAXday8rCq/axfZhboIA==
+tapwrite@1.1.72:
+  version "1.1.72"
+  resolved "https://registry.yarnpkg.com/tapwrite/-/tapwrite-1.1.72.tgz#8abb70d90f8d8f7cf6d31a58fbf049ea6c40bec7"
+  integrity sha512-fNiB4PpaZrpX9GvFlHoiEWpSk589b5C/g58dAtjsdiVtT2VoCjf+5UQGUIWbo+ccGH1g6SQ44iHEssDzKd92iA==
   dependencies:
     re-resizable "^6.10.0"
     tippy.js "^6.3.7"


### PR DESCRIPTION
### Changes

- [x] tapwrite update. [PR](https://github.com/aatbip/tapwrite/pull/14)
- [x] uploading image through floating menu upload commands sets the image through attachments extension and displays it in attachment card.
- [x] design fix on attachment card hover state.

### Testing Criteria

- [LOOM](https://www.loom.com/share/448dd04a60624862aa5f719afb9eedc7)
