### PR TITLE
OUT-773 | Show 'No matches found for {search-text}' when there is no search result

### DIFF
--- a/src/components/inputs/Selector.tsx
+++ b/src/components/inputs/Selector.tsx
@@ -81,7 +81,6 @@ export default function Selector({
     }
     onClick?.()
   }
-
   const open = Boolean(anchorEl)
   const id = open ? 'autocomplete-popper' : ''
 
@@ -192,7 +191,7 @@ export default function Selector({
           }}
           openOnFocus
           onKeyDown={handleKeyDown}
-          ListboxProps={{ sx: { maxHeight: { xs: '175px', sm: '291px' } } }}
+          ListboxProps={{ sx: { maxHeight: { xs: '175px', sm: '291px' }, padding: '0px 0px 12px 0px' } }}
           options={extraOption ? [extraOption, ...options] : options}
           value={value}
           onChange={(_, newValue: unknown) => {
@@ -259,8 +258,29 @@ export default function Selector({
               />
             )
           }}
-          renderOption={(props, option: unknown) =>
-            extraOption && extraOptionRenderer && (option as IExtraOption)?.extraOptionFlag ? (
+          renderOption={(props, option: unknown) => {
+            if ((option as IExtraOption).id === 'not_found') {
+              return (
+                <Box
+                  sx={{
+                    color: 'gray',
+                    textAlign: 'left',
+                    padding: '2px 14px',
+
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                    maxWidth: '205px',
+                  }}
+                >
+                  <Typography variant="sm" sx={{ color: (theme) => theme.color.text.textDisabled }}>
+                    {`No matches found for "${inputStatusValue}"`}
+                  </Typography>
+                </Box>
+              )
+            }
+
+            return extraOption && extraOptionRenderer && (option as IExtraOption)?.extraOptionFlag ? (
               extraOptionRenderer(setAnchorEl, anchorEl, props)
             ) : selectorType === SelectorType.ASSIGNEE_SELECTOR ? (
               <AssigneeSelectorRenderer props={props} option={option} />
@@ -271,7 +291,7 @@ export default function Selector({
             ) : (
               <></>
             )
-          }
+          }}
         />
       </Popper>
     </Stack>

--- a/src/components/layouts/FilterBar.tsx
+++ b/src/components/layouts/FilterBar.tsx
@@ -22,7 +22,7 @@ import FilterButtonGroup from '@/components/buttonsGroup/FilterButtonsGroup'
 import { selectAuthDetails } from '@/redux/features/authDetailsSlice'
 import { useFilter } from '@/hooks/useFilter'
 import { IUTokenSchema } from '@/types/common'
-import { NoAssigneeExtraOptions } from '@/utils/noAssignee'
+import { NoAssigneeExtraOptions, NoDataFoundOption } from '@/utils/noAssignee'
 import { CreateViewSettingsDTO } from '@/types/dto/viewSettings.dto'
 import { z } from 'zod'
 import { setDebouncedFilteredAssignees } from '@/utils/users'
@@ -214,7 +214,7 @@ export const FilterBar = ({ mode, updateViewModeSetting }: FilterBarProps) => {
                           </IconButton>
                         )
                       }
-                      options={loading ? [] : filteredAssignee}
+                      options={loading ? [] : filteredAssignee.length ? filteredAssignee : [NoDataFoundOption]}
                       placeholder="Assignee"
                       value={assigneeValue}
                       selectorType={SelectorType.ASSIGNEE_SELECTOR}
@@ -381,7 +381,7 @@ export const FilterBar = ({ mode, updateViewModeSetting }: FilterBarProps) => {
                       </IconButton>
                     )
                   }
-                  options={loading ? [] : filteredAssignee}
+                  options={loading ? [] : filteredAssignee.length ? filteredAssignee : [NoDataFoundOption]}
                   placeholder="Assignee"
                   value={assigneeValue}
                   selectorType={SelectorType.ASSIGNEE_SELECTOR}

--- a/src/utils/noAssignee.ts
+++ b/src/utils/noAssignee.ts
@@ -15,3 +15,10 @@ export const NoAssigneeExtraOptions: IExtraOption = {
   value: '',
   extraOptionFlag: true,
 }
+
+export const NoDataFoundOption: IExtraOption = {
+  id: 'not_found',
+  name: 'Not found',
+  value: '',
+  extraOptionFlag: true,
+} //treating no data found placeholder also as an option.


### PR DESCRIPTION
### Changes

- [x] added noDataOption to be rendered when assignee filter is loaded and there is no data for the searched text

### Testing Criteria

- [LOOM](https://www.loom.com/share/a4991955e780401fb3ee8d599535d8db)
