### PR TITLE
OUT-1122 | OUT-1125 | '+ Create template' button doesn't appear / disappear in real-time

### DIFF
--- a/src/app/manage-templates/page.tsx
+++ b/src/app/manage-templates/page.tsx
@@ -76,7 +76,7 @@ export default async function ManageTemplatesPage({ searchParams }: ManageTempla
     >
       <RealTimeTemplates tokenPayload={tokenPayload}>
         <AppMargin size={SizeofAppMargin.LARGE}>
-          <ManageTemplateHeader showNewTemplateButton={templates?.length > 0} />
+          <ManageTemplateHeader />
           <TemplateBoard
             handleCreateTemplate={async (payload: CreateTemplateRequest) => {
               'use server'

--- a/src/app/manage-templates/ui/Header.tsx
+++ b/src/app/manage-templates/ui/Header.tsx
@@ -6,7 +6,7 @@ import { PrimaryBtn } from '@/components/buttons/PrimaryBtn'
 import { PlusIcon } from '@/icons'
 import { StyledBox, StyledKeyboardIcon, StyledTypography } from '@/app/detail/ui/styledComponent'
 import store from '@/redux/store'
-import { setShowTemplateModal } from '@/redux/features/templateSlice'
+import { selectCreateTemplate, setShowTemplateModal } from '@/redux/features/templateSlice'
 import { TargetMethod } from '@/types/interfaces'
 import { useRouter } from 'next/navigation'
 import { useSelector } from 'react-redux'
@@ -14,9 +14,10 @@ import { selectTaskBoard } from '@/redux/features/taskBoardSlice'
 import { IconBtn } from '@/components/buttons/IconBtn'
 import { Add } from '@mui/icons-material'
 
-export const ManageTemplateHeader = ({ showNewTemplateButton }: { showNewTemplateButton: boolean }) => {
+export const ManageTemplateHeader = () => {
   const router = useRouter()
   const { token } = useSelector(selectTaskBoard)
+  const { templates } = useSelector(selectCreateTemplate)
   return (
     <StyledBox>
       <AppMargin size={SizeofAppMargin.LARGE} py="16px">
@@ -33,7 +34,7 @@ export const ManageTemplateHeader = ({ showNewTemplateButton }: { showNewTemplat
             <StyledKeyboardIcon />
             <Typography variant="sm">Manage Templates</Typography>
           </Stack>
-          {showNewTemplateButton && (
+          {templates?.length ? (
             <>
               <Box
                 sx={{
@@ -57,7 +58,7 @@ export const ManageTemplateHeader = ({ showNewTemplateButton }: { showNewTemplat
                 />
               </Box>
             </>
-          )}
+          ) : null}
         </Stack>
       </AppMargin>
     </StyledBox>


### PR DESCRIPTION
### Changes

- [x] Fix static API response being used as single source of truth for showing / hiding create template button
- [x] Make showing / hiding button dependent on `templates ` redux value instead

### Testing Criteria

- [x] Screencast
[Screencast from 2024-12-10 15-17-29.webm](https://github.com/user-attachments/assets/191cb707-eb3d-4340-9d37-f9bb37132027)
