### PR TITLE
OUT-1126, OUT-1124 | Status doesn’t update correctly when template is applied

### DIFF
--- a/src/app/ui/MenuBoxContainer.tsx
+++ b/src/app/ui/MenuBoxContainer.tsx
@@ -14,7 +14,7 @@ export const MenuBoxContainer = () => {
       menuContent={
         <CustomLink href={{ pathname: '/manage-templates', query: { token } }}>
           <ListBtn
-            content="Manage Templates"
+            content="Manage templates"
             handleClick={() => {}}
             icon={<TemplateIcon />}
             contentColor={(theme) => theme.color.text.text}

--- a/src/app/ui/NewTaskForm.tsx
+++ b/src/app/ui/NewTaskForm.tsx
@@ -230,6 +230,7 @@ export const NewTaskForm = ({ handleCreate, handleClose }: NewTaskFormProps) => 
         handleCreate={handleCreateWithAssignee}
         handleClose={handleClose}
         setIsEditorReadonly={setIsEditorReadonly}
+        updateWorkflowStatusValue={updateStatusValue}
       />
     </NewTaskContainer>
   )
@@ -290,11 +291,16 @@ const NewTaskFormInputs = ({ isEditorReadonly }: NewTaskFormInputsProps) => {
   )
 }
 
-const NewTaskFooter = ({ handleCreate, handleClose, setIsEditorReadonly }: NewTaskFormProps) => {
+const NewTaskFooter = ({
+  handleCreate,
+  handleClose,
+  setIsEditorReadonly,
+  updateWorkflowStatusValue,
+}: NewTaskFormProps & { updateWorkflowStatusValue: (value: unknown) => void }) => {
   const [inputStatusValue, setInputStatusValue] = useState('')
 
   const { title, assigneeId } = useSelector(selectCreateTask)
-  const { token } = useSelector(selectTaskBoard)
+  const { token, workflowStates } = useSelector(selectTaskBoard)
   const { templates } = useSelector(selectCreateTemplate)
 
   const { renderingItem: _templateValue, updateRenderingItem: updateTemplateValue } = useHandleSelectorComponent({
@@ -311,6 +317,8 @@ const NewTaskFooter = ({ handleCreate, handleClose, setIsEditorReadonly }: NewTa
       const { data: template } = await resp.json()
       setIsEditorReadonly?.(false)
 
+      updateWorkflowStatusValue(workflowStates.find((state) => state.id === template.workflowStateId))
+      store.dispatch(setCreateTaskFields({ targetField: 'workflowStateId', value: template.workflowStateId }))
       store.dispatch(setCreateTaskFields({ targetField: 'description', value: template.body }))
       // Reset any errors that might have come from title field being empty
       store.dispatch(setErrors({ key: CreateTaskErrors.TITLE, value: false }))


### PR DESCRIPTION
### Changes

- [x] updated status while applying the template on ```createTaskFields``` state and ```workflowStateSelector``` component.
- [x] Fixed copy in Manage templates kebab menu button from "Manage Templates" to "Manage templates".

### Testing Criteria

- [LOOM](https://www.loom.com/share/a8c4b4f9adde4629b5fecaa743af6b15)


