### PR TITLE
OUT-1047 | OUT-1048 | OUT-1049 | OUT-1055 | Fix initial design & functionality issues

### DIFF
--- a/src/app/detail/[task_id]/[user_type]/page.tsx
+++ b/src/app/detail/[task_id]/[user_type]/page.tsx
@@ -116,7 +116,6 @@ export default async function TaskDetailPage({
                     <Typography
                       variant="sm"
                       sx={{
-                        marginTop: '3px',
                         fontSize: '13px',
                       }}
                     >

--- a/src/app/detail/ui/LastArchiveField.tsx
+++ b/src/app/detail/ui/LastArchiveField.tsx
@@ -35,7 +35,7 @@ export const LastArchivedField = () => {
         color: (theme) => theme.color.gray[500],
       }}
     >
-      {`Archived ${timeAgoText}`}
+      {`Archived ${timeAgoText.toLowerCase()}`}
     </Typography>
   )
 }

--- a/src/components/buttons/ArchiveBtn.tsx
+++ b/src/components/buttons/ArchiveBtn.tsx
@@ -2,6 +2,7 @@
 
 import { DustbinIcon } from '@/icons'
 import { Stack, Typography } from '@mui/material'
+import { SecondaryBtn } from '@/components/buttons/SecondaryBtn'
 
 export const ArchiveBtn = ({ isArchived, handleClick }: { isArchived: boolean; handleClick: () => void }) => {
   return (
@@ -19,10 +20,14 @@ export const ArchiveBtn = ({ isArchived, handleClick }: { isArchived: boolean; h
       }}
       onClick={handleClick}
     >
-      <DustbinIcon />
-      <Typography variant="sm" sx={{ color: (theme) => theme.color.gray[600] }}>
-        {!isArchived ? 'Archive' : 'Unarchive'}
-      </Typography>
+      <SecondaryBtn
+        startIcon={<DustbinIcon />}
+        buttonContent={
+          <Typography variant="sm" sx={{ color: (theme) => theme.color.gray[600] }}>
+            {!isArchived ? 'Archive' : 'Unarchive'}
+          </Typography>
+        }
+      />
     </Stack>
   )
 }

--- a/src/components/cards/ListViewTaskCard.tsx
+++ b/src/components/cards/ListViewTaskCard.tsx
@@ -89,7 +89,11 @@ export const ListViewTaskCard = ({
                 >
                   {task?.title}
                 </Typography>
-                {task.isArchived && <ArchiveBoxIcon />}
+                {task.isArchived && (
+                  <Box title="Archived.">
+                    <ArchiveBoxIcon />
+                  </Box>
+                )}
               </Stack>
             </Box>
           </Stack>


### PR DESCRIPTION
### Changes

- [x] Made time ago text lowercase
- [x] Used secondary button as per figma design in Archive / Unarchived button 
- [x] Add tooltip in archived icon in List view task card
- [x] Vertically center taskId in breadcrumbs  

### Testing Criteria

- [x] Screenshots / screencasts in order:

#### OUT-1047
![image](https://github.com/user-attachments/assets/e474cc25-9ea2-4d55-98f9-8c4ab33b0aa2)

#### OUT-1048
[Screencast from 2024-11-21 18-37-16.webm](https://github.com/user-attachments/assets/0758ed29-e54b-48a6-b24a-7d17fa3d60ae)

#### OUT-1049
![image](https://github.com/user-attachments/assets/6eba599d-c4bf-44a9-b9ee-ad3d8890a737)

#### OUT-1055
![image](https://github.com/user-attachments/assets/081362d2-154e-4d88-8f7a-820dfacf7978)

