### PR TITLE
OUT-1113 | template title cannot be empty

### DIFF
--- a/src/app/manage-templates/ui/TemplateForm.tsx
+++ b/src/app/manage-templates/ui/TemplateForm.tsx
@@ -160,6 +160,15 @@ const NewTaskFormInputs = () => {
 }
 
 const NewTaskFooter = ({ handleCreate, targetMethod }: { handleCreate: () => void; targetMethod: TargetMethod }) => {
+  const { taskName } = useSelector(selectCreateTemplate)
+  const handleTemplateCreation = () => {
+    const hasTitleError = !taskName.trim()
+    if (hasTitleError) {
+      store.dispatch(setErrors({ key: createTemplateErrors.TITLE, value: true }))
+    } else {
+      handleCreate()
+    }
+  }
   return (
     <Box sx={{ borderTop: (theme) => `1px solid ${theme.color.borders.border2}` }}>
       <AppMargin size={SizeofAppMargin.MEDIUM} py="16px">
@@ -176,7 +185,10 @@ const NewTaskFooter = ({ handleCreate, targetMethod }: { handleCreate: () => voi
                 </Typography>
               }
             />
-            <PrimaryBtn handleClick={handleCreate} buttonText={targetMethod === TargetMethod.POST ? 'Create' : 'Save'} />
+            <PrimaryBtn
+              handleClick={handleTemplateCreation}
+              buttonText={targetMethod === TargetMethod.POST ? 'Create' : 'Save'}
+            />
           </Stack>
         </Stack>
       </AppMargin>


### PR DESCRIPTION
### Changes

- [x] added validation for template titles not to be empty while creating/editing a template. 


### Testing Criteria

![image](https://github.com/user-attachments/assets/bb59cc3a-7a15-49b6-805c-90f6902e5ad6)


