### PR TITLE
OUT-1026 | Task description is temporarily disappearing after leaving a comment on a task with multiple attachments and images

### DIFF
--- a/src/app/detail/ui/TaskEditor.tsx
+++ b/src/app/detail/ui/TaskEditor.tsx
@@ -50,8 +50,6 @@ export const TaskEditor = ({
   const [isUserTyping, setIsUserTyping] = useState(false)
   const [activeUploads, setActiveUploads] = useState(0)
 
-  useEffect(() => console.log('aaa TaskEditor updateDetail', updateDetail), [updateDetail])
-
   // const handleFileSelect = async (event: React.ChangeEvent<HTMLInputElement>) => {
   //   event.preventDefault()
   //   const files = event.target.files

--- a/src/components/inputs/CommentInput.tsx
+++ b/src/components/inputs/CommentInput.tsx
@@ -33,8 +33,6 @@ export const CommentInput = ({ createComment, task_id }: Prop) => {
     return emptyContentRegex.test(content)
   }
 
-  useEffect(() => console.log('aaa CommentInput detail', detail), [detail])
-
   const handleSubmit = () => {
     let content = detail
     const END_P = '<p></p>'

--- a/src/hoc/RealTime.tsx
+++ b/src/hoc/RealTime.tsx
@@ -79,6 +79,13 @@ export const RealTime = ({
           }
           //if the task is updated
         } else {
+          // Address Postgres' 8kb pagesize limitation (See TOAST https://www.postgresql.org/docs/current/storage-toast.html)
+          // If `body` field (which can be larger than pagesize) is not changed, Supabase Realtime won't send large fields like this in `payload.new`
+
+          // So, we need to check if the oldTask has valid body but new body field is not being sent in updatedTask, and add it if required
+          if (oldTask?.body && updatedTask.body === undefined) {
+            updatedTask.body = oldTask?.body
+          }
           if (oldTask && oldTask.body && updatedTask.body) {
             const oldImgSrcs = extractImgSrcs(oldTask.body)
             const newImgSrcs = extractImgSrcs(updatedTask.body)
@@ -88,8 +95,6 @@ export const RealTime = ({
               updatedTask.body = replaceImgSrcs(updatedTask.body, newImgSrcs, oldImgSrcs)
             }
           }
-          console.log('aaa oldTask', oldTask)
-          console.log('aaa updatedTask', updatedTask)
 
           const newTaskArr = [...tasks.filter((task) => task.id !== updatedTask.id), updatedTask]
           store.dispatch(setTasks(newTaskArr))

--- a/src/hoc/RealTime.tsx
+++ b/src/hoc/RealTime.tsx
@@ -43,7 +43,6 @@ export const RealTime = ({
   }
 
   const handleTaskRealTimeUpdates = (payload: RealtimePostgresChangesPayload<RealTimeTaskResponse>) => {
-    console.log('aaa payload', payload)
     if (payload.eventType === 'INSERT') {
       // For both user types, filter out just tasks belonging to workspace.
       let canUserAccessTask = payload.new.workspaceId === tokenPayload?.workspaceId


### PR DESCRIPTION
## Cause
- When the value of the `body` attribute was larger than Postgres replica's pagesize, Supabase Realtime omitted this field. Our Realtime handler picked this up and set `body` to `undefined`, which was causing the task descriptions to disappear
- Ref 1: https://github.com/supabase/realtime/issues/223
- Ref 2: https://www.postgresql.org/docs/current/storage-toast.html

[Screencast from 2024-11-14 19-28-32.webm](https://github.com/user-attachments/assets/2453b7fa-08b8-4c09-bf89-e1e3834aae7e)


### Changes

- [x] Address Postgres Replica's TOAST pagesize limitation which causes Supabase Realtime to not send oversized attribute fields in `payload.new` if field was not changed 
- [x] This issue appeared to be only occuring sparingly in preview branches, but much frequently in `main` so I added some console.log's to non-sensitive data in `main`. These have been removed.

### Testing Criteria

- [x] Screencast:
[Screencast from 2024-11-14 19-26-41.webm](https://github.com/user-attachments/assets/94890067-6a56-4fee-b9f2-e9a5b0f42eed)
