### PR TITLE
OUT-1046, OUT-1085 | When tasks board goes from empty state to one with tasks, display drawer closes unexpectedly

### DIFF
--- a/src/app/_fetchers/TaskDataFetcher.tsx
+++ b/src/app/_fetchers/TaskDataFetcher.tsx
@@ -2,13 +2,12 @@ import { selectTaskBoard, setIsTasksLoading, setTasks } from '@/redux/features/t
 import store from '@/redux/store'
 import { ArchivedOptionsType } from '@/types/dto/viewSettings.dto'
 import { fetcher } from '@/utils/fetcher'
-import { useCallback, useEffect, useRef } from 'react'
+import { useCallback, useEffect } from 'react'
 import { useSelector } from 'react-redux'
 import useSWR from 'swr'
 
 export const TaskDataFetcher = ({ token }: { token: string }) => {
   const { showArchived, showUnarchived, tasks } = useSelector(selectTaskBoard)
-  const lastRequestIdRef = useRef(0)
 
   const buildQueryString = useCallback((token: string, archivedOptions?: ArchivedOptionsType) => {
     const queryParams = new URLSearchParams({ token })
@@ -27,21 +26,12 @@ export const TaskDataFetcher = ({ token }: { token: string }) => {
 
   const updateTaskOnArchivedStateUpdate = useCallback(async () => {
     if (token) {
-      const currentRequestId = ++lastRequestIdRef.current
-
       try {
         store.dispatch(setIsTasksLoading(true))
-        const result = await mutate()
-        //updating the recent requests only
-        if (currentRequestId === lastRequestIdRef.current) {
-          store.dispatch(setTasks(result.tasks))
-          store.dispatch(setIsTasksLoading(false))
-        }
+        await mutate().then((data) => store.dispatch(setTasks(data.tasks))) // preventing extra rerendering
+        store.dispatch(setIsTasksLoading(isLoading))
       } catch (error) {
-        if (currentRequestId === lastRequestIdRef.current) {
-          console.error('Error updating tasks:', error)
-          store.dispatch(setIsTasksLoading(false))
-        }
+        console.error('Error updating tasks:', error)
       }
     }
   }, [token, mutate])

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -83,8 +83,9 @@ export default async function Main({ searchParams }: { searchParams: { token: st
   redirectIfTaskCta(searchParams, userRole)
 
   const viewSettings = await getViewSettings(token)
-  const [workflowStates, tasks] = await Promise.all([
+  const [workflowStates, allTasks, tasks] = await Promise.all([
     getAllWorkflowStates(token),
+    getAllTasks(token),
     getAllTasks(token, { showArchived: viewSettings.showArchived, showUnarchived: viewSettings.showUnarchived }),
   ])
 
@@ -92,7 +93,8 @@ export default async function Main({ searchParams }: { searchParams: { token: st
   return (
     <ClientSideStateUpdate
       workflowStates={workflowStates}
-      tasks={tasks}
+      allTasks={allTasks} //for globalTasksRepo
+      tasks={tasks} // for tasks
       token={token}
       viewSettings={viewSettings}
       tokenPayload={tokenPayload}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -85,7 +85,7 @@ export default async function Main({ searchParams }: { searchParams: { token: st
   const viewSettings = await getViewSettings(token)
   const [workflowStates, allTasks, tasks] = await Promise.all([
     getAllWorkflowStates(token),
-    getAllTasks(token),
+    getAllTasks(token, { showArchived: true, showUnarchived: true }), //fetching all data
     getAllTasks(token, { showArchived: viewSettings.showArchived, showUnarchived: viewSettings.showUnarchived }),
   ])
 

--- a/src/app/ui/TaskBoard.tsx
+++ b/src/app/ui/TaskBoard.tsx
@@ -43,6 +43,7 @@ export const TaskBoard = ({ mode }: TaskBoardProps) => {
     showArchived,
     showUnarchived,
     isTasksLoading,
+    globalTasksRepo,
   } = useSelector(selectTaskBoard)
 
   const onDropItem = useCallback(
@@ -88,7 +89,7 @@ export const TaskBoard = ({ mode }: TaskBoardProps) => {
 
   const isNoTasksWithFilter = tasks && !userHasNoFilter && !filteredTasks.length
 
-  if (tasks && tasks.length === 0 && userHasNoFilter && !isTasksLoading) {
+  if (globalTasksRepo && globalTasksRepo.length === 0) {
     return (
       <>
         <TaskDataFetcher token={token ?? ''} />

--- a/src/hoc/ClientSideStateUpdate.tsx
+++ b/src/hoc/ClientSideStateUpdate.tsx
@@ -44,10 +44,12 @@ export const ClientSideStateUpdate = ({
   templates,
   assigneeSuggestions,
   task,
+  allTasks,
 }: {
   children: ReactNode
   workflowStates?: WorkflowStateResponse[]
   tasks?: TaskResponse[]
+  allTasks?: TaskResponse[]
   assignee?: IAssigneeCombined[]
   viewSettings?: CreateViewSettingsDTO
   token?: string
@@ -65,6 +67,10 @@ export const ClientSideStateUpdate = ({
     if (tasks && tasksInStore.length === 0) {
       store.dispatch(setGlobalTasksRepo(tasks))
       store.dispatch(setTasks(tasks))
+    }
+
+    if (allTasks && globalTasksInStore.length === 0) {
+      store.dispatch(setGlobalTasksRepo(allTasks))
     }
 
     if (token) {
@@ -97,7 +103,7 @@ export const ClientSideStateUpdate = ({
       store.dispatch(setGlobalTasksRepo(updatedGlobalTasks))
       store.dispatch(setTasks(updatedTasks))
     } //for updating a task in store with respect to task response from db in task details page
-  }, [workflowStates, tasks, token, assignee, viewSettings, tokenPayload, templates, assigneeSuggestions, task])
+  }, [workflowStates, tasks, token, assignee, viewSettings, tokenPayload, templates, assigneeSuggestions, task, allTasks])
 
   return children
 }


### PR DESCRIPTION
### Changes

- [x] removed  ```showArchived``` dependency from  ```hasNoFilter``` and introduced ```globalTasksRepo``` check on it. 
- [x] api calls optimization on taskDataFetcher. 

### Testing Criteria

- [LOOM](https://www.loom.com/share/34d5da049caf44e0af9660ae5a431925)
