### PR TITLE
OUT-1147, OUT-1149, OUT-1133 | Ellipsis hover state is always showing on task details page

### DIFF
--- a/src/app/detail/ui/MenuBoxContainer.tsx
+++ b/src/app/detail/ui/MenuBoxContainer.tsx
@@ -18,6 +18,10 @@ export const MenuBoxContainer = () => {
           contentColor="#CC0000"
         />
       }
+      noHover={true}
+      displayButtonBackground={false}
+      width={'28px'}
+      height={'28px'}
     />
   )
 }

--- a/src/app/ui/NewTaskForm.tsx
+++ b/src/app/ui/NewTaskForm.tsx
@@ -382,10 +382,13 @@ const NewTaskFooter = ({
             endOptionHref={`/manage-templates?token=${token}`}
             listAutoHeightMax="147px"
             buttonContent={
-              <Typography variant="sm" sx={{ color: (theme) => theme.color.gray[600] }}>
+              <Typography variant="sm" sx={{ color: (theme) => theme.color.gray[600], lineHeight: '24px' }}>
                 {'Apply template'}
               </Typography>
             }
+            disableOutline
+            responsiveNoHide
+            buttonWidth="auto"
           />
           <Stack
             direction="row"

--- a/src/components/buttons/ArchiveBtn.tsx
+++ b/src/components/buttons/ArchiveBtn.tsx
@@ -26,6 +26,7 @@ export const ArchiveBtn = ({ isArchived, handleClick }: { isArchived: boolean; h
       ) : (
         <SecondaryBtn
           startIcon={<DustbinIcon />}
+          height="28px"
           buttonContent={
             isXsScreen ? (
               <DustbinIcon />

--- a/src/redux/features/templateSlice.tsx
+++ b/src/redux/features/templateSlice.tsx
@@ -68,6 +68,7 @@ const createTemplateSlice = createSlice({
       state.errors = {
         [createTemplateErrors.TITLE]: false,
       }
+      state.activeWorkflowStateId = null
     },
     setTargetTemplateId: (state, action: { payload: string }) => {
       state.targetTemplateId = action.payload


### PR DESCRIPTION
### Changes

- [x] Fixed status of recently updated template showing up on new template. Cleared activeWorkflowStateId while closing the create template modal.
- [x] Ellipsis hover state always showing on task Details page solved. applied menuxBox exactly like the main page.
- [x] Removed border from the apply template button in task creation modal.

### Testing Criteria

- [LOOM](https://www.loom.com/share/6c1437341a7e4fbab9ccb83f075666c0)

