### PR TITLE
OUT-1056 | Opening task from Task assigned email shows incorrect task details

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -64,13 +64,18 @@ export default async function Main({ searchParams }: { searchParams: { token: st
     return <SilentError message="Please provide a Valid Token" />
   }
 
-  redirectIfTaskCta(searchParams, UserType.INTERNAL_USER)
+  const tokenPayload = await getTokenPayload(token)
+  const userRole = tokenPayload.internalUserId ? UserType.INTERNAL_USER : tokenPayload.clientId ? UserType.CLIENT_USER : null
+  if (!userRole) {
+    return <SilentError message="Please provide a Valid Token" />
+  }
+  // Both clients and IUs can access this page so hardcoding a UserRole will not work
+  redirectIfTaskCta(searchParams, userRole)
 
-  const [workflowStates, tasks, viewSettings, tokenPayload] = await Promise.all([
+  const [workflowStates, tasks, viewSettings] = await Promise.all([
     getAllWorkflowStates(token),
     getAllTasks(token),
     getViewSettings(token),
-    getTokenPayload(token),
   ])
 
   console.info(`app/page.tsx | Serving user ${token} with payload`, tokenPayload)

--- a/src/utils/redirect.ts
+++ b/src/utils/redirect.ts
@@ -13,7 +13,7 @@ export const redirectIfTaskCta = (searchParams: Record<string, string>, userType
         `${apiUrl}/detail/${taskId.data}/${userType}?token=${z.string().parse(searchParams.token)}&commentId=${commentId.data}&isRedirect=1`,
       )
     }
-    redirect(`${apiUrl}/detail/${taskId.data}/iu?token=${z.string().parse(searchParams.token)}&isRedirect=1`)
+    redirect(`${apiUrl}/detail/${taskId.data}/${userType}?token=${z.string().parse(searchParams.token)}&isRedirect=1`)
   }
 }
 


### PR DESCRIPTION
### Changes

- [x] `UserRole` was being hardcoded as INTERNAL_USER in tasks board, even though the same board is accessible to both IU and CU. As a result the CU was redirected to `/details/:id/iu` instead of the intended `/details/:id/cu` page.
