### PR TITLE
OUT-1097, OUT-1096 | Fix 'Display' button alignment issue

### DIFF
--- a/src/app/detail/[task_id]/[user_type]/page.tsx
+++ b/src/app/detail/[task_id]/[user_type]/page.tsx
@@ -123,9 +123,11 @@ export default async function TaskDetailPage({
                     </Typography>
                   </Stack>
                   <Stack direction="row" alignItems="center" columnGap="8px">
-                    <ArchiveWrapper taskId={task_id} userType={user_type} />
+                    {params.user_type === UserType.INTERNAL_USER && <MenuBoxContainer />}
+
                     <Stack direction="row" alignItems="center" columnGap="8px">
-                      {params.user_type === UserType.INTERNAL_USER && <MenuBoxContainer />}
+                      <ArchiveWrapper taskId={task_id} userType={user_type} />
+
                       <ToggleButtonContainer />
                     </Stack>
                   </Stack>

--- a/src/components/buttons/ArchiveBtn.tsx
+++ b/src/components/buttons/ArchiveBtn.tsx
@@ -1,10 +1,11 @@
 'use client'
 
 import { DustbinIcon } from '@/icons'
-import { Stack, Typography } from '@mui/material'
+import { Stack, Theme, Typography, useMediaQuery } from '@mui/material'
 import { SecondaryBtn } from '@/components/buttons/SecondaryBtn'
 
 export const ArchiveBtn = ({ isArchived, handleClick }: { isArchived: boolean; handleClick: () => void }) => {
+  const isXsScreen = useMediaQuery((theme: Theme) => `(max-width:${theme.breakpoints.values.sm}px)`)
   return (
     <Stack
       direction="row"
@@ -20,14 +21,22 @@ export const ArchiveBtn = ({ isArchived, handleClick }: { isArchived: boolean; h
       }}
       onClick={handleClick}
     >
-      <SecondaryBtn
-        startIcon={<DustbinIcon />}
-        buttonContent={
-          <Typography variant="sm" sx={{ color: (theme) => theme.color.gray[600] }}>
-            {!isArchived ? 'Archive' : 'Unarchive'}
-          </Typography>
-        }
-      />
+      {isXsScreen ? (
+        <DustbinIcon />
+      ) : (
+        <SecondaryBtn
+          startIcon={<DustbinIcon />}
+          buttonContent={
+            isXsScreen ? (
+              <DustbinIcon />
+            ) : (
+              <Typography variant="sm" sx={{ color: (theme) => theme.color.gray[600] }}>
+                {!isArchived ? 'Archive' : 'Unarchive'}
+              </Typography>
+            )
+          }
+        />
+      )}
     </Stack>
   )
 }

--- a/src/components/buttons/SecondaryBtn.tsx
+++ b/src/components/buttons/SecondaryBtn.tsx
@@ -14,6 +14,7 @@ export const SecondaryBtn = ({
   padding,
   variant,
   height,
+  width,
 }: {
   startIcon?: ReactNode
   buttonContent: ReactNode
@@ -23,6 +24,7 @@ export const SecondaryBtn = ({
   padding?: string
   variant?: SecondaryBtnVariant
   height?: string
+  width?: string
 }) => {
   const variantStyles: {
     [key in SecondaryBtnVariant]: { padding: string; border: string; bgcolor: string; hoverBgcolor: string }
@@ -52,6 +54,8 @@ export const SecondaryBtn = ({
         padding: padding ? padding : (variantStyling?.padding ?? { xs: '2px 9px', md: '4px 16px' }),
         cursor: 'pointer',
         height: height ?? 'auto',
+        width: width ?? 'auto',
+        minWidth: width ? 'auto' : '64px',
       })}
       onClick={handleClick}
       disableRipple

--- a/src/components/inputs/DisplaySelector.tsx
+++ b/src/components/inputs/DisplaySelector.tsx
@@ -11,6 +11,7 @@ interface DisplaySelectorProps {
   selectedMode: ViewMode
   archivedOptions: ArchivedOptionsType
   handleArchivedOptionsChange: (archivedOptions: ArchivedOptionsType) => void
+  mobileView?: boolean
 }
 
 export const DisplaySelector = ({
@@ -18,6 +19,7 @@ export const DisplaySelector = ({
   selectedMode,
   archivedOptions,
   handleArchivedOptionsChange,
+  mobileView,
 }: DisplaySelectorProps) => {
   const [anchorEl, setAnchorEl] = useState<null | Element>(null)
   const open = Boolean(anchorEl)
@@ -33,14 +35,19 @@ export const DisplaySelector = ({
     <>
       <SecondaryBtn
         buttonContent={
-          <Typography variant="bodySm" sx={{ color: (theme) => theme.color.gray[600], fontSize: '12px' }}>
-            Display
-          </Typography>
+          !mobileView ? (
+            <Typography variant="bodySm" sx={{ color: (theme) => theme.color.gray[600], fontSize: '12px' }}>
+              Display
+            </Typography>
+          ) : (
+            <DisplayOptionsIcon />
+          )
         }
-        startIcon={<DisplayOptionsIcon />}
+        startIcon={!mobileView && <DisplayOptionsIcon />}
         height="31.25px"
         padding="4px 8px 4px 10px"
         handleClick={handleClick}
+        width={mobileView ? '32px' : 'auto'}
       />
       <Menu
         id="basic-menu"

--- a/src/components/layouts/FilterBar.tsx
+++ b/src/components/layouts/FilterBar.tsx
@@ -331,7 +331,19 @@ export const FilterBar = ({ mode, updateViewModeSetting }: FilterBarProps) => {
         <Stack direction="column" rowGap={'8px'}>
           {mode === UserRole.IU && <FilterButtonGroup filterButtons={filterButtons} activeButtonIndex={ButtonIndex} />}
 
-          <Stack direction="row" justifyContent="space-between" alignItems="center">
+          <Stack
+            direction="row"
+            justifyContent="space-between"
+            alignItems="center"
+            sx={{
+              '@media (max-width: 368px)': {
+                flexWrap: 'wrap',
+                height: 'auto',
+              },
+              rowGap: '8px',
+              columnGap: '8px',
+            }}
+          >
             <Box>
               {filterOptions[FilterOptions.TYPE] !== tokenPayload?.internalUserId && mode === UserRole.IU && (
                 <Selector
@@ -424,6 +436,7 @@ export const FilterBar = ({ mode, updateViewModeSetting }: FilterBarProps) => {
                 }}
               />
               <DisplaySelector
+                mobileView
                 selectedMode={viewMode}
                 handleModeChange={(mode) => {
                   store.dispatch(


### PR DESCRIPTION
### Changes

- [x] fix alignment issue for searchbar and display button in mobile view when the name of filter assignee is too large.
- [x] created a flexwrap to transfer searchbar and display button to another row when they are overflowing. 
- [x] added display icon for display button in mobile view  

### Testing Criteria

- [LOOM](https://www.loom.com/share/c6028bd5c77b4c329a02d3cc985ee484)
![image](https://github.com/user-attachments/assets/86ee32a1-bde6-440f-8df4-d823e0424429)

