### PR TITLE
OUT-1116 | Applying the same template a second time causes part of the templates menu to disappear

### DIFF
--- a/src/components/inputs/Selector.tsx
+++ b/src/components/inputs/Selector.tsx
@@ -199,6 +199,7 @@ export default function Selector({
           onBlur={() => {
             setAnchorEl(null)
           }}
+          blurOnSelect={true}
           openOnFocus
           onKeyDown={handleKeyDown}
           ListboxProps={{ sx: { maxHeight: { xs: '175px', sm: '291px' }, padding: '0px 0px 8px 0px' } }}


### PR DESCRIPTION
### Changes

- [x] Add prop to blur select when an option is clicked

### Testing Criteria

- [x] Screencast

[Screencast from 2024-12-10 15-31-27.webm](https://github.com/user-attachments/assets/c555cec8-5eb4-4245-b94a-c9a5b31c172d)
