### PR TITLE
OUT-1050 | Add and retain selected design state to List/Board view buttons in Display drawer

### DIFF
--- a/src/components/inputs/DisplaySelector.tsx
+++ b/src/components/inputs/DisplaySelector.tsx
@@ -75,14 +75,26 @@ export const DisplaySelector = ({
             paddingBottom: '8px',
           }}
         >
-          <IconContainer direction="column" onClick={() => handleModeChange(ViewMode.list)}>
+          <IconContainer
+            direction="column"
+            onClick={() => handleModeChange(ViewMode.list)}
+            sx={{
+              background: (theme) => (selectedMode == ViewMode.list ? theme.color.gray[100] : theme.color.base.white),
+            }}
+          >
             <ListViewIcon />
             <Typography variant="bodySm" fontSize={'12px'}>
               List
             </Typography>
           </IconContainer>
 
-          <IconContainer direction="column" onClick={() => handleModeChange(ViewMode.board)}>
+          <IconContainer
+            direction="column"
+            onClick={() => handleModeChange(ViewMode.board)}
+            sx={{
+              background: (theme) => (selectedMode == ViewMode.board ? theme.color.gray[100] : theme.color.base.white),
+            }}
+          >
             <BoardViewIcon />
             <Typography variant="bodySm" fontSize={'12px'}>
               Board


### PR DESCRIPTION
### Changes

- [x] added background for list and board view icon containers according to their selected state.

### Testing Criteria

![image](https://github.com/user-attachments/assets/a060357f-0ac5-4052-bef5-9d985ad3f8be)

