### PR TITLE
OUT-1111 | Task details page header and properties header div are misaligned

### DIFF
--- a/src/app/detail/ui/Sidebar.tsx
+++ b/src/app/detail/ui/Sidebar.tsx
@@ -105,12 +105,7 @@ export const Sidebar = ({
     >
       <StyledBox>
         <AppMargin size={SizeofAppMargin.HEADER} py="17.5px">
-          <Stack
-            direction="row"
-            justifyContent="space-between"
-            alignItems="center"
-            sx={{ height: { xs: '28px', sm: '34px' } }}
-          >
+          <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ height: '28px' }}>
             <Typography variant="sm" lineHeight={'21px'} fontSize={'13px'}>
               Properties
             </Typography>
@@ -288,12 +283,7 @@ export const SidebarSkeleton = () => {
     >
       <StyledBox>
         <AppMargin size={SizeofAppMargin.HEADER} py="17.5px">
-          <Stack
-            direction="row"
-            justifyContent="space-between"
-            alignItems="center"
-            sx={{ height: { xs: '28px', sm: '34px' } }}
-          >
+          <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ height: '28px' }}>
             <Typography variant="sm" lineHeight={'21px'} fontSize={'13px'}>
               Properties
             </Typography>

--- a/src/components/buttons/ArchiveBtn.tsx
+++ b/src/components/buttons/ArchiveBtn.tsx
@@ -12,7 +12,7 @@ export const ArchiveBtn = ({ isArchived, handleClick }: { isArchived: boolean; h
       alignItems="center"
       columnGap="6px"
       sx={{
-        padding: '3px 8px',
+        padding: '0px 8px',
         ':hover': {
           cursor: 'pointer',
           border: ' 1px solid #EOEOEO, rgba(0, 0, 0, 0.12))',


### PR DESCRIPTION
### Changes

- [x] removed Y padding of archived button to make it consistent on clients view too.
- [x] decreased height of properties header in sidebar to 28px from 36px.

### Testing Criteria

![image](https://github.com/user-attachments/assets/603640ab-cff1-4a85-9320-259b049509c5)
![image](https://github.com/user-attachments/assets/af9efd5b-946e-44c4-8a9e-b3aafcd36792)


### Notes

- Dependencies on other PRs, any required changes in config/setup to test behaviour, or links to external documents, threads, etc -- if any of them are required