### PR TITLE
OUT 1064 Update hover state for a task

### DIFF
--- a/src/components/cards/TaskCard.tsx
+++ b/src/components/cards/TaskCard.tsx
@@ -21,7 +21,7 @@ const TaskCardContainer = styled(Stack)(({ theme }) => ({
   overflowWrap: 'break-word',
   userSelect: 'none',
   ':hover': {
-    background: theme.color.gray[150],
+    background: theme.color.gray[100],
   },
   cursor: 'pointer',
   width: '304px',


### PR DESCRIPTION
### Changes

- [x] Updates hover state to `gray[100]` 

### Testing Criteria

- Hover on the task card and notice the hover state background color is now `#F8F9FB` i.e. `gray[100]` according to the `theme.ts` design system

![image](https://github.com/user-attachments/assets/ed2c52d4-2614-45d0-b91f-928bfbee2fbd)

