### PR TITLE
OUT-1101 | Change past due date from red to standard grey when status = done

### DIFF
--- a/src/components/cards/ClientTaskCard.tsx
+++ b/src/components/cards/ClientTaskCard.tsx
@@ -16,6 +16,7 @@ import { CustomLink } from '@/hoc/CustomLink'
 import { getAssigneeName } from '@/utils/assignee'
 import { GetMaxAssigneeNameWidth } from '@/utils/getMaxAssigneeNameWidth'
 import { useEffect, useState } from 'react'
+import { isTaskCompleted } from '@/utils/isTaskCompleted'
 
 export const ClientTaskCard = ({
   task,
@@ -28,7 +29,7 @@ export const ClientTaskCard = ({
   markdoneFlag: boolean
   href: string | UrlObject
 }) => {
-  const { assignee } = useSelector(selectTaskBoard)
+  const { assignee, workflowStates } = useSelector(selectTaskBoard)
   const [currentAssignee, setCurrentAssignee] = useState<IAssigneeCombined | undefined>(undefined)
 
   useEffect(() => {
@@ -132,7 +133,7 @@ export const ClientTaskCard = ({
                     }}
                   >
                     <Typography variant="bodySm" sx={{ fontSize: '12px', color: (theme) => theme.color.gray[500] }}>
-                      <DueDateLayout dateString={task.dueDate} />
+                      <DueDateLayout dateString={task.dueDate} isDone={isTaskCompleted(task, workflowStates)} />
                     </Typography>
                   </Box>
                 )}
@@ -149,7 +150,7 @@ export const ClientTaskCard = ({
                   >
                     {task.dueDate && (
                       <Typography variant="bodySm" sx={{ fontSize: '12px', color: (theme) => theme.color.gray[500] }}>
-                        <DueDateLayout dateString={task.dueDate} />
+                        <DueDateLayout dateString={task.dueDate} isDone={isTaskCompleted(task, workflowStates)} />
                       </Typography>
                     )}
                   </Box>

--- a/src/components/cards/ListViewTaskCard.tsx
+++ b/src/components/cards/ListViewTaskCard.tsx
@@ -19,6 +19,7 @@ import { getAssigneeName } from '@/utils/assignee'
 import { AssigneeType } from '@prisma/client'
 import { useEffect, useState } from 'react'
 import { ArchiveBoxIcon } from '@/icons'
+import { isTaskCompleted } from '@/utils/isTaskCompleted'
 
 export const ListViewTaskCard = ({
   task,
@@ -29,7 +30,7 @@ export const ListViewTaskCard = ({
   updateTask?: ({ payload }: { payload: UpdateTaskRequest }) => void
   href: string | UrlObject
 }) => {
-  const { assignee } = useSelector(selectTaskBoard)
+  const { assignee, workflowStates } = useSelector(selectTaskBoard)
 
   const [currentAssignee, setCurrentAssignee] = useState<IAssigneeCombined | undefined>(undefined)
   const [inputStatusValue, setInputStatusValue] = useState('')
@@ -109,7 +110,7 @@ export const ListViewTaskCard = ({
                 whiteSpace: 'nowrap',
               }}
             >
-              {task.dueDate && <DueDateLayout dateString={task.dueDate} />}
+              {task.dueDate && <DueDateLayout dateString={task.dueDate} isDone={isTaskCompleted(task, workflowStates)} />}
             </Box>
 
             {currentAssignee ? (

--- a/src/components/cards/TaskCard.tsx
+++ b/src/components/cards/TaskCard.tsx
@@ -12,6 +12,7 @@ import { UrlObject } from 'url'
 import { useEffect, useState } from 'react'
 import { ArchiveBoxIcon } from '@/icons'
 import { getAssigneeName } from '@/utils/assignee'
+import { isTaskCompleted } from '@/utils/isTaskCompleted'
 
 const TaskCardContainer = styled(Stack)(({ theme }) => ({
   border: `1px solid ${theme.color.borders.border}`,
@@ -33,7 +34,7 @@ interface TaskCardProps {
 }
 
 export const TaskCard = ({ task, href }: TaskCardProps) => {
-  const { assignee } = useSelector(selectTaskBoard)
+  const { assignee, workflowStates } = useSelector(selectTaskBoard)
 
   const [currentAssignee, setCurrentAssignee] = useState<IAssigneeCombined | undefined>(undefined)
 
@@ -92,7 +93,7 @@ export const TaskCard = ({ task, href }: TaskCardProps) => {
         <Typography variant="sm" sx={{ color: (theme) => theme.color.gray[600] }}>
           {task.title}
         </Typography>
-        {task.dueDate && <DueDateLayout dateString={task.dueDate} />}
+        {task.dueDate && <DueDateLayout dateString={task.dueDate} isDone={isTaskCompleted(task, workflowStates)} />}
       </Stack>
     </TaskCardContainer>
   )

--- a/src/components/layouts/DueDateLayout.tsx
+++ b/src/components/layouts/DueDateLayout.tsx
@@ -11,9 +11,10 @@ dayjs.extend(isTomorrow)
 
 interface DueDateLayoutProp {
   dateString: DateString
+  isDone: boolean
 }
 
-export const DueDateLayout = ({ dateString }: DueDateLayoutProp) => {
+export const DueDateLayout = ({ dateString, isDone }: DueDateLayoutProp) => {
   const date = createDateFromFormattedDateString(dateString)
   const now = dayjs()
   const calculateFormattedDueDate = useCallback(() => {
@@ -53,7 +54,7 @@ export const DueDateLayout = ({ dateString }: DueDateLayoutProp) => {
   const isPast = now.isAfter(formattedDueDate)
 
   return (
-    <Typography variant="bodySm" sx={{ color: (theme) => (isPast ? theme.color.error : theme.color.gray[500]) }}>
+    <Typography variant="bodySm" sx={{ color: (theme) => (isPast && !isDone ? theme.color.error : theme.color.gray[500]) }}>
       {formattedDueDate}
     </Typography>
   )

--- a/src/utils/isTaskCompleted.ts
+++ b/src/utils/isTaskCompleted.ts
@@ -1,0 +1,10 @@
+'use client'
+
+import { selectTaskBoard } from '@/redux/features/taskBoardSlice'
+import { TaskResponse } from '@/types/dto/tasks.dto'
+import { WorkflowStateResponse } from '@/types/dto/workflowStates.dto'
+import { StateType } from '@prisma/client'
+
+export const isTaskCompleted = (task: TaskResponse, workflowStates: WorkflowStateResponse[]): boolean => {
+  return workflowStates?.find((workflowState) => workflowState.id == task.workflowStateId)?.type === StateType.completed
+}


### PR DESCRIPTION
### Changes

- [x] created isTaskCompleted function to check whether a task's type is completed or not. 
- [x] in ```DueDateLayout```, applied the error color for due date if the due date is a past date and not in the completed state by passing isDone prop. 

### Testing Criteria

- [LOOM](https://www.loom.com/share/d1a7ccfa82374f8680a29698649ff0e8)


