### PR TITLE
OUT 1089 Unnecessary scrollbar appears with 'No tasks found' empty state

### DIFF
--- a/src/components/layouts/EmptyState/NoFilteredTasksState.tsx
+++ b/src/components/layouts/EmptyState/NoFilteredTasksState.tsx
@@ -10,7 +10,7 @@ export const NoFilteredTasksState = () => {
         <Box
           sx={{
             display: 'flex',
-            height: '80vh',
+            height: 'calc(100vh - 160px)',
             ...SxCenter,
           }}
         >


### PR DESCRIPTION
### Changes

- [x] Adds a height attribute to the `NoFilteredTasksState` container

### Testing Criteria
- Unselect both the filters in the "Display" pop up then observe the vertical scroll doesn't appear during "No tasks found" screen

![image](https://github.com/user-attachments/assets/1463a7dd-216b-44af-a88c-b86bd6e8999b)