### PR TITLE
OUT-1108 | Task details are missing when opening a task from email notification & notification center

### DIFF
--- a/src/app/detail/[task_id]/[user_type]/DetailStateUpdate.tsx
+++ b/src/app/detail/[task_id]/[user_type]/DetailStateUpdate.tsx
@@ -34,6 +34,7 @@ export const DetailStateUpdate = async ({ isRedirect, token, tokenPayload, task,
       token={token}
       viewSettings={viewSettings}
       tokenPayload={tokenPayload}
+      task={task}
     >
       {children}
     </ClientSideStateUpdate>

--- a/src/app/detail/ui/Sidebar.tsx
+++ b/src/app/detail/ui/Sidebar.tsx
@@ -92,7 +92,7 @@ export const Sidebar = ({
     }
   }, [isMobile])
 
-  if (!activeTask) return null
+  if (!activeTask) return <SidebarSkeleton />
 
   return (
     <Box


### PR DESCRIPTION
### Changes

- [x] task from getOneTask on details page was not being stored in the store as an active task when isRedirect was true, this was causing active task to be set as undefined when redirected and returning null from sidebar. Made sure to update activeTask when redirect is true. 

### Testing Criteria

- [LOOM](https://www.loom.com/share/05a34b3c18bd46bb8a40c2ec79d37bb6)


