### PR TITLE
OUT-1101 | Change past due date from red to standard grey when status = done

### DIFF
--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -107,7 +107,7 @@ export class TasksService extends BaseService {
       // @ts-ignore TS support for this param is still shakey
       relationLoadStrategy: 'join',
       include: {
-        workflowState: { select: { name: true } },
+        workflowState: { select: { name: true, type: true } },
       },
     })
 

--- a/src/components/cards/ClientTaskCard.tsx
+++ b/src/components/cards/ClientTaskCard.tsx
@@ -135,7 +135,7 @@ export const ClientTaskCard = ({
                     <Typography variant="bodySm" sx={{ fontSize: '12px', color: (theme) => theme.color.gray[500] }}>
                       <DueDateLayout
                         dateString={task.dueDate}
-                        isCompleted={task.workflowState.type === StateType.completed}
+                        isCompleted={task.workflowState?.type === StateType.completed}
                       />
                     </Typography>
                   </Box>
@@ -155,7 +155,7 @@ export const ClientTaskCard = ({
                       <Typography variant="bodySm" sx={{ fontSize: '12px', color: (theme) => theme.color.gray[500] }}>
                         <DueDateLayout
                           dateString={task.dueDate}
-                          isCompleted={task.workflowState.type === StateType.completed}
+                          isCompleted={task.workflowState?.type === StateType.completed}
                         />
                       </Typography>
                     )}

--- a/src/components/cards/ClientTaskCard.tsx
+++ b/src/components/cards/ClientTaskCard.tsx
@@ -16,6 +16,7 @@ import { CustomLink } from '@/hoc/CustomLink'
 import { getAssigneeName } from '@/utils/assignee'
 import { GetMaxAssigneeNameWidth } from '@/utils/getMaxAssigneeNameWidth'
 import { useEffect, useState } from 'react'
+import { StateType } from '@prisma/client'
 
 export const ClientTaskCard = ({
   task,
@@ -132,7 +133,10 @@ export const ClientTaskCard = ({
                     }}
                   >
                     <Typography variant="bodySm" sx={{ fontSize: '12px', color: (theme) => theme.color.gray[500] }}>
-                      <DueDateLayout dateString={task.dueDate} />
+                      <DueDateLayout
+                        dateString={task.dueDate}
+                        isCompleted={task.workflowState.type === StateType.completed}
+                      />
                     </Typography>
                   </Box>
                 )}
@@ -149,7 +153,10 @@ export const ClientTaskCard = ({
                   >
                     {task.dueDate && (
                       <Typography variant="bodySm" sx={{ fontSize: '12px', color: (theme) => theme.color.gray[500] }}>
-                        <DueDateLayout dateString={task.dueDate} />
+                        <DueDateLayout
+                          dateString={task.dueDate}
+                          isCompleted={task.workflowState.type === StateType.completed}
+                        />
                       </Typography>
                     )}
                   </Box>

--- a/src/components/cards/ListViewTaskCard.tsx
+++ b/src/components/cards/ListViewTaskCard.tsx
@@ -16,7 +16,7 @@ import { CopilotAvatar } from '@/components/atoms/CopilotAvatar'
 import { UrlObject } from 'url'
 import { CustomLink } from '@/hoc/CustomLink'
 import { getAssigneeName } from '@/utils/assignee'
-import { AssigneeType } from '@prisma/client'
+import { AssigneeType, StateType } from '@prisma/client'
 import { useEffect, useState } from 'react'
 import { ArchiveBoxIcon } from '@/icons'
 
@@ -109,7 +109,9 @@ export const ListViewTaskCard = ({
                 whiteSpace: 'nowrap',
               }}
             >
-              {task.dueDate && <DueDateLayout dateString={task.dueDate} />}
+              {task.dueDate && (
+                <DueDateLayout dateString={task.dueDate} isCompleted={task.workflowState.type === StateType.completed} />
+              )}
             </Box>
 
             {currentAssignee ? (

--- a/src/components/cards/ListViewTaskCard.tsx
+++ b/src/components/cards/ListViewTaskCard.tsx
@@ -110,7 +110,7 @@ export const ListViewTaskCard = ({
               }}
             >
               {task.dueDate && (
-                <DueDateLayout dateString={task.dueDate} isCompleted={task.workflowState.type === StateType.completed} />
+                <DueDateLayout dateString={task.dueDate} isCompleted={task.workflowState?.type === StateType.completed} />
               )}
             </Box>
 

--- a/src/components/cards/TaskCard.tsx
+++ b/src/components/cards/TaskCard.tsx
@@ -12,6 +12,7 @@ import { UrlObject } from 'url'
 import { useEffect, useState } from 'react'
 import { ArchiveBoxIcon } from '@/icons'
 import { getAssigneeName } from '@/utils/assignee'
+import { StateType } from '@prisma/client'
 
 const TaskCardContainer = styled(Stack)(({ theme }) => ({
   border: `1px solid ${theme.color.borders.border}`,
@@ -33,6 +34,7 @@ interface TaskCardProps {
 }
 
 export const TaskCard = ({ task, href }: TaskCardProps) => {
+  console.log('tt', task)
   const { assignee } = useSelector(selectTaskBoard)
 
   const [currentAssignee, setCurrentAssignee] = useState<IAssigneeCombined | undefined>(undefined)
@@ -92,7 +94,9 @@ export const TaskCard = ({ task, href }: TaskCardProps) => {
         <Typography variant="sm" sx={{ color: (theme) => theme.color.gray[600] }}>
           {task.title}
         </Typography>
-        {task.dueDate && <DueDateLayout dateString={task.dueDate} />}
+        {task.dueDate && (
+          <DueDateLayout dateString={task.dueDate} isCompleted={task.workflowState.type === StateType.completed} />
+        )}
       </Stack>
     </TaskCardContainer>
   )

--- a/src/components/cards/TaskCard.tsx
+++ b/src/components/cards/TaskCard.tsx
@@ -34,7 +34,6 @@ interface TaskCardProps {
 }
 
 export const TaskCard = ({ task, href }: TaskCardProps) => {
-  console.log('tt', task)
   const { assignee } = useSelector(selectTaskBoard)
 
   const [currentAssignee, setCurrentAssignee] = useState<IAssigneeCombined | undefined>(undefined)
@@ -95,7 +94,7 @@ export const TaskCard = ({ task, href }: TaskCardProps) => {
           {task.title}
         </Typography>
         {task.dueDate && (
-          <DueDateLayout dateString={task.dueDate} isCompleted={task.workflowState.type === StateType.completed} />
+          <DueDateLayout dateString={task.dueDate} isCompleted={task.workflowState?.type === StateType.completed} />
         )}
       </Stack>
     </TaskCardContainer>

--- a/src/components/layouts/DueDateLayout.tsx
+++ b/src/components/layouts/DueDateLayout.tsx
@@ -11,9 +11,11 @@ dayjs.extend(isTomorrow)
 
 interface DueDateLayoutProp {
   dateString: DateString
+  isCompleted: Boolean
 }
 
-export const DueDateLayout = ({ dateString }: DueDateLayoutProp) => {
+export const DueDateLayout = ({ dateString, isCompleted }: DueDateLayoutProp) => {
+  console.log('isCompleted', isCompleted)
   const date = createDateFromFormattedDateString(dateString)
   const now = dayjs()
   const calculateFormattedDueDate = useCallback(() => {
@@ -53,7 +55,10 @@ export const DueDateLayout = ({ dateString }: DueDateLayoutProp) => {
   const isPast = now.isAfter(formattedDueDate)
 
   return (
-    <Typography variant="bodySm" sx={{ color: (theme) => (isPast ? theme.color.error : theme.color.gray[500]) }}>
+    <Typography
+      variant="bodySm"
+      sx={{ color: (theme) => (isPast && !isCompleted ? theme.color.error : theme.color.gray[500]) }}
+    >
       {formattedDueDate}
     </Typography>
   )

--- a/src/components/layouts/DueDateLayout.tsx
+++ b/src/components/layouts/DueDateLayout.tsx
@@ -15,7 +15,6 @@ interface DueDateLayoutProp {
 }
 
 export const DueDateLayout = ({ dateString, isCompleted }: DueDateLayoutProp) => {
-  console.log('isCompleted', isCompleted)
   const date = createDateFromFormattedDateString(dateString)
   const now = dayjs()
   const calculateFormattedDueDate = useCallback(() => {


### PR DESCRIPTION
### Changes

- [x] Change API response to also include workflowstate type to prevent excessive prop drilling on frontend
- [x] When task is moved to completed, past due dates will appear as gray instead of red.

### Testing Criteria

- [x] Screenshot:
