### PR TITLE
OUT-972 | Set up proper Supabase Storage folder structure in SupabaseService

### DIFF
--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -53,8 +53,8 @@ export const createMultipleAttachments = async (token: string, attachments: Crea
   })
 }
 
-export async function getSignedUrlUpload(token: string, fileName: string) {
-  const res = await fetch(`${apiUrl}/api/attachments/upload?token=${token}&fileName=${fileName}`)
+export async function getSignedUrlUpload(token: string, fileName: string, filePath: string) {
+  const res = await fetch(`${apiUrl}/api/attachments/upload?token=${token}&fileName=${fileName}&filePath=${filePath}`)
 
   const data = await res.json()
   return data.signedUrl

--- a/src/app/api/attachments/attachments.controller.ts
+++ b/src/app/api/attachments/attachments.controller.ts
@@ -49,12 +49,14 @@ export const deleteAttachment = async (req: NextRequest, { params: { id } }: IdP
 
 export const getSignedUrlUpload = async (req: NextRequest) => {
   const fileName = req.nextUrl.searchParams.get('fileName')
-  if (!fileName) {
-    throw new APIError(httpStatus.BAD_REQUEST, 'fileName is required')
-  }
+  if (!fileName) throw new APIError(httpStatus.BAD_REQUEST, 'fileName is required')
+
+  const filePath = req.nextUrl.searchParams.get('filePath')
+  if (!filePath) throw new APIError(httpStatus.BAD_REQUEST, 'filePath is required')
+
   const user = await authenticate(req)
   const attachmentsService = new AttachmentsService(user)
-  const signedUrl = await attachmentsService.signUrlUpload(fileName)
+  const signedUrl = await attachmentsService.signUrlUpload(fileName, filePath)
   return NextResponse.json({ signedUrl })
 }
 

--- a/src/app/api/attachments/attachments.service.ts
+++ b/src/app/api/attachments/attachments.service.ts
@@ -8,6 +8,7 @@ import { supabaseBucket } from '@/config'
 import APIError from '@api/core/exceptions/api'
 import httpStatus from 'http-status'
 import { SupabaseService } from '@api/core/services/supabase.service'
+import { signedUrlTtl } from '@/constants/attachments'
 
 export class AttachmentsService extends BaseService {
   async getAttachments(taskId: string) {
@@ -62,11 +63,14 @@ export class AttachmentsService extends BaseService {
     return deletedAttachment
   }
 
-  async signUrlUpload(fileName: string) {
+  async signUrlUpload(fileName: string, filePath: string) {
     const policyGate = new PoliciesService(this.user)
     const supabase = new SupabaseService()
     policyGate.authorize(UserAction.Create, Resource.Attachments)
-    const { data, error } = await supabase.supabase.storage.from(supabaseBucket).createSignedUploadUrl(fileName)
+
+    const { data, error } = await supabase.supabase.storage
+      .from(supabaseBucket)
+      .createSignedUploadUrl(filePath + '/' + fileName)
     if (error) {
       throw new APIError(httpStatus.BAD_REQUEST)
     }
@@ -77,7 +81,7 @@ export class AttachmentsService extends BaseService {
     const policyGate = new PoliciesService(this.user)
     const supabase = new SupabaseService()
     policyGate.authorize(UserAction.Create, Resource.Attachments)
-    const { data } = await supabase.supabase.storage.from(supabaseBucket).createSignedUrl(filePath, 60) // only 60 seconds expiry time here for testing purposes
+    const { data } = await supabase.supabase.storage.from(supabaseBucket).createSignedUrl(filePath, signedUrlTtl)
     return data?.signedUrl
   }
 }

--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -1,10 +1,11 @@
 import { ScrapImageService } from '@/app/api/scrap-images/scrap-images.service'
 import { supabaseBucket } from '@/config'
+import { signedUrlTtl } from '@/constants/attachments'
 import { ClientResponse, CompanyResponse, InternalUsers, NotificationCreatedResponseSchema } from '@/types/common'
-import { signedUrlTtl } from '@/types/constants'
 import { CreateTaskRequest, UpdateTaskRequest } from '@/types/dto/tasks.dto'
 import { CopilotAPI } from '@/utils/CopilotAPI'
-import { replaceImageSrc } from '@/utils/signedUrlReplacer'
+import { getFilePathFromUrl, replaceImageSrc } from '@/utils/signedUrlReplacer'
+import { SupabaseActions } from '@/utils/SupabaseActions'
 import { TaskAssignedSchema } from '@api/activity-logs/schemas/TaskAssignedSchema'
 import { TaskCreatedSchema } from '@api/activity-logs/schemas/TaskCreatedSchema'
 import { WorkflowStateUpdatedSchema } from '@api/activity-logs/schemas/WorkflowStateUpdatedSchema'
@@ -145,7 +146,7 @@ export class TasksService extends BaseService {
           dueData: newTask.dueDate,
         }),
       )
-      newTask.body && (await scrapImageService.updateTaskIdOfScrapImagesAfterCreation(newTask.body, newTask.id))
+      newTask.body && (await this.updateTaskIdOfAttachmentsAfterCreation(newTask.body, newTask.id))
     }
 
     await this.sendTaskCreateNotifications(newTask)
@@ -306,6 +307,42 @@ export class TasksService extends BaseService {
     // ...In case requirements change later again
     // const notificationService = new NotificationService(this.user)
     // await notificationService.deleteInternalUserNotificationForTask(id)
+  }
+
+  private async updateTaskIdOfAttachmentsAfterCreation(htmlString: string, task_id: string) {
+    const imgTagRegex = /<img\s+[^>]*src="([^"]+)"[^>]*>/g //expression used to match all img srcs in provided HTML string.
+    const attachmentTagRegex = /<\s*[a-zA-Z]+\s+[^>]*data-type="attachment"[^>]*src="([^"]+)"[^>]*>/g //expression used to match all attachment srcs in provided HTML string.
+    let match
+    const filePaths: string[] = []
+    const copyAttachmentPromises: Promise<void>[] = []
+    while ((match = imgTagRegex.exec(htmlString)) !== null || (match = attachmentTagRegex.exec(htmlString)) !== null) {
+      const originalSrc = match[1]
+      const filePath = getFilePathFromUrl(originalSrc)
+      const fileName = filePath?.split('/').pop()
+      if (!fileName) {
+        console.error('Could not extract filename from filepath')
+        return
+      }
+
+      if (filePath) {
+        const newFilePath = `${this.user.workspaceId}/${task_id}/${fileName}`
+        const supabaseActions = new SupabaseActions()
+        copyAttachmentPromises.push(supabaseActions.moveAttachment(filePath, newFilePath))
+        filePaths.push(filePath)
+      }
+    }
+    await Promise.all(copyAttachmentPromises)
+
+    await this.db.scrapImage.updateMany({
+      where: {
+        filePath: {
+          in: filePaths,
+        },
+      },
+      data: {
+        taskId: task_id,
+      },
+    })
   }
 
   async setNewLastActivityLogUpdated(taskId: string) {

--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -146,7 +146,15 @@ export class TasksService extends BaseService {
           dueData: newTask.dueDate,
         }),
       )
