### PR TITLE
OUT-1155 | Rename button label to ´+ Create task´.

### DIFF
--- a/src/components/layouts/EmptyState/DashboardEmptyState.tsx
+++ b/src/components/layouts/EmptyState/DashboardEmptyState.tsx
@@ -48,7 +48,7 @@ const DashboardEmptyState = ({ userType }: { userType: UserRole }) => {
               <Box>
                 <PrimaryBtn
                   startIcon={<AddIcon />}
-                  buttonText="Create Task"
+                  buttonText="Create task"
                   handleClick={() => {
                     store.dispatch(setShowModal())
                   }}

--- a/src/components/layouts/Header.tsx
+++ b/src/components/layouts/Header.tsx
@@ -28,7 +28,7 @@ export const Header = ({ showCreateTaskButton }: { showCreateTaskButton: boolean
                 >
                   <PrimaryBtn
                     startIcon={<AddIcon />}
-                    buttonText="Create Task"
+                    buttonText="Create task"
                     handleClick={() => {
                       store.dispatch(setShowModal())
                     }}


### PR DESCRIPTION
### Changes

- [x] New task button name change from "Create Task" to "Create task" in board and dashboard empty state.

### Testing Criteria

![image](https://github.com/user-attachments/assets/ecca911c-93a6-4dd9-8ff2-f62aee224e82)
