### PR TITLE
OUT-1063 Archive indicator and properties tab breaks when one of the display toggles are disabled

### DIFF
--- a/src/app/detail/ui/ArchiveWrapper.tsx
+++ b/src/app/detail/ui/ArchiveWrapper.tsx
@@ -20,6 +20,7 @@ export const ArchiveWrapper = ({ taskId }: { taskId: string }) => {
   // Set the initial state when `data` becomes available
   useEffect(() => {
     const currentTask = globalTasksRepo.find((el) => el.id === taskId)
+    console.log('test', currentTask)
     if (currentTask) {
       setIsArchived(currentTask.isArchived)
       store.dispatch(setTask(currentTask))

--- a/src/app/detail/ui/ArchiveWrapper.tsx
+++ b/src/app/detail/ui/ArchiveWrapper.tsx
@@ -20,7 +20,6 @@ export const ArchiveWrapper = ({ taskId }: { taskId: string }) => {
   // Set the initial state when `data` becomes available
   useEffect(() => {
     const currentTask = globalTasksRepo.find((el) => el.id === taskId)
-    console.log('test', currentTask)
     if (currentTask) {
       setIsArchived(currentTask.isArchived)
       store.dispatch(setTask(currentTask))

--- a/src/app/detail/ui/ArchiveWrapper.tsx
+++ b/src/app/detail/ui/ArchiveWrapper.tsx
@@ -11,7 +11,7 @@ import store from '@/redux/store'
 import { selectTaskDetails, setTask } from '@/redux/features/taskDetailsSlice'
 
 export const ArchiveWrapper = ({ taskId }: { taskId: string }) => {
-  const { token, tasks } = useSelector(selectTaskBoard)
+  const { token, globalTasksRepo } = useSelector(selectTaskBoard)
   const { task } = useSelector(selectTaskDetails)
   const { mutate } = useSWRConfig()
   const cacheKey = `/api/tasks/${taskId}?token=${token}`
@@ -19,12 +19,12 @@ export const ArchiveWrapper = ({ taskId }: { taskId: string }) => {
 
   // Set the initial state when `data` becomes available
   useEffect(() => {
-    const currentTask = tasks.find((el) => el.id === taskId)
+    const currentTask = globalTasksRepo.find((el) => el.id === taskId)
     if (currentTask) {
       setIsArchived(currentTask.isArchived)
       store.dispatch(setTask(currentTask))
     }
-  }, [tasks, taskId])
+  }, [globalTasksRepo, taskId])
 
   const handleToggleArchive = async () => {
     if (isArchived === undefined) return // Prevent toggling if state isn't initialized yet

--- a/src/app/detail/ui/Sidebar.tsx
+++ b/src/app/detail/ui/Sidebar.tsx
@@ -49,7 +49,7 @@ export const Sidebar = ({
   disabled: boolean
   workflowDisabled?: false
 }) => {
-  const { tasks, token, workflowStates, assignee } = useSelector(selectTaskBoard)
+  const { globalTasksRepo, token, workflowStates, assignee } = useSelector(selectTaskBoard)
   const { showSidebar } = useSelector(selectTaskDetails)
   const [filteredAssignees, setFilteredAssignees] = useState(assignee)
   const [activeDebounceTimeoutId, setActiveDebounceTimeoutId] = useState<NodeJS.Timeout | null>(null)
@@ -72,15 +72,16 @@ export const Sidebar = ({
   const assigneeValue = _assigneeValue as IAssigneeCombined //typecasting
 
   useEffect(() => {
-    if (tasks && workflowStates) {
-      const currentTask = tasks.find((el) => el.id === task_id)
+    if (globalTasksRepo && workflowStates) {
+      const currentTask = globalTasksRepo.find((el) => el.id === task_id)
+
       const currentWorkflowState = workflowStates.find((el) => el?.id === currentTask?.workflowStateId)
       const currentAssigneeId = currentTask?.assigneeId
       updateStatusValue(currentWorkflowState)
       updateAssigneeValue(currentAssigneeId ? assignee.find((el) => el.id === currentAssigneeId) : NoAssignee)
       setDueDate(currentTask?.dueDate)
     }
-  }, [tasks, workflowStates])
+  }, [globalTasksRepo, workflowStates])
 
   const windowWidth = useWindowWidth()
   const isMobile = windowWidth < 600 && windowWidth !== 0
@@ -91,7 +92,7 @@ export const Sidebar = ({
     }
   }, [isMobile])
 
-  if (!tasks) return null
+  if (!globalTasksRepo) return null
 
   return (
     <Box

--- a/src/app/detail/ui/TaskEditor.tsx
+++ b/src/app/detail/ui/TaskEditor.tsx
@@ -46,7 +46,7 @@ export const TaskEditor = ({
   const [updateTitle, setUpdateTitle] = useState('')
   const [updateDetail, setUpdateDetail] = useState('')
   const { showConfirmDeleteModal } = useSelector(selectTaskDetails)
-  const { tasks, token } = useSelector(selectTaskBoard)
+  const { token, globalTasksRepo } = useSelector(selectTaskBoard)
   const [isUserTyping, setIsUserTyping] = useState(false)
   const [activeUploads, setActiveUploads] = useState(0)
 
@@ -66,14 +66,13 @@ export const TaskEditor = ({
 
   useEffect(() => {
     if (!isUserTyping && activeUploads === 0) {
-      const currentTask = tasks.find((el) => el.id === task_id)
+      const currentTask = globalTasksRepo.find((el) => el.id === task_id)
       if (currentTask) {
         setUpdateTitle(currentTask.title || '')
-
         setUpdateDetail(currentTask.body ?? '')
       }
     }
-  }, [tasks, task_id, isUserTyping, activeUploads])
+  }, [globalTasksRepo, task_id, isUserTyping, activeUploads])
 
   const _titleUpdateDebounced = async (title: string) => updateTaskTitle(title)
 
@@ -104,7 +103,7 @@ export const TaskEditor = ({
   const handleTitleBlur = () => {
     if (updateTitle.trim() == '') {
       setTimeout(() => {
-        const currentTask = tasks.find((el) => el.id === task_id)
+        const currentTask = globalTasksRepo.find((el) => el.id === task_id)
         setUpdateTitle(currentTask?.title ?? '')
       }, 300)
     }

--- a/src/hoc/ClientSideStateUpdate.tsx
+++ b/src/hoc/ClientSideStateUpdate.tsx
@@ -2,7 +2,13 @@
 
 import { LogResponse } from '@/app/api/activity-logs/schemas/LogResponseSchema'
 import { setTokenPayload } from '@/redux/features/authDetailsSlice'
-import { selectTaskBoard, setAssigneeList, setFilteredAssgineeList, setViewSettings } from '@/redux/features/taskBoardSlice'
+import {
+  selectTaskBoard,
+  setAssigneeList,
+  setFilteredAssgineeList,
+  setGlobalTasksRepo,
+  setViewSettings,
+} from '@/redux/features/taskBoardSlice'
 import { setTasks, setToken, setWorkflowStates } from '@/redux/features/taskBoardSlice'
 import { setAssigneeSuggestion } from '@/redux/features/taskDetailsSlice'
 import { setTemplates } from '@/redux/features/templateSlice'
@@ -50,13 +56,14 @@ export const ClientSideStateUpdate = ({
   assigneeSuggestions?: IAssigneeSuggestions[]
   task?: TaskResponse
 }) => {
-  const { tasks: tasksInStore, viewSettingsTemp } = useSelector(selectTaskBoard)
+  const { tasks: tasksInStore, viewSettingsTemp, globalTasksRepo: globalTasksInStore } = useSelector(selectTaskBoard)
   useEffect(() => {
     if (workflowStates) {
       store.dispatch(setWorkflowStates(workflowStates))
     }
 
     if (tasks && tasksInStore.length === 0) {
+      store.dispatch(setGlobalTasksRepo(tasks))
       store.dispatch(setTasks(tasks))
     }
 
@@ -86,6 +93,8 @@ export const ClientSideStateUpdate = ({
     }
     if (task) {
       const updatedTasks = tasksInStore.map((t) => (t.id === task.id ? task : t))
+      const updatedGlobalTasks = globalTasksInStore.map((t) => (t.id === task.id ? task : t))
+      store.dispatch(setGlobalTasksRepo(updatedGlobalTasks))
       store.dispatch(setTasks(updatedTasks))
     } //for updating a task in store with respect to task response from db in task details page
   }, [workflowStates, tasks, token, assignee, viewSettings, tokenPayload, templates, assigneeSuggestions, task])

--- a/src/hoc/RealTime.tsx
+++ b/src/hoc/RealTime.tsx
@@ -66,6 +66,8 @@ export const RealTime = ({
       const updatedTask = payload.new
       const oldTask = tasks.find((task) => task.id == updatedTask.id)
       if ((updatedTask.isArchived && !showArchived) || (!updatedTask.isArchived && !showUnarchived)) {
+        const updatedGlobalTasksRepo = globalTasksRepo.map((task) => (task.id === updatedTask.id ? updatedTask : task))
+        store.dispatch(setGlobalTasksRepo(updatedGlobalTasksRepo))
         store.dispatch(setTasks(tasks.filter((el) => el.id !== updatedTask.id)))
         return
       }

--- a/src/redux/features/taskBoardSlice.tsx
+++ b/src/redux/features/taskBoardSlice.tsx
@@ -10,6 +10,7 @@ import { sortTaskByDescendingOrder } from '@/utils/sortTask'
 interface IInitialState {
   workflowStates: WorkflowStateResponse[]
   assignee: IAssigneeCombined[]
+  globalTasksRepo: TaskResponse[]
   tasks: TaskResponse[]
   token: string | undefined
   view: ViewMode
@@ -24,6 +25,7 @@ interface IInitialState {
 
 const initialState: IInitialState = {
   workflowStates: [],
+  globalTasksRepo: [],
   tasks: [],
   token: undefined,
   assignee: [],
@@ -48,6 +50,9 @@ const taskBoardSlice = createSlice({
   reducers: {
     setWorkflowStates: (state, action: { payload: WorkflowStateResponse[] }) => {
       state.workflowStates = action.payload
+    },
+    setGlobalTasksRepo: (state, action: { payload: TaskResponse[] }) => {
+      state.globalTasksRepo = action.payload
     },
     setTasks: (state, action: { payload: TaskResponse[] }) => {
       state.tasks = action.payload
@@ -128,6 +133,7 @@ export const selectTaskBoard = (state: RootState) => state.taskBoard
 
 export const {
   setWorkflowStates,
+  setGlobalTasksRepo,
   setTasks,
   appendTask,
   updateWorkflowStateIdByTaskId,

--- a/src/redux/features/taskBoardSlice.tsx
+++ b/src/redux/features/taskBoardSlice.tsx
@@ -25,12 +25,12 @@ interface IInitialState {
 
 const initialState: IInitialState = {
   workflowStates: [],
-  globalTasksRepo: [],
-  tasks: [],
+  globalTasksRepo: [], //contains all tasks in the current workspace, is populated from page.tsx server component.
+  tasks: [], //contains tasks which are filtered(from api). is populated from client components using swr.
   token: undefined,
   assignee: [],
   view: ViewMode.board,
-  filteredTasks: [],
+  filteredTasks: [], //contains tasks which are client-side filtered. is modified from the useFilter custom hook.
   filterOptions: {
     [FilterOptions.ASSIGNEE]: '',
     [FilterOptions.KEYWORD]: '',


### PR DESCRIPTION
### Changes

- [x] Introduced a global state for tasks called ```globalTasksRepo```, to store details of all the available tasks regardless of archived/unarchived filter

### Testing Criteria

- [LOOM](https://www.loom.com/share/ff4b79e9b7a24ddf8baedc474e9f0d35)
