### PR TITLE
OUT-1141, OUT-1144, OUT-1146, OUT-1140, OUT-1150 | Vertical line in the Manage templates page does not extend all the way

### DIFF
--- a/src/app/detail/[task_id]/[user_type]/page.tsx
+++ b/src/app/detail/[task_id]/[user_type]/page.tsx
@@ -98,7 +98,7 @@ export default async function TaskDetailPage({
         <Stack direction="row" sx={{ height: '100vh' }}>
           <ToggleController>
             <StyledBox>
-              <AppMargin size={SizeofAppMargin.LARGE} py="16px">
+              <AppMargin size={SizeofAppMargin.HEADER} py="17.5px">
                 <Stack direction="row" justifyContent="space-between">
                   <HeaderBreadcrumbs token={token} title={task?.label} userType={params.user_type} />
                   <Stack direction="row" alignItems="center" columnGap="8px">

--- a/src/app/detail/ui/Sidebar.tsx
+++ b/src/app/detail/ui/Sidebar.tsx
@@ -104,7 +104,7 @@ export const Sidebar = ({
       }}
     >
       <StyledBox>
-        <AppMargin size={SizeofAppMargin.LARGE} py="16px">
+        <AppMargin size={SizeofAppMargin.HEADER} py="17.5px">
           <Stack
             direction="row"
             justifyContent="space-between"
@@ -125,8 +125,8 @@ export const Sidebar = ({
         </AppMargin>
       </StyledBox>
 
-      <AppMargin size={SizeofAppMargin.SMALL}>
-        <Stack direction="row" alignItems="center" m="16px 0px" columnGap="10px">
+      <AppMargin size={SizeofAppMargin.HEADER} py={'4px'}>
+        <Stack direction="row" alignItems="center" m="4px 0px" columnGap="10px">
           <StyledText variant="md" minWidth="80px">
             Status
           </StyledText>
@@ -291,20 +291,29 @@ export const SidebarSkeleton = () => {
           display="flex"
           justifyContent="space-between"
           alignItems="center"
-          sx={{ padding: { xs: '16px 20px', sm: '20px 20px' } }}
+          sx={{ padding: { xs: '17.5px 20px', sm: '17.5px 20px' } }}
         >
-          <Typography variant="sm">Properties</Typography>
-          <Box
-            sx={{
-              display: isMobile ? 'block' : 'none',
-            }}
+          <Stack
+            direction="row"
+            justifyContent="space-between"
+            alignItems="center"
+            sx={{ height: { sm: '32px', md: '36px' } }}
           >
-            <ToggleButtonContainer />
-          </Box>
+            <Typography variant="sm" lineHeight={'21px'} fontSize={'13px'}>
+              Properties
+            </Typography>
+            <Box
+              sx={{
+                display: isMobile ? 'block' : 'none',
+              }}
+            >
+              <ToggleButtonContainer />
+            </Box>
+          </Stack>
         </StyledBox>
       </Stack>
-      <AppMargin size={SizeofAppMargin.SMALL}>
-        <Stack direction="row" alignItems="center" m="25px 0px" columnGap="10px">
+      <AppMargin size={SizeofAppMargin.HEADER} py={'4px'}>
+        <Stack direction="row" alignItems="center" m="4px 0px" columnGap="10px">
           <StyledText variant="md" minWidth="80px">
             Status
           </StyledText>

--- a/src/app/manage-templates/page.tsx
+++ b/src/app/manage-templates/page.tsx
@@ -75,23 +75,21 @@ export default async function ManageTemplatesPage({ searchParams }: ManageTempla
       tokenPayload={tokenPayload}
     >
       <RealTimeTemplates tokenPayload={tokenPayload}>
-        <AppMargin size={SizeofAppMargin.LARGE}>
-          <ManageTemplateHeader />
-          <TemplateBoard
-            handleCreateTemplate={async (payload: CreateTemplateRequest) => {
-              'use server'
-              return await createNewTemplate(token, payload)
-            }}
-            handleDeleteTemplate={async (templateId: string) => {
-              'use server'
-              await deleteTemplate(token, templateId)
-            }}
-            handleEditTemplate={async (payload: UpdateTemplateRequest, templateId: string) => {
-              'use server'
-              await editTemplate(token, templateId, payload)
-            }}
-          />
-        </AppMargin>
+        <ManageTemplateHeader token={token} />
+        <TemplateBoard
+          handleCreateTemplate={async (payload: CreateTemplateRequest) => {
+            'use server'
+            return await createNewTemplate(token, payload)
+          }}
+          handleDeleteTemplate={async (templateId: string) => {
+            'use server'
+            await deleteTemplate(token, templateId)
+          }}
+          handleEditTemplate={async (payload: UpdateTemplateRequest, templateId: string) => {
+            'use server'
+            await editTemplate(token, templateId, payload)
+          }}
+        />
       </RealTimeTemplates>
     </ClientSideStateUpdate>
   )

--- a/src/app/manage-templates/ui/Header.tsx
+++ b/src/app/manage-templates/ui/Header.tsx
@@ -14,12 +14,11 @@ import { IconBtn } from '@/components/buttons/IconBtn'
 import { Add } from '@mui/icons-material'
 import { HeaderBreadcrumbs } from '@/components/layouts/HeaderBreadcrumbs'
 
-export const ManageTemplateHeader = () => {
-  const { token } = useSelector(selectTaskBoard)
+export const ManageTemplateHeader = ({ token }: { token: string }) => {
   const { templates } = useSelector(selectCreateTemplate)
   return (
     <StyledBox>
-      <AppMargin size={SizeofAppMargin.LARGE} py="16px">
+      <AppMargin size={SizeofAppMargin.HEADER} py="17.5px">
         <Stack direction="row" justifyContent="space-between" alignItems="center">
           <HeaderBreadcrumbs title="Manage templates" token={token} />
           {templates?.length ? (

--- a/src/app/manage-templates/ui/TemplateForm.tsx
+++ b/src/app/manage-templates/ui/TemplateForm.tsx
@@ -121,7 +121,7 @@ const NewTaskFormInputs = () => {
             store.dispatch(setErrors({ key: createTemplateErrors.TITLE, value: false }))
           }}
           error={errors.title}
-          helperText={errors.title && 'Required'}
+          helperText={errors.title && 'Enter template name'}
           inputProps={{
             maxLength: 255,
           }}

--- a/src/app/ui/NewTaskForm.tsx
+++ b/src/app/ui/NewTaskForm.tsx
@@ -106,7 +106,10 @@ export const NewTaskForm = ({ handleCreate, handleClose }: NewTaskFormProps) => 
         }}
       >
         <AppMargin size={SizeofAppMargin.MEDIUM} py="12px">
-          <Stack direction="row" alignItems="center" justifyContent="flex-end">
+          <Stack direction="row" alignItems="center" justifyContent="space-between">
+            <Typography variant="md" fontSize={'15px'} lineHeight={'18.15px'}>
+              Create task
+            </Typography>
             <CloseIcon style={{ cursor: 'pointer' }} onClick={() => handleClose()} />
           </Stack>
         </AppMargin>
@@ -332,7 +335,7 @@ const NewTaskFooter = ({
         id="manage-templates-btn"
         key={'Manage templates'}
         direction="row"
-        pl="20px"
+        pl="16px"
         py="6px"
         justifyContent="space-between"
         sx={{


### PR DESCRIPTION
### Changes

- [x] create task title in create new task modal added
- [x] Manage templates button aligned with other options in apply templates dropdown.
- [x] Updated error message when template name is missing while creating a new template.
- [x] Fixed margin not taking the full width in header of manage templates page
- [x] Fixed spacing of header component in task details and manage templates page.     

### Testing Criteria

- [LOOM](https://www.loom.com/share/d76b6515410245e8ac3f57c8f0c3d176)
