### PR TITLE
OUT-773 (hotfix) : Show 'No matches found for {search-text}' when there is no search result

### DIFF
--- a/src/components/inputs/Selector.tsx
+++ b/src/components/inputs/Selector.tsx
@@ -191,7 +191,7 @@ export default function Selector({
           }}
           openOnFocus
           onKeyDown={handleKeyDown}
-          ListboxProps={{ sx: { maxHeight: { xs: '175px', sm: '291px' }, padding: '0px 0px 12px 0px' } }}
+          ListboxProps={{ sx: { maxHeight: { xs: '175px', sm: '291px' }, padding: '0px' } }}
           options={extraOption ? [extraOption, ...options] : options}
           value={value}
           onChange={(_, newValue: unknown) => {


### PR DESCRIPTION
### Changes

- [x] disabled bottom padding for selector component

### Testing Criteria

![image](https://github.com/user-attachments/assets/4946e5a6-7fd3-4273-80b5-48daad7af997)