### PR TITLE
OUT-1119 | Template cards in manage templates should be clickable

### DIFF
--- a/src/components/cards/TemplateCard.tsx
+++ b/src/components/cards/TemplateCard.tsx
@@ -29,6 +29,14 @@ export const TemplateCard = ({ title, handleDelete, handleEdit }: TemplateCardPr
         padding: '16px',
         background: (theme) => (isHovered ? theme.color.background.bgCallout : 'white'),
       }}
+      onClick={(e) => {
+        setTimeout(() => {
+          const menuOpen = document.getElementById('template-menu-open')
+          if (!menuOpen) {
+            handleEdit()
+          }
+        }, 0)
+      }}
       justifyContent="space-between"
       alignItems="center"
       onMouseEnter={handleMouseHover}
@@ -39,7 +47,10 @@ export const TemplateCard = ({ title, handleDelete, handleEdit }: TemplateCardPr
         <Typography variant="bodyMd">{truncateText(title, 38)}</Typography>
       </Box>
 
-      <Box sx={{ opacity: isHovered || isMenuOpen ? '100%' : '0' }}>
+      <Box
+        id={isMenuOpen ? 'template-menu-open' : 'template-menu-closed'}
+        sx={{ opacity: isHovered || isMenuOpen ? '100%' : '0' }}
+      >
         <StyledMenuBox
           setIsMenuOpen={setIsMenuOpen}
           menuContent={

--- a/src/components/cards/TemplateCard.tsx
+++ b/src/components/cards/TemplateCard.tsx
@@ -25,6 +25,7 @@ export const TemplateCard = ({ title, handleDelete, handleEdit }: TemplateCardPr
       direction="row"
       sx={{
         border: (theme) => `1px solid ${theme.color.borders.border}`,
+        cursor: 'pointer',
         borderRadius: '4px',
         padding: '16px',
         background: (theme) => (isHovered ? theme.color.background.bgCallout : 'white'),


### PR DESCRIPTION
### Changes

- [x] Make templates card clickable
- [x] Add cursor: pointer to card 

### Testing Criteria

- [x] Screencast

[Screencast from 2024-12-10 18-04-35.webm](https://github.com/user-attachments/assets/046e8a95-232a-45c7-967f-3e15a96fe4a3)
