### PR TITLE
OUT-1161 | OUT-1162 | Add support for Preview mode in client & company details view

### DIFF
--- a/src/app/client/page.tsx
+++ b/src/app/client/page.tsx
@@ -1,23 +1,27 @@
 export const fetchCache = 'force-no-store'
 
+import { AssigneeFetcher } from '@/app/_fetchers/AssigneeFetcher'
+import { ValidateNotificationCountFetcher } from '@/app/_fetchers/ValidateNotificationCountFetcher'
+import { createMultipleAttachments } from '@/app/actions'
+import { getViewSettings } from '@/app/page'
+import { ModalNewTaskForm } from '@/app/ui/Modal_NewTaskForm'
+import { TaskBoard } from '@/app/ui/TaskBoard'
+import { SilentError } from '@/components/templates/SilentError'
 import { apiUrl } from '@/config'
 import { ClientSideStateUpdate } from '@/hoc/ClientSideStateUpdate'
+import { DndWrapper } from '@/hoc/DndWrapper'
+import { RealTime } from '@/hoc/RealTime'
+import { Token, TokenSchema } from '@/types/common'
+import { CreateAttachmentRequest } from '@/types/dto/attachments.dto'
 import { TaskResponse } from '@/types/dto/tasks.dto'
 import { WorkflowStateResponse } from '@/types/dto/workflowStates.dto'
 import { UserType } from '@/types/interfaces'
-import { RealTime } from '@/hoc/RealTime'
 import { CopilotAPI } from '@/utils/CopilotAPI'
-import { Token, TokenSchema } from '@/types/common'
-import { Suspense } from 'react'
-import { AssigneeFetcher } from '@/app/_fetchers/AssigneeFetcher'
-import { z } from 'zod'
-import { SilentError } from '@/components/templates/SilentError'
-import { TaskBoard } from '@/app/ui/TaskBoard'
-import { DndWrapper } from '@/hoc/DndWrapper'
-import { UserRole } from '@api/core/types/user'
-import { getViewSettings } from '@/app/page'
-import { ValidateNotificationCountFetcher } from '../_fetchers/ValidateNotificationCountFetcher'
 import { redirectIfTaskCta } from '@/utils/redirect'
