### PR TITLE
OUT-1067 | Images refresh on archiving tasks

### DIFF
--- a/src/hoc/RealTime.tsx
+++ b/src/hoc/RealTime.tsx
@@ -64,7 +64,7 @@ export const RealTime = ({
     }
     if (payload.eventType === 'UPDATE') {
       const updatedTask = payload.new
-      const oldTask = tasks.find((task) => task.id == updatedTask.id)
+      const oldTask = backupTasks.find((task) => task.id == updatedTask.id)
 
       if (payload.new.workspaceId === tokenPayload?.workspaceId) {
         //check if the new task in this event belongs to the same workspaceId


### PR DESCRIPTION
### Changes

- [x] image refresh mechanism on real time task update updated : updatedTask's body is fetched from backupTasks state now. 

### Testing Criteria

- [LOOM](https://www.loom.com/share/435c0c805dc54002a7f55cc098abd4b6)

