### PR TITLE
OUT-1071 | Tasks should sort by due date, not created date

### DIFF
--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -96,7 +96,14 @@ export class TasksService extends BaseService {
         ...filters.where,
         isArchived,
       },
-      orderBy: { createdAt: 'desc' },
+      orderBy: [
+        {
+          dueDate: { sort: 'asc', nulls: 'last' },
+        },
+        {
+          createdAt: 'desc',
+        },
+      ],
       // @ts-ignore TS support for this param is still shakey
       relationLoadStrategy: 'join',
       include: {

--- a/src/app/ui/TaskBoard.tsx
+++ b/src/app/ui/TaskBoard.tsx
@@ -138,7 +138,7 @@ export const TaskBoard = ({ mode }: TaskBoardProps) => {
                 >
                   <CustomScrollbar style={{ padding: '4px' }}>
                     <Stack direction="column" rowGap="6px" sx={{ overflowX: 'auto' }}>
-                      {sortTaskByDescendingOrder(filterTaskWithWorkflowStateId(list.id)).map((task, index) => {
+                      {sortTaskByDescendingOrder<TaskResponse>(filterTaskWithWorkflowStateId(list.id)).map((task, index) => {
                         return (
                           <CustomLink
                             key={task.id}
@@ -199,7 +199,7 @@ export const TaskBoard = ({ mode }: TaskBoardProps) => {
                   taskCount={taskCountForWorkflowStateId(list.id)}
                   display={!!filterTaskWithWorkflowStateId(list.id).length}
                 >
-                  {sortTaskByDescendingOrder(filterTaskWithWorkflowStateId(list.id)).map((task, index) => {
+                  {sortTaskByDescendingOrder<TaskResponse>(filterTaskWithWorkflowStateId(list.id)).map((task, index) => {
                     return (
                       <CustomLink key={task.id} href={{ pathname: getCardHref(task), query: { token } }}>
                         <DragDropHandler

--- a/src/components/cards/ListViewTaskCard.tsx
+++ b/src/components/cards/ListViewTaskCard.tsx
@@ -90,7 +90,7 @@ export const ListViewTaskCard = ({
                   {task?.title}
                 </Typography>
                 {task.isArchived && (
-                  <Box title="Archived.">
+                  <Box title="Archived">
                     <ArchiveBoxIcon />
                   </Box>
                 )}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,5 +1,6 @@
 import { PrismaClient } from '@prisma/client'
 import { filterSoftDeleted, softDelete, softDeleteMany } from '@/lib/prismaExtensions'
+import { isProd } from '@/config'
 
 class DBClient {
   private static client: PrismaClient
@@ -21,7 +22,12 @@ class DBClient {
       if (!this.isInitialized) {
         // Make sure that prisma client is only created once
         // @ts-expect-error $use is deprecated but it is expected
-        this.client = new PrismaClient().$extends(softDelete).$extends(softDeleteMany).$extends(filterSoftDeleted)
+        this.client = new PrismaClient({
+          log: isProd ? undefined : ['query'],
+        })
+          .$extends(softDelete)
+          .$extends(softDeleteMany)
+          .$extends(filterSoftDeleted)
         this.isInitialized = true
 
         // disconnect the client when the Node.js process exits

--- a/src/redux/features/taskBoardSlice.tsx
+++ b/src/redux/features/taskBoardSlice.tsx
@@ -5,7 +5,6 @@ import { TaskResponse } from '@/types/dto/tasks.dto'
 import { AssigneeType, FilterByOptions, FilterOptions, IAssigneeCombined, IFilterOptions, View } from '@/types/interfaces'
 import { ViewMode } from '@prisma/client'
 import { CreateViewSettingsDTO, FilterOptionsType } from '@/types/dto/viewSettings.dto'
-import { sortTaskByDescendingOrder } from '@/utils/sortTask'
 
 interface IInitialState {
   workflowStates: WorkflowStateResponse[]

--- a/src/utils/sortTask.ts
+++ b/src/utils/sortTask.ts
@@ -1,9 +1,23 @@
-import { TaskResponse } from '@/types/dto/tasks.dto'
+interface Sortable {
+  dueDate?: string
+  createdAt: Date
+}
 
-export const sortTaskByDescendingOrder = (tasks: TaskResponse[]) => {
-  return [...tasks].sort((a, b) => {
-    const dateA = new Date(a.createdAt).getTime()
-    const dateB = new Date(b.createdAt).getTime()
-    return dateB - dateA
+const getTimestamp = (date: string | Date) => new Date(date).getTime()
+
+export const sortTaskByDescendingOrder = <T extends Sortable>(tasks: T[]): T[] => {
+  return tasks.sort((a, b) => {
+    // Prioritize tasks with due dates over tasks without due dates
+    if (a.dueDate && !b.dueDate) {
+      return -1
+    } else if (b.dueDate && !a.dueDate) {
+      return 1
+    } else if (a.dueDate && b.dueDate) {
+      // Sort by duedate in asc order
+      return getTimestamp(a.dueDate) - getTimestamp(b.dueDate)
+    } else {
+      // Sort by createdAt in desc order
+      return getTimestamp(b.createdAt) - getTimestamp(a.createdAt)
+    }
   })
 }


### PR DESCRIPTION
### Changes

- [x] Change backend query to sort by dueDate, then createdAt as secondary ordering criteria:
```sql
 ORDER by "tasks"."dueDate" asc nulls last, "tasks"."createdAt" DESC
```
- [x] Change frontend tasks sorter to also sort by dueDate (if defined), also made it reusable.
- [x] (OUT-1087) Remove the period from the "Archived." tooltip 
 
### Testing Criteria

- [x] Screencast
[Screencast from 2024-11-27 15-21-43.webm](https://github.com/user-attachments/assets/a12a04ca-b2d9-4678-90ef-2c5d3f48e362)