+import { UserRole } from '@api/core/types/user'
+
+import { Suspense } from 'react'
+import { z } from 'zod'
 
 async function getAllWorkflowStates(token: string): Promise<WorkflowStateResponse[]> {
   const res = await fetch(`${apiUrl}/api/workflow-states?token=${token}`, {
@@ -78,6 +82,12 @@ export default async function ClientPage({ searchParams }: { searchParams: { tok
           <DndWrapper>
             <TaskBoard mode={UserRole.Client} />
           </DndWrapper>
+          <ModalNewTaskForm
+            handleCreateMultipleAttachments={async (attachments: CreateAttachmentRequest[]) => {
+              'use server'
+              await createMultipleAttachments(token, attachments)
+            }}
+          />
         </RealTime>
       </ClientSideStateUpdate>
     </>

--- a/src/app/ui/TaskBoard.tsx
+++ b/src/app/ui/TaskBoard.tsx
@@ -43,6 +43,7 @@ export const TaskBoard = ({ mode }: TaskBoardProps) => {
     showArchived,
     showUnarchived,
     isTasksLoading,
+    previewMode,
   } = useSelector(selectTaskBoard)
 
   const onDropItem = useCallback(
@@ -100,7 +101,7 @@ export const TaskBoard = ({ mode }: TaskBoardProps) => {
   return (
     <>
       <TaskDataFetcher token={token ?? ''} />
-      <Header showCreateTaskButton={mode === UserRole.IU} />
+      <Header showCreateTaskButton={mode === UserRole.IU || !!previewMode} />
       <FilterBar
         mode={mode}
         updateViewModeSetting={async (payload: CreateViewSettingsDTO) => {
@@ -135,6 +136,7 @@ export const TaskBoard = ({ mode }: TaskBoardProps) => {
                   workflowStateId={list.id}
                   columnName={list.name}
                   taskCount={taskCountForWorkflowStateId(list.id)}
+                  showAddBtn={mode === UserRole.IU || !!previewMode}
                 >
                   <CustomScrollbar style={{ padding: '4px' }}>
                     <Stack direction="column" rowGap="6px" sx={{ overflowX: 'auto' }}>

--- a/src/components/cards/TaskColumn.tsx
+++ b/src/components/cards/TaskColumn.tsx
@@ -22,9 +22,11 @@ const TaskColumnContainer = styled(Stack)({
   alignItems: 'center',
 })
 
-interface TaskColumnProps extends TaskWorkflowStateProps {}
+interface TaskColumnProps extends TaskWorkflowStateProps {
+  showAddBtn: boolean
+}
 
-export const TaskColumn = ({ workflowStateId, mode, children, columnName, taskCount }: TaskColumnProps) => {
+export const TaskColumn = ({ workflowStateId, children, columnName, taskCount, showAddBtn }: TaskColumnProps) => {
   return (
     <>
       <TaskColumnHeader>
@@ -37,7 +39,7 @@ export const TaskColumn = ({ workflowStateId, mode, children, columnName, taskCo
           </Stack>
 
           {/* ((22 - 16) / 2) + 10 */}
-          {mode === UserRole.IU && <AddBtn handleClick={() => handleAddBtnClicked(workflowStateId)} />}
+          {showAddBtn && <AddBtn handleClick={() => handleAddBtnClicked(workflowStateId)} />}
           {/* (22 - 16) / 2 */}
         </Box>
       </TaskColumnHeader>

--- a/src/components/layouts/EmptyState/DashboardEmptyState.tsx
+++ b/src/components/layouts/EmptyState/DashboardEmptyState.tsx
@@ -5,11 +5,19 @@ import { PrimaryBtn } from '@/components/buttons/PrimaryBtn'
 import { AppMargin, SizeofAppMargin } from '@/hoc/AppMargin'
 import { AddIcon, TasksListIcon } from '@/icons'
 import { setShowModal } from '@/redux/features/createTaskSlice'
+import { selectTaskBoard } from '@/redux/features/taskBoardSlice'
 import store from '@/redux/store'
 import { SxCenter } from '@/utils/mui'
 import { Box, Stack, Typography } from '@mui/material'
+import { useSelector } from 'react-redux'
 
 const DashboardEmptyState = ({ userType }: { userType: UserRole }) => {
+  const { previewMode } = useSelector(selectTaskBoard)
+
+  if (previewMode) {
+    userType = UserRole.IU
+  }
+
   return (
     <>
       <AppMargin size={SizeofAppMargin.LARGE} py="20px">

--- a/src/hoc/ClientSideStateUpdate.tsx
+++ b/src/hoc/ClientSideStateUpdate.tsx
@@ -2,23 +2,27 @@
 
 import { LogResponse } from '@/app/api/activity-logs/schemas/LogResponseSchema'
 import { setTokenPayload } from '@/redux/features/authDetailsSlice'
+import { setCreateTaskFields } from '@/redux/features/createTaskSlice'
 import {
   selectTaskBoard,
   setActiveTask,
   setAssigneeList,
   setFilteredAssgineeList,
+  setPreviewMode,
   setViewSettings,
 } from '@/redux/features/taskBoardSlice'
 import { setTasks, setToken, setWorkflowStates } from '@/redux/features/taskBoardSlice'
 import { setAssigneeSuggestion } from '@/redux/features/taskDetailsSlice'
 import { setTemplates } from '@/redux/features/templateSlice'
 import store from '@/redux/store'
-import { Token } from '@/types/common'
+import { PreviewMode, Token } from '@/types/common'
 import { TaskResponse } from '@/types/dto/tasks.dto'
 import { CreateViewSettingsDTO } from '@/types/dto/viewSettings.dto'
 import { WorkflowStateResponse } from '@/types/dto/workflowStates.dto'
 import { IAssigneeSuggestions, IAssigneeCombined, ITemplate } from '@/types/interfaces'
 import { filterOptionsMap } from '@/types/objectMaps'
+import { handlePreviewMode } from '@/utils/previewMode'
+import { AssigneeType } from '@prisma/client'
 import { ReactNode, useEffect } from 'react'
 import { useSelector } from 'react-redux'
 
@@ -73,8 +77,18 @@ export const ClientSideStateUpdate = ({
       const view = viewSettingsTemp ? viewSettingsTemp.filterOptions : viewSettings.filterOptions
       store.dispatch(setFilteredAssgineeList({ filteredType: filterOptionsMap[view?.type] || filterOptionsMap.default }))
     }
+
     if (tokenPayload) {
       store.dispatch(setTokenPayload(tokenPayload))
+
+      // Handle preview mode feature
+      const isClientPreview = tokenPayload.internalUserId && tokenPayload.clientId
+      const isCompanyPreview = tokenPayload.internalUserId && tokenPayload.companyId === 'default'
+      const previewMode: PreviewMode = isClientPreview ? 'client' : isCompanyPreview ? 'company' : null
+      console.log('xxx', previewMode)
+      store.dispatch(setPreviewMode(previewMode))
+
+      previewMode && handlePreviewMode(previewMode, tokenPayload)
     }
 
     if (templates) {

--- a/src/redux/features/taskBoardSlice.tsx
+++ b/src/redux/features/taskBoardSlice.tsx
@@ -2,9 +2,10 @@ import { createSlice } from '@reduxjs/toolkit'
 import { RootState } from '../store'
 import { WorkflowStateResponse } from '@/types/dto/workflowStates.dto'
 import { TaskResponse } from '@/types/dto/tasks.dto'
-import { AssigneeType, FilterByOptions, FilterOptions, IAssigneeCombined, IFilterOptions, View } from '@/types/interfaces'
+import { FilterByOptions, FilterOptions, IAssigneeCombined, IFilterOptions } from '@/types/interfaces'
 import { ViewMode } from '@prisma/client'
 import { CreateViewSettingsDTO, FilterOptionsType } from '@/types/dto/viewSettings.dto'
+import { PreviewMode } from '@/types/common'
 
 interface IInitialState {
   workflowStates: WorkflowStateResponse[]
@@ -20,6 +21,7 @@ interface IInitialState {
   viewSettingsTemp: CreateViewSettingsDTO | undefined
   isTasksLoading: boolean
   activeTask: TaskResponse | undefined
+  previewMode: PreviewMode
 }
 
 const initialState: IInitialState = {
@@ -41,6 +43,7 @@ const initialState: IInitialState = {
   // Use this state as a global loading flag for tasks
   isTasksLoading: true,
   activeTask: undefined,
+  previewMode: null,
 }
 
 const taskBoardSlice = createSlice({
@@ -125,6 +128,10 @@ const taskBoardSlice = createSlice({
     setIsTasksLoading: (state, action: { payload: boolean }) => {
       state.isTasksLoading = action.payload
     },
+
+    setPreviewMode: (state, action: { payload: PreviewMode }) => {
+      state.previewMode = action.payload
+    },
   },
 })
 
@@ -144,6 +151,7 @@ export const {
   setViewSettingsTemp,
   setIsTasksLoading,
   setActiveTask,
+  setPreviewMode,
 } = taskBoardSlice.actions
 
 export default taskBoardSlice.reducer

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,4 +1,5 @@
 import { UserRole } from '@/app/api/core/types/user'
+import { AssigneeType } from '@prisma/client'
 import { z } from 'zod'
 
 export const HexColorSchema = z.string().refine((val) => /^#([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$/.test(val), {
@@ -218,3 +219,5 @@ export interface FilterableUser {
   familyName?: string
   name?: string
 }
+
+export type PreviewMode = 'client' | 'company' | null

--- a/src/utils/previewMode.ts
+++ b/src/utils/previewMode.ts
@@ -1,0 +1,14 @@
+import { setCreateTaskFields } from '@/redux/features/createTaskSlice'
+import store from '@/redux/store'
+import { PreviewMode, Token } from '@/types/common'
+
+export const handlePreviewMode = (previewMode: NonNullable<PreviewMode>, tokenPayload: Token) => {
+  // If clientId is provided, ignore corresponding companyId. Else pick up the companyId
+  const previewId = tokenPayload.clientId || tokenPayload.companyId
+  if (!previewId) {
+    throw new Error('Could not find preview client / company id')
+  }
+
+  store.dispatch(setCreateTaskFields({ targetField: 'assigneeId', value: previewId }))
+  store.dispatch(setCreateTaskFields({ targetField: 'assigneeType', value: previewMode }))
+}


### PR DESCRIPTION
### Changes

- [x] Add core support for Preview Mode in frontend so other tasks can build off this
- [x] Add "Add task" buttons in client  and company preview 

### Testing Criteria

- [x] Screenshots:
![image](https://github.com/user-attachments/assets/ce1e25e1-5617-4ef3-84bd-69929701283f)

