### PR TITLE
OUT-1027  | Hover state over attachments button should be a rectangle, not a circle

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "react-dom": "^18",
     "react-redux": "^9.1.0",
     "swr": "^2.2.5",
-    "tapwrite": "1.1.78",
+    "tapwrite": "1.1.79",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7000,10 +7000,10 @@ tapable@^2.2.0:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"
   integrity sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==
 
-tapwrite@1.1.78:
-  version "1.1.78"
-  resolved "https://registry.yarnpkg.com/tapwrite/-/tapwrite-1.1.78.tgz#fcd07f3955a1d732c3d906d3bb5213004e0cba3a"
-  integrity sha512-fT1bJEqjFb52qOY3Ht/dxdAocYvlZAeO6Bnqm+zyvjZO8k4+c60pZdLLBgERwSCAiQHq5SPjtDdMq3wlmCac5g==
+tapwrite@1.1.79:
+  version "1.1.79"
+  resolved "https://registry.yarnpkg.com/tapwrite/-/tapwrite-1.1.79.tgz#ed59de949b5eb85da27ccf608677e0c83571c3c5"
+  integrity sha512-x4kTvdd4y3/XfpQ/oLVMnoLtPwaaN0lbRSTL8LIamATDO4QZ/2GvsrG9KykPZW7W8gUxxC1CNfs69Gj1eKJDkA==
   dependencies:
     re-resizable "^6.10.0"
     tippy.js "^6.3.7"


### PR DESCRIPTION


### Changes

- [x] tapwrite update : change hover to rectangular from circular for attachments button 

### Testing Criteria

![image](https://github.com/user-attachments/assets/71b2726c-37fa-4530-8551-8eff52f172d4)