-      newTask.body && (await this.updateTaskIdOfAttachmentsAfterCreation(newTask.body, newTask.id))
+      if (newTask.body) {
+        const newBody = await this.updateTaskIdOfAttachmentsAfterCreation(newTask.body, newTask.id)
+        await this.db.task.update({
+          where: { id: newTask.id },
+          data: {
+            body: newBody,
+          },
+        })
+      }
     }
 
     await this.sendTaskCreateNotifications(newTask)
@@ -313,26 +321,52 @@ export class TasksService extends BaseService {
     const imgTagRegex = /<img\s+[^>]*src="([^"]+)"[^>]*>/g //expression used to match all img srcs in provided HTML string.
     const attachmentTagRegex = /<\s*[a-zA-Z]+\s+[^>]*data-type="attachment"[^>]*src="([^"]+)"[^>]*>/g //expression used to match all attachment srcs in provided HTML string.
     let match
-    const filePaths: string[] = []
+    const replacements: { originalSrc: string; newUrl: string }[] = []
+
+    const newFilePaths: { originalSrc: string; newFilePath: string }[] = []
     const copyAttachmentPromises: Promise<void>[] = []
-    while ((match = imgTagRegex.exec(htmlString)) !== null || (match = attachmentTagRegex.exec(htmlString)) !== null) {
+    const matches: { originalSrc: string; filePath: string; fileName: string }[] = []
+
+    while ((match = imgTagRegex.exec(htmlString)) !== null) {
       const originalSrc = match[1]
       const filePath = getFilePathFromUrl(originalSrc)
       const fileName = filePath?.split('/').pop()
-      if (!fileName) {
-        console.error('Could not extract filename from filepath')
-        return
-      }
-
-      if (filePath) {
-        const newFilePath = `${this.user.workspaceId}/${task_id}/${fileName}`
-        const supabaseActions = new SupabaseActions()
-        copyAttachmentPromises.push(supabaseActions.moveAttachment(filePath, newFilePath))
-        filePaths.push(filePath)
+      if (filePath && fileName) {
+        matches.push({ originalSrc, filePath, fileName })
       }
     }
+
+    while ((match = attachmentTagRegex.exec(htmlString)) !== null) {
+      const originalSrc = match[1]
+      const filePath = getFilePathFromUrl(originalSrc)
+      const fileName = filePath?.split('/').pop()
+      if (filePath && fileName) {
+        matches.push({ originalSrc, filePath, fileName })
+      }
+    }
+
+    for (const { originalSrc, filePath, fileName } of matches) {
+      const newFilePath = `${this.user.workspaceId}/${task_id}/${fileName}`
+      const supabaseActions = new SupabaseActions()
+      copyAttachmentPromises.push(supabaseActions.moveAttachment(filePath, newFilePath))
+      newFilePaths.push({ originalSrc, newFilePath })
+    }
+
     await Promise.all(copyAttachmentPromises)
 
+    const signedUrlPromises = newFilePaths.map(async ({ originalSrc, newFilePath }) => {
+      const newUrl = await this.getSignedUrl(newFilePath)
+      if (newUrl) {
+        replacements.push({ originalSrc, newUrl })
+      }
+    })
+
+    await Promise.all(signedUrlPromises)
+
+    for (const { originalSrc, newUrl } of replacements) {
+      htmlString = htmlString.replace(originalSrc, newUrl)
+    }
+    const filePaths = newFilePaths.map(({ newFilePath }) => newFilePath)
     await this.db.scrapImage.updateMany({
       where: {
         filePath: {
@@ -343,6 +377,7 @@ export class TasksService extends BaseService {
         taskId: task_id,
       },
     })
+    return htmlString
   }
 
   async setNewLastActivityLogUpdated(taskId: string) {
@@ -642,6 +677,7 @@ export class TasksService extends BaseService {
     const { data } = await supabase.supabase.storage.from(supabaseBucket).createSignedUrl(filePath, signedUrlTtl)
 
     const url = data?.signedUrl
+
     return url
   } // used to replace urls for images in task body
 }

--- a/src/app/detail/[task_id]/[user_type]/page.tsx
+++ b/src/app/detail/[task_id]/[user_type]/page.tsx
@@ -38,10 +38,10 @@ import { CustomLink } from '@/hoc/CustomLink'
 import { DetailStateUpdate } from '@/app/detail/[task_id]/[user_type]/DetailStateUpdate'
 import { SilentError } from '@/components/templates/SilentError'
 import { z } from 'zod'
-import { signedUrlTtl } from '@/types/constants'
 import { ActivityWrapper } from '@/app/detail/ui/ActivityWrapper'
 import { DeletedTaskRedirectPage } from '@/components/layouts/DeletedTaskRedirectPage'
 import { UserRole } from '@/app/api/core/types/user'
+import { signedUrlTtl } from '@/constants/attachments'
 
 async function getOneTask(token: string, taskId: string): Promise<TaskResponse> {
   const res = await fetch(`${apiUrl}/api/tasks/${taskId}?token=${token}`, {

--- a/src/app/detail/ui/TaskEditor.tsx
+++ b/src/app/detail/ui/TaskEditor.tsx
@@ -1,26 +1,21 @@
 'use client'
 
 import { StyledTextField } from '@/components/inputs/TextField'
-import { selectTaskDetails, setShowConfirmDeleteModal } from '@/redux/features/taskDetailsSlice'
-import { Box, Modal } from '@mui/material'
-import { useEffect, useState, useCallback } from 'react'
-import { useSelector } from 'react-redux'
 import { ConfirmDeleteUI } from '@/components/layouts/ConfirmDeleteUI'
-import store from '@/redux/store'
-import { upload } from '@vercel/blob/client'
-import { CreateAttachmentRequest } from '@/types/dto/attachments.dto'
-import { ISignedUrlUpload, UserType } from '@/types/interfaces'
-import { Tapwrite } from 'tapwrite'
 import { useDebounce, useDebounceWithCancel } from '@/hooks/useDebounce'
-import { useRouter } from 'next/navigation'
 import { selectTaskBoard } from '@/redux/features/taskBoardSlice'
-import { SupabaseActions } from '@/utils/SupabaseActions'
-import { generateRandomString } from '@/utils/generateRandomString'
+import { selectTaskDetails, setShowConfirmDeleteModal } from '@/redux/features/taskDetailsSlice'
+import store from '@/redux/store'
+import { CreateAttachmentRequest } from '@/types/dto/attachments.dto'
 import { TaskResponse } from '@/types/dto/tasks.dto'
-import { ScrapImageRequest } from '@/types/common'
+import { UserType } from '@/types/interfaces'
+import { Box, Modal } from '@mui/material'
+import { useCallback, useEffect, useState } from 'react'
+import { useSelector } from 'react-redux'
+import { Tapwrite } from 'tapwrite'
 
-import { deleteEditorAttachmentsHandler, uploadImageHandler } from '@/utils/inlineImage'
 import AttachmentLayout from '@/components/AttachmentLayout'
+import { deleteEditorAttachmentsHandler, uploadImageHandler } from '@/utils/inlineImage'
 
 interface Prop {
   task_id: string
@@ -125,6 +120,15 @@ export const TaskEditor = ({
     debouncedResetTypingFlag()
   }
 
+  const uploadFn = token
+    ? async (file: File) => {
+        setActiveUploads((prev) => prev + 1)
+        const fileUrl = await uploadImageHandler(file, token ?? '', task.workspaceId, task_id)
+        setActiveUploads((prev) => prev - 1)
+        return fileUrl
+      }
+    : undefined
+
   return (
     <>
       <StyledTextField
@@ -167,12 +171,7 @@ export const TaskEditor = ({
           readonly={userType === UserType.CLIENT_USER}
           editorClass=""
           placeholder="Add description..."
-          uploadFn={async (file) => {
-            setActiveUploads((prev) => prev + 1)
-            const t = await uploadImageHandler(file, token ?? '', task_id)
-            setActiveUploads((prev) => prev - 1)
-            return t
-          }}
+          uploadFn={uploadFn}
           deleteEditorAttachments={(url) => deleteEditorAttachmentsHandler(url, token ?? '', task_id)}
           attachmentLayout={AttachmentLayout}
           addAttachmentButton

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -91,10 +91,6 @@ export default async function Main({ searchParams }: { searchParams: { token: st
         </DndWrapper>
 
         <ModalNewTaskForm
-          getSignedUrlUpload={async (fileName: string) => {
-            'use server'
-            return await getSignedUrlUpload(token, fileName)
-          }}
           handleCreateMultipleAttachments={async (attachments: CreateAttachmentRequest[]) => {
             'use server'
             await createMultipleAttachments(token, attachments)

--- a/src/app/ui/Modal_NewTaskForm.tsx
+++ b/src/app/ui/Modal_NewTaskForm.tsx
@@ -19,10 +19,8 @@ import { FilterOptions, ISignedUrlUpload } from '@/types/interfaces'
 import dayjs from 'dayjs'
 
 export const ModalNewTaskForm = ({
-  getSignedUrlUpload,
   handleCreateMultipleAttachments,
 }: {
-  getSignedUrlUpload: (fileName: string) => Promise<ISignedUrlUpload>
   handleCreateMultipleAttachments: (attachments: CreateAttachmentRequest[]) => Promise<void>
 }) => {
   const { token, filterOptions } = useSelector(selectTaskBoard)
@@ -66,7 +64,6 @@ export const ModalNewTaskForm = ({
           }
         }}
         handleClose={handleModalClose}
-        getSignedUrlUpload={getSignedUrlUpload}
       />
     </Modal>
   )

--- a/src/app/ui/NewTaskForm.tsx
+++ b/src/app/ui/NewTaskForm.tsx
@@ -1,63 +1,53 @@
+import AttachmentLayout from '@/components/AttachmentLayout'
+import { CopilotAvatar } from '@/components/atoms/CopilotAvatar'
+import { MiniLoader } from '@/components/atoms/MiniLoader'
 import { PrimaryBtn } from '@/components/buttons/PrimaryBtn'
 import { SecondaryBtn } from '@/components/buttons/SecondaryBtn'
-import { SelectorType } from '@/components/inputs/Selector'
-import Selector from '@/components/inputs/Selector'
+import { AttachmentInput } from '@/components/inputs/AttachmentInput'
+import { DatePickerComponent } from '@/components/inputs/DatePickerComponent'
+import Selector, { SelectorType } from '@/components/inputs/Selector'
+import { WorkflowStateSelector } from '@/components/inputs/Selector-WorkflowState'
 import { StyledTextField } from '@/components/inputs/TextField'
+import { advancedFeatureFlag } from '@/config'
 import { AppMargin, SizeofAppMargin } from '@/hoc/AppMargin'
+import { useHandleSelectorComponent } from '@/hooks/useHandleSelectorComponent'
 import { ArrowLinkIcon, AssigneePlaceholderSmall, CloseIcon, TemplateIconSm } from '@/icons'
-import {
-  clearCreateTaskFields,
-  removeOneAttachment,
-  selectCreateTask,
-  setCreateTaskFields,
-  setErrors,
-  setShowModal,
-} from '@/redux/features/createTaskSlice'
+import { selectAuthDetails } from '@/redux/features/authDetailsSlice'
+import { selectCreateTask, setCreateTaskFields, setErrors, setShowModal } from '@/redux/features/createTaskSlice'
+import { selectTaskBoard, setAssigneeList } from '@/redux/features/taskBoardSlice'
+import { selectCreateTemplate } from '@/redux/features/templateSlice'
 import store from '@/redux/store'
-import { Box, Stack, Typography, styled } from '@mui/material'
-import { useEffect, useState } from 'react'
+import { WorkflowStateResponse } from '@/types/dto/workflowStates.dto'
 import {
   CreateTaskErrors,
   FilterOptions,
+  HandleSelectorComponentModes,
   IAssigneeCombined,
   ISignedUrlUpload,
   ITemplate,
-  HandleSelectorComponentModes,
 } from '@/types/interfaces'
-import { useHandleSelectorComponent } from '@/hooks/useHandleSelectorComponent'
-import { useSelector } from 'react-redux'
-import { selectTaskBoard, setAssigneeList } from '@/redux/features/taskBoardSlice'
-import { WorkflowStateResponse } from '@/types/dto/workflowStates.dto'
-import { getAssigneeTypeCorrected } from '@/utils/getAssigneeTypeCorrected'
-import { useRouter } from 'next/navigation'
-import { selectCreateTemplate } from '@/redux/features/templateSlice'
-import { NoAssigneeExtraOptions } from '@/utils/noAssignee'
-import { upload } from '@vercel/blob/client'
-import { AttachmentInput } from '@/components/inputs/AttachmentInput'
 import { SupabaseActions } from '@/utils/SupabaseActions'
-import { generateRandomString } from '@/utils/generateRandomString'
-import { bulkRemoveAttachments } from '@/utils/bulkRemoveAttachments'
-import { advancedFeatureFlag } from '@/config'
-import { WorkflowStateSelector } from '@/components/inputs/Selector-WorkflowState'
-import { Tapwrite } from 'tapwrite'
-import { DatePickerComponent } from '@/components/inputs/DatePickerComponent'
-import { CopilotAvatar } from '@/components/atoms/CopilotAvatar'
-import { setDebouncedFilteredAssignees } from '@/utils/users'
-import { z } from 'zod'
-import { MiniLoader } from '@/components/atoms/MiniLoader'
 import { getAssigneeName } from '@/utils/assignee'
+import { generateRandomString } from '@/utils/generateRandomString'
+import { getAssigneeTypeCorrected } from '@/utils/getAssigneeTypeCorrected'
 import { deleteEditorAttachmentsHandler, uploadImageHandler } from '@/utils/inlineImage'
-import AttachmentLayout from '@/components/AttachmentLayout'
+import { NoAssigneeExtraOptions } from '@/utils/noAssignee'
+import { setDebouncedFilteredAssignees } from '@/utils/users'
+import { Box, Stack, Typography, styled } from '@mui/material'
+import { useRouter } from 'next/navigation'
+import { useEffect, useState } from 'react'
+import { useSelector } from 'react-redux'
+import { Tapwrite } from 'tapwrite'
+import { z } from 'zod'
 
 const supabaseActions = new SupabaseActions()
 
 interface NewTaskFormProps {
   handleCreate: () => void
   handleClose: () => void
-  getSignedUrlUpload: (fileName: string) => Promise<ISignedUrlUpload>
 }
 
-export const NewTaskForm = ({ handleCreate, handleClose, getSignedUrlUpload }: NewTaskFormProps) => {
+export const NewTaskForm = ({ handleCreate, handleClose }: NewTaskFormProps) => {
   const { activeWorkflowStateId, errors } = useSelector(selectCreateTask)
   const { workflowStates, assignee, token, filterOptions } = useSelector(selectTaskBoard)
   const [filteredAssignees, setFilteredAssignees] = useState(assignee)
@@ -299,11 +289,7 @@ export const NewTaskForm = ({ handleCreate, handleClose, getSignedUrlUpload }: N
           </Stack>
         </Stack>
       </AppMargin>
-      <NewTaskFooter
-        handleCreate={handleCreateWithAssignee}
-        handleClose={handleClose}
-        getSignedUrlUpload={getSignedUrlUpload}
-      />
+      <NewTaskFooter handleCreate={handleCreateWithAssignee} handleClose={handleClose} />
     </NewTaskContainer>
   )
 }
@@ -312,9 +298,15 @@ const NewTaskFormInputs = () => {
   const { title, description, attachments } = useSelector(selectCreateTask)
   const { errors } = useSelector(selectCreateTask)
   const { token } = useSelector(selectTaskBoard)
+  const { tokenPayload } = useSelector(selectAuthDetails)
 
   const handleDetailChange = (content: string) =>
     store.dispatch(setCreateTaskFields({ targetField: 'description', value: content }))
+
+  const uploadFn =
+    token && tokenPayload?.workspaceId
+      ? (file: File) => uploadImageHandler(file, token, tokenPayload.workspaceId, null)
+      : undefined
 
   return (
     <>
@@ -343,7 +335,7 @@ const NewTaskFormInputs = () => {
           getContent={handleDetailChange}
           placeholder="Add description..."
           editorClass="tapwrite-task-description"
-          uploadFn={(file) => uploadImageHandler(file, token ?? '', null)}
+          uploadFn={uploadFn}
           deleteEditorAttachments={(url) => deleteEditorAttachmentsHandler(url, token ?? '', null)}
           attachmentLayout={AttachmentLayout}
         />
@@ -352,31 +344,13 @@ const NewTaskFormInputs = () => {
   )
 }
 
-const NewTaskFooter = ({ handleCreate, handleClose, getSignedUrlUpload }: NewTaskFormProps) => {
-  const { attachments, title, assigneeId } = useSelector(selectCreateTask)
-  const { filterOptions } = useSelector(selectTaskBoard)
-
-  const handleFileSelect = async (event: React.ChangeEvent<HTMLInputElement>) => {
-    event.preventDefault()
-    const files = event.target.files
-    if (files && files.length > 0) {
-      const file = files[0]
-      const signedUrl: ISignedUrlUpload = await getSignedUrlUpload(generateRandomString(file.name))
-      const { filePayload, error } = await supabaseActions.uploadAttachment(file, signedUrl, '')
-      if (error) {
-        console.error('Failed to upload image') //handle error through chip here in the future
-      }
-      if (filePayload) {
-        store.dispatch(setCreateTaskFields({ targetField: 'attachments', value: [...attachments, filePayload] }))
-      }
-    }
-  }
+const NewTaskFooter = ({ handleCreate, handleClose }: NewTaskFormProps) => {
+  const { title, assigneeId } = useSelector(selectCreateTask)
 
   return (
     <Box sx={{ borderTop: (theme) => `1px solid ${theme.color.borders.border2}` }}>
       <AppMargin size={SizeofAppMargin.MEDIUM} py="21px">
-        <Stack direction="row" justifyContent="space-between" alignItems="center">
-          <Box>{advancedFeatureFlag && <AttachmentInput handleFileSelect={handleFileSelect} />}</Box>
+        <Stack direction="row" justifyContent="flex-end" alignItems="center">
           <Stack direction="row" columnGap={4}>
             <SecondaryBtn
               handleClick={handleClose}

--- a/src/constants/attachments.ts
+++ b/src/constants/attachments.ts
@@ -1,0 +1,1 @@
+export const signedUrlTtl = 3600

--- a/src/types/constants.ts
+++ b/src/types/constants.ts
@@ -2,5 +2,3 @@ export enum TruncateMaxNumber {
   SELECTOR = 16,
   CLIENT_TASK_DESCRIPTION = 256,
 }
-
-export const signedUrlTtl = 3600

--- a/src/utils/SupabaseActions.ts
+++ b/src/utils/SupabaseActions.ts
@@ -41,4 +41,11 @@ export class SupabaseActions extends SupabaseService {
     }
     return { data }
   }
+
+  async moveAttachment(oldPath: string, newPath: string) {
+    const { error } = await this.supabase.storage.from(supabaseBucket).move(oldPath, newPath)
+    if (error) {
+      throw new APIError(httpStatus.BAD_REQUEST, error.message)
+    }
+  }
 }

--- a/src/utils/inlineImage.ts
+++ b/src/utils/inlineImage.ts
@@ -1,19 +1,24 @@
-import { SupabaseActions } from '@/utils/SupabaseActions'
-import React from 'react'
-import { generateRandomString } from '@/utils/generateRandomString'
 import { ISignedUrlUpload } from '@/types/interfaces'
-
+import { generateRandomString } from '@/utils/generateRandomString'
+import { SupabaseActions } from '@/utils/SupabaseActions'
 import { postScrapImage } from '@/app/detail/[task_id]/[user_type]/actions'
 import { ScrapImageRequest } from '@/types/common'
 import { getFilePathFromUrl } from '@/utils/signedUrlReplacer'
 
-import { getSignedUrlUpload, getSignedUrlFile } from '@/app/actions'
+import { getSignedUrlFile, getSignedUrlUpload } from '@/app/actions'
 
-export const uploadImageHandler = async (file: File, token: string, task_id: string | null): Promise<string | undefined> => {
+const buildFilePath = (workspaceId: string, taskId: string | null) => `/${workspaceId}${taskId ? `/${taskId}` : ''}`
+
+export const uploadImageHandler = async (
+  file: File,
+  token: string,
+  workspaceId: string,
+  task_id: string | null,
+): Promise<string | undefined> => {
   const supabaseActions = new SupabaseActions()
 
   const fileName = generateRandomString(file.name)
-  const signedUrl: ISignedUrlUpload = await getSignedUrlUpload(token, fileName)
+  const signedUrl: ISignedUrlUpload = await getSignedUrlUpload(token, fileName, buildFilePath(workspaceId, task_id))
   const { filePayload, error } = await supabaseActions.uploadAttachment(file, signedUrl, task_id)
   if (filePayload) {
     const url = await getSignedUrlFile(token ?? '', filePayload?.filePath ?? '')

--- a/src/utils/signedUrlReplacer.ts
+++ b/src/utils/signedUrlReplacer.ts
@@ -9,7 +9,7 @@ export async function replaceImageSrc(htmlString: string, getSignedUrl: (filePat
   // First pass: collect all replacements
   while ((match = imgTagRegex.exec(htmlString)) !== null) {
     const originalSrc = match[1] //matches the content of the first capture of regex, ie string inside the src attribute of the img tag.
-    const filePath = await getFilePathFromUrl(originalSrc)
+    const filePath = getFilePathFromUrl(originalSrc)
     if (filePath) {
       const newUrl = await getSignedUrl(filePath)
       newUrl && replacements.push({ originalSrc, newUrl })


### PR DESCRIPTION
### Changes

- [x] Improved Supabase folder structure : Made new uploads follow a clean supabase folder structure following this pattern : {bucketName}/{workspaceId}/{taskId}/{filename}. Before, every files were stored under bucket at root level, which was not scalable.
- [x] Add support for `filePath` in attachments API and server action 

### Testing Criteria

![Screenshot from 2024-11-07 18-00-49](https://github.com/user-attachments/assets/63bfc81a-de1c-417e-b342-0c98cc62c2af)


