### PR TITLE
OUT-1117 | Do not allow templates with duplicate names

### DIFF
--- a/prisma/migrations/20241211122347_add_unique_constraint_to_task_templates_title_and_workspace_id/migration.sql
+++ b/prisma/migrations/20241211122347_add_unique_constraint_to_task_templates_title_and_workspace_id/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[title,workspaceId]` on the table `TaskTemplates` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "TaskTemplates_title_workspaceId_key" ON "TaskTemplates"("title", "workspaceId");

--- a/prisma/schema/taskTemplate.prisma
+++ b/prisma/schema/taskTemplate.prisma
@@ -11,5 +11,6 @@ model TaskTemplate {
   updatedAt   DateTime  @updatedAt
   deletedAt   DateTime?
 
+  @@unique([title, workspaceId], name: "UQ_TaskTemplates_title_workspaceId")
   @@map("TaskTemplates")
 }

--- a/src/app/api/tasks/templates/templates.service.ts
+++ b/src/app/api/tasks/templates/templates.service.ts
@@ -60,6 +60,7 @@ export class TemplatesService extends BaseService {
       SELECT COUNT(*) AS count
       FROM "TaskTemplates"
       WHERE "title" ~ '^${Prisma.raw(`${title}`)}( copy)*$'
+        AND "workspaceId" = '${Prisma.raw(`${this.user.workspaceId}`)}'
         AND "deletedAt" IS NULL;
     `
     const result = await this.db.$queryRaw<{ count: bigint }[]>`${query}`

--- a/src/app/api/tasks/templates/templates.service.ts
+++ b/src/app/api/tasks/templates/templates.service.ts
@@ -5,12 +5,14 @@ import { CreateTemplateRequest, UpdateTemplateRequest } from '@/types/dto/templa
 import { copyTemplateMediaToTask } from '@/utils/signedTemplateUrlReplacer'
 import { getFilePathFromUrl, replaceImageSrc } from '@/utils/signedUrlReplacer'
 import { getSignedUrl } from '@/utils/signUrl'
+import { sanitize } from '@/utils/sql'
 import { SupabaseActions } from '@/utils/SupabaseActions'
 import APIError from '@api/core/exceptions/api'
 import { BaseService } from '@api/core/services/base.service'
 import { PoliciesService } from '@api/core/services/policies.service'
 import { Resource } from '@api/core/types/api'
 import { UserAction } from '@api/core/types/user'
+import { Prisma } from '@prisma/client'
 import httpStatus from 'http-status'
 import { z } from 'zod'
 
@@ -50,9 +52,27 @@ export class TemplatesService extends BaseService {
     const policyGate = new PoliciesService(this.user)
     policyGate.authorize(UserAction.Create, Resource.TaskTemplates)
 
+    // If template with same title already exists, append successive "copy" string after it
+    // E.g. "hello" -> "hello copy" -> "hello copy copy"
+    let title = sanitize(payload.title.trim())
+    // For some reason normal parameterized string doesn't work so using Prisma.raw with sanitized strings
+    const query = Prisma.sql`
+      SELECT COUNT(*) AS count
+      FROM "TaskTemplates"
+      WHERE "title" ~ '^${Prisma.raw(`${title}`)}( copy)*$'
+        AND "deletedAt" IS NULL;
+    `
+    const result = await this.db.$queryRaw<{ count: bigint }[]>`${query}`
+
+    const count = result[0]?.count
+    for (let i = 0; i < count; i++) {
+      title += ' copy'
+    }
+
     let templates = await this.db.taskTemplate.create({
       data: {
         ...payload,
+        title,
         workspaceId: this.user.workspaceId,
         createdById: z.string().parse(this.user.internalUserId),
       },

--- a/src/app/manage-templates/ui/TemplateBoard.tsx
+++ b/src/app/manage-templates/ui/TemplateBoard.tsx
@@ -99,7 +99,7 @@ export const TemplateBoard = ({
               body: description,
             }
             if (targetMethod === TargetMethod.POST) {
-              const data = await handleCreateTemplate(temp)
+              const resp = await handleCreateTemplate(temp)
             } else {
               handleEditTemplate(temp, targetTemplateId)
             }

--- a/src/utils/sql.ts
+++ b/src/utils/sql.ts
@@ -1,0 +1,8 @@
+/**
+ * Util that escapes special characters to prevent SQL injection
+ */
+export const sanitize = (str: string) =>
+  str
+    .replace(/(\x00|\x1a)/g, '') // Remove null bytes
+    .replace(/['"]/g, "''") // Escape single/double quotes by doubling them
+    .replace(/;/g, '') // Remove semicolons (end of sql statement)


### PR DESCRIPTION
### Changes

- [x] Identify and remove duplicate titled templates from preview db

```sql
-- Identify dup titles
SELECT "TaskTemplates"."title", "TaskTemplates"."workspaceId", count(*)
FROM "TaskTemplates"
GROUP BY "TaskTemplates"."title", "TaskTemplates"."workspaceId"
HAVING COUNT(*) > 1;
```

```sql
-- Delete dup template having higher row number (deletes everything except the original template for a title)
WITH ranked_templates AS (
  SELECT id, title, "workspaceId",
         ROW_NUMBER() OVER (
           PARTITION BY title, "workspaceId"
           ORDER BY id ASC
         ) AS row_num
  FROM "TaskTemplates"
)
DELETE FROM "TaskTemplates"
WHERE id IN (
  SELECT id
  FROM ranked_templates
  WHERE row_num > 1
);
```

- [x] Add composite unique constraint on `title` and `workspaceId` for TaskTemplates table
- [x] Append "copy" to duplicate template names

### Testing Criteria

- [x] Screenshots (because screencast is crashing my system)

1st creation:
![image](https://github.com/user-attachments/assets/e7fa0eef-0151-4626-9a0e-26dbdd85f924)

2nd creation:
![image](https://github.com/user-attachments/assets/86f6e358-f3c2-41ad-816f-beda5d7612e1)

3rd creation:
![image](https://github.com/user-attachments/assets/4f24248f-1ede-42d7-b76b-4bb9136efe9e)

UI view:
![image](https://github.com/user-attachments/assets/19071dbd-13b6-4038-8491-2ae8f8bc6e99)
