### PR TITLE
OUT-1109 | Design regression from m5 on assignee selector

### DIFF
--- a/src/components/inputs/Selector.tsx
+++ b/src/components/inputs/Selector.tsx
@@ -191,7 +191,7 @@ export default function Selector({
           }}
           openOnFocus
           onKeyDown={handleKeyDown}
-          ListboxProps={{ sx: { maxHeight: { xs: '175px', sm: '291px' }, padding: '0px' } }}
+          ListboxProps={{ sx: { maxHeight: { xs: '175px', sm: '291px' }, padding: '0px 0px 8px 0px' } }}
           options={extraOption ? [extraOption, ...options] : options}
           value={value}
           onChange={(_, newValue: unknown) => {
@@ -265,7 +265,7 @@ export default function Selector({
                   sx={{
                     color: 'gray',
                     textAlign: 'left',
-                    padding: '2px 14px',
+                    padding: '6px 14px',
 
                     overflow: 'hidden',
                     textOverflow: 'ellipsis',


### PR DESCRIPTION
### Changes

- [x] added 8px padding below the listBoxProps in selector to make consistent spacing. 

### Testing Criteria

![image](https://github.com/user-attachments/assets/a39f5fc1-a215-49b9-ac71-e528c8d9227a)


