### PR TITLE
OUT-1016 | Implement isArchived & lastArchivedDate fields for Tasks API

### DIFF
--- a/prisma/migrations/20241116013134_feat_add_is_archived_and_last_archived_date_fields_to_tasks/migration.sql
+++ b/prisma/migrations/20241116013134_feat_add_is_archived_and_last_archived_date_fields_to_tasks/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Tasks" ADD COLUMN     "isArchived" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "lastArchivedDate" TIMESTAMP(3);

--- a/prisma/schema/task.prisma
+++ b/prisma/schema/task.prisma
@@ -29,5 +29,8 @@ model Task {
   ClientNotification       ClientNotification[]
   InternalUserNotification InternalUserNotification[]
 
+  isArchived       Boolean   @default(false)
+  lastArchivedDate DateTime?
+
   @@map("Tasks")
 }

--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -38,12 +38,21 @@ export class TasksService extends BaseService {
   private buildReadFilters(id?: string) {
     const user = this.user
 
-    let filters = { where: { id, workspaceId: user.workspaceId, OR: undefined as unknown as FilterByAssigneeId[] } }
+    // Default filters
+    let filters = {
+      where: {
+        id,
+        workspaceId: user.workspaceId,
+        OR: undefined as FilterByAssigneeId[] | undefined,
+        isArchived: undefined as boolean | undefined,
+      },
+    }
 
     if (user.clientId) {
       filters = {
         where: {
           ...filters.where,
+          isArchived: false,
           OR: [{ assigneeId: user.clientId as string, assigneeType: 'client' }],
         },
       }
@@ -52,6 +61,7 @@ export class TasksService extends BaseService {
       filters = {
         where: {
           ...filters.where,
+          isArchived: false,
           OR: [
             { assigneeId: user.clientId as string, assigneeType: 'client' },
             { assigneeId: user.companyId, assigneeType: 'company' },
@@ -217,6 +227,10 @@ export class TasksService extends BaseService {
       await labelMappingService.deleteLabel(prevTask.label)
       label = z.string().parse(await labelMappingService.getLabel(data.assigneeId, data.assigneeType))
     }
+
+    // Set / reset lastArchivedDate if isArchived has been triggered, else remove it from the update query
+    const lastArchivedDate = data.isArchived === true ? new Date() : data.isArchived === false ? null : undefined
+
     // Get the updated task
     const updatedTask = await this.db.task.update({
       where: { id },
@@ -224,6 +238,7 @@ export class TasksService extends BaseService {
         ...data,
         assigneeId: data.assigneeId === '' ? null : data.assigneeId,
         label,
+        lastArchivedDate,
         ...(await getTaskTimestamps('update', this.user, data, prevTask)),
       },
       include: { workflowState: true },

--- a/src/cmd/load-testing/load-testing.service.ts
+++ b/src/cmd/load-testing/load-testing.service.ts
@@ -89,7 +89,10 @@ class LoadTester {
   private async seedTasks(users: Taskable[], assigneeType: TaskableAssigneeType, taskPerUser: number) {
     const seedPromises = []
     for (let user of users) {
-      const data: Omit<Task, 'id' | 'completedAt' | 'deletedAt' | 'lastActivityLogUpdated'>[] = []
+      const data: Omit<
+        Task,
+        'id' | 'completedAt' | 'deletedAt' | 'lastActivityLogUpdated' | 'isArchived' | 'lastArchivedDate'
+      >[] = []
       const currentUser = await authenticateWithToken(this.token, this.apiKey)
       const labelsService = new LabelMappingService(currentUser, this.apiKey)
       const workflowStates = await this.db.workflowState.findMany({

--- a/src/types/dto/tasks.dto.ts
+++ b/src/types/dto/tasks.dto.ts
@@ -24,6 +24,7 @@ export const UpdateTaskRequestSchema = z.object({
   body: z.string().nullish(),
   workflowStateId: z.string().uuid().optional(),
   dueDate: DateStringSchema.nullish(),
+  isArchived: z.boolean().optional(),
 })
 export type UpdateTaskRequest = z.infer<typeof UpdateTaskRequestSchema>
 


### PR DESCRIPTION
### Changes

- [x] Change Tasks schema to support isArchived & lastArchivedDate
- [x] Add support for archive fields in update, list and getOne endpoints 

### Testing Criteria

- [x] Notice that `isArchived` is returned in list endpoint, archived tasks are filtered out when CU lists tasks, and `isArchived` can only be updated (PATCH) by IU 