### PR TITLE
OUT-1035 | Fix spacing between Description field label and its text field

### DIFF
--- a/src/app/ui/NewTaskForm.tsx
+++ b/src/app/ui/NewTaskForm.tsx
@@ -334,6 +334,7 @@ const NewTaskFormInputs = () => {
           deleteEditorAttachments={(url) => deleteEditorAttachmentsHandler(url, token ?? '', null)}
           attachmentLayout={AttachmentLayout}
           maxUploadLimit={MAX_UPLOAD_LIMIT}
+          parentContainerStyle={{ gap: '0px' }}
         />
       </Stack>
     </>


### PR DESCRIPTION
### Changes

- [x] added a parentContainerStyle with gap '0px' to let tapwrite handle the spacing with 0px gap among its component 

### Testing Criteria

![image](https://github.com/user-attachments/assets/08ba5fdd-efc4-42f8-99c1-3c367bec5da8)


