### PR TITLE
OUT-1156, OUT-1168 | Design changes on current selector component

### DIFF
--- a/src/app/detail/ui/ActivityWrapper.tsx
+++ b/src/app/detail/ui/ActivityWrapper.tsx
@@ -49,7 +49,7 @@ export const ActivityWrapper = ({
     }
   }, [task?.lastActivityLogUpdated])
 
-  const currentUserId = tokenPayload.clientId ?? tokenPayload.internalUserId
+  const currentUserId = tokenPayload.internalUserId ?? tokenPayload.clientId
 
   const currentUserDetails = useMemo(() => {
     const currentAssignee = assignee.find((el) => el.id === currentUserId)

--- a/src/app/ui/Modal_NewTaskForm.tsx
+++ b/src/app/ui/Modal_NewTaskForm.tsx
@@ -40,10 +40,6 @@ export const ModalNewTaskForm = ({
     // await bulkRemoveAttachments(attachments)
   }
 
-  useEffect(() => {
-    store.dispatch(setCreateTaskFields({ targetField: 'description', value: '' }))
-  }, [showModal])
-
   return (
     <Modal
       open={showModal}

--- a/src/app/ui/NewTaskForm.tsx
+++ b/src/app/ui/NewTaskForm.tsx
@@ -362,7 +362,7 @@ const NewTaskFooter = ({
         justifyContent="space-between"
         sx={{
           borderTop: (theme) => `1px solid ${theme.color.borders.borderDisabled}`,
-          borderBottom: (theme) => `1px solid ${theme.color.borders.borderDisabled}`,
+          borderBottom: (theme) => `0px solid ${theme.color.borders.borderDisabled}`,
           cursor: 'pointer',
           lineHeight: '21px',
           ':hover': (theme) => ({

--- a/src/components/inputs/Autocomplete.tsx
+++ b/src/components/inputs/Autocomplete.tsx
@@ -1,29 +1,18 @@
 import { Autocomplete, styled } from '@mui/material'
 
-export const StyledAutocomplete = styled(Autocomplete)(({ theme }) => ({
-  '& .MuiOutlinedInput-root': {
-    borderRadius: '4px',
-    padding: '6px 14px 10px 14px !important',
-    paddingRight: '14px !important',
-  },
-
-  '& .MuiOutlinedInput-root.Mui-focused': {
-    borderRadius: '4px 4px 0px 0px',
-  },
-  '& fieldset.MuiOutlinedInput-notchedOutline': {
-    borderWidth: '1px',
-  },
-  '& .MuiAutocomplete-inputRoot .MuiAutocomplete-input': {
-    padding: '0px',
-  },
-  '& .MuiAutocomplete-popper div': {
-    borderTopRightRadius: '0px',
-    borderTopLeftRadius: '0px',
-  },
+export const StyledAutocomplete = styled(Autocomplete)({
   '& .MuiAutocomplete-endAdornment': {
     display: 'none',
+  },
+  '& .MuiOutlinedInput-root': {
+    padding: 0,
+    border: '1px solid #EDEDF0',
   },
   '&:hover .MuiOutlinedInput-notchedOutline': {
     border: '1px solid #EDEDF0',
   },
-}))
+  '& .MuiOutlinedInput-root .MuiOutlinedInput-notchedOutline': {
+    border: '1px solid #EDEDF0',
+    padding: 0,
+  },
+})

--- a/src/components/inputs/Autocomplete.tsx
+++ b/src/components/inputs/Autocomplete.tsx
@@ -1,12 +1,26 @@
+import React from 'react'
 import { Autocomplete, styled } from '@mui/material'
 
-export const StyledAutocomplete = styled(Autocomplete)({
+interface StyledAutocompleteProps {
+  placement?: string
+}
+
+export const StyledAutocomplete = styled(Autocomplete, {
+  shouldForwardProp: (prop) => prop !== 'placement',
+})<StyledAutocompleteProps>(({ theme, placement }) => ({
   '& .MuiAutocomplete-endAdornment': {
     display: 'none',
   },
   '& .MuiOutlinedInput-root': {
-    padding: 0,
-    border: '1px solid #EDEDF0',
+    padding: placement === 'top' ? '8px 12px 4px 12px' : '4px 12px 8px 12px',
+    paddingRight: '12px !important',
+    '& .MuiAutocomplete-input': {
+      padding: '0px',
+      height: '21px',
+    },
+  },
+  '& .MuiOutlinedInput-root.Mui-focused': {
+    borderRadius: placement === 'top' ? '0px 0px 4px 4px' : '4px 4px 0px 0px',
   },
   '&:hover .MuiOutlinedInput-notchedOutline': {
     border: '1px solid #EDEDF0',
@@ -15,4 +29,4 @@ export const StyledAutocomplete = styled(Autocomplete)({
     border: '1px solid #EDEDF0',
     padding: 0,
   },
-})
+}))

--- a/src/components/inputs/CommentInput.tsx
+++ b/src/components/inputs/CommentInput.tsx
@@ -24,7 +24,7 @@ export const CommentInput = ({ createComment, task_id }: Prop) => {
   const { assigneeSuggestions } = useSelector(selectTaskDetails)
   const { tokenPayload } = useSelector(selectAuthDetails)
   const { assignee } = useSelector(selectTaskBoard)
-  const currentUserId = tokenPayload?.clientId ?? tokenPayload?.internalUserId
+  const currentUserId = tokenPayload?.internalUserId ?? tokenPayload?.clientId
   const currentUserDetails = assignee.find((el) => el.id === currentUserId)
 
   const isContentEmpty = (content: string) => {

--- a/src/components/inputs/ListComponent.tsx
+++ b/src/components/inputs/ListComponent.tsx
@@ -12,7 +12,7 @@ export interface ListComponentProps extends Omit<ScrollbarProps, 'ref'> {
 
 const ListComponentInternal = forwardRef<Scrollbars, ListComponentProps>((props, ref) => {
   const { children, endOption, endOptionHref, autoHeightMax, ...comProps } = props
-  const xs = useMediaQuery('(max-width:600px) or (max-height:800px)')
+  const xs = useMediaQuery('(max-width:600px)')
   const router = useRouter()
 
   return (
@@ -36,7 +36,7 @@ const ListComponentInternal = forwardRef<Scrollbars, ListComponentProps>((props,
               ...viewProps.style,
               borderRadius: '0',
               position: 'relative',
-              maxHeight: autoHeightMax ?? (xs ? '17vh' : '30vh'),
+              maxHeight: autoHeightMax ?? (xs ? '175px' : '291px'),
               inset: '0px',
               overflow: 'auto',
               paddingBottom: '7px',
@@ -45,7 +45,7 @@ const ListComponentInternal = forwardRef<Scrollbars, ListComponentProps>((props,
         )}
         autoHide
         autoHeight
-        autoHeightMax={autoHeightMax ?? (xs ? '15vh' : '30vh')}
+        autoHeightMax={autoHeightMax ?? (xs ? '172px' : '291px')}
         autoHideTimeout={500}
         autoHideDuration={500}
         hideTracksWhenNotNeeded
@@ -59,5 +59,9 @@ const ListComponentInternal = forwardRef<Scrollbars, ListComponentProps>((props,
 ListComponentInternal.displayName = 'ListComponentInternal'
 
 export const ListComponent = (
-  props: JSX.IntrinsicElements['div'] & { endOption?: React.ReactNode; endOptionHref?: string; autoHeightMax?: string },
+  props: JSX.IntrinsicElements['div'] & {
+    endOption?: React.ReactNode
+    endOptionHref?: string
+    autoHeightMax?: string
+  },
 ) => <ListComponentInternal {...(props as ListComponentProps)} />

--- a/src/components/inputs/ListComponent.tsx
+++ b/src/components/inputs/ListComponent.tsx
@@ -12,7 +12,7 @@ export interface ListComponentProps extends Omit<ScrollbarProps, 'ref'> {
 
 const ListComponentInternal = forwardRef<Scrollbars, ListComponentProps>((props, ref) => {
   const { children, endOption, endOptionHref, autoHeightMax, ...comProps } = props
-  const xs = useMediaQuery('(max-width:600px) or (max-height:800px)')
+  const xs = useMediaQuery('(max-width:600px)')
   const router = useRouter()
 
   return (
@@ -36,16 +36,16 @@ const ListComponentInternal = forwardRef<Scrollbars, ListComponentProps>((props,
               ...viewProps.style,
               borderRadius: '0',
               position: 'relative',
-              maxHeight: autoHeightMax ?? (xs ? '17vh' : '30vh'),
+              maxHeight: autoHeightMax ?? (xs ? '175px' : '291px'),
               inset: '0px',
               overflow: 'auto',
-              paddingBottom: '7px',
+              paddingBottom: xs ? '12px' : '7px',
             }}
           />
         )}
         autoHide
         autoHeight
-        autoHeightMax={autoHeightMax ?? (xs ? '15vh' : '30vh')}
+        autoHeightMax={autoHeightMax ?? (xs ? '172px' : '291px')}
         autoHideTimeout={500}
         autoHideDuration={500}
         hideTracksWhenNotNeeded

--- a/src/components/inputs/ListComponent.tsx
+++ b/src/components/inputs/ListComponent.tsx
@@ -12,7 +12,7 @@ export interface ListComponentProps extends Omit<ScrollbarProps, 'ref'> {
 
 const ListComponentInternal = forwardRef<Scrollbars, ListComponentProps>((props, ref) => {
   const { children, endOption, endOptionHref, autoHeightMax, ...comProps } = props
-  const xs = useMediaQuery('(max-width:600px)')
+  const xs = useMediaQuery('(max-width:600px) or (max-height:800px)')
   const router = useRouter()
 
   return (
@@ -36,16 +36,16 @@ const ListComponentInternal = forwardRef<Scrollbars, ListComponentProps>((props,
               ...viewProps.style,
               borderRadius: '0',
               position: 'relative',
-              maxHeight: autoHeightMax ?? (xs ? '175px' : '291px'),
+              maxHeight: autoHeightMax ?? (xs ? '17vh' : '30vh'),
               inset: '0px',
               overflow: 'auto',
-              paddingBottom: xs ? '12px' : '7px',
+              paddingBottom: '7px',
             }}
           />
         )}
         autoHide
         autoHeight
-        autoHeightMax={autoHeightMax ?? (xs ? '172px' : '291px')}
+        autoHeightMax={autoHeightMax ?? (xs ? '15vh' : '30vh')}
         autoHideTimeout={500}
         autoHideDuration={500}
         hideTracksWhenNotNeeded

--- a/src/components/inputs/Selector.tsx
+++ b/src/components/inputs/Selector.tsx
@@ -13,6 +13,7 @@ import { getAssigneeName } from '@/utils/assignee'
 import { StyledHelperText } from '@/components/error/FormHelperText'
 import React from 'react'
 import { ListComponent } from '@/components/inputs/ListComponent'
+import { ModifierArguments } from '@popperjs/core'
 
 export enum SelectorType {
   ASSIGNEE_SELECTOR = 'assigneeSelector',
@@ -110,6 +111,14 @@ export default function Selector({
     }
   }
 
+  const [placement, setPlacement] = useState('')
+
+  const handlePlacementChange = (data: ModifierArguments<any>) => {
+    if (data.state && data.state.placement) {
+      setPlacement(data.state.placement)
+    }
+  }
+
   useEffect(() => {
     function closePopper(e: KeyboardEvent) {
       if (e.key === 'Escape') {
@@ -195,6 +204,7 @@ export default function Selector({
         placement="bottom-start"
       >
         <StyledAutocomplete
+          placement={placement}
           id={selectorType}
           onBlur={() => {
             setAnchorEl(null)
@@ -202,7 +212,7 @@ export default function Selector({
           blurOnSelect={true}
           openOnFocus
           onKeyDown={handleKeyDown}
-          ListboxProps={{ sx: { maxHeight: { xs: '175px', sm: '291px' }, padding: { xs: ' 0px', sm: '0px 0px 8px 0px' } } }}
+          ListboxProps={{ sx: { maxHeight: { xs: '175px', sm: '291px' }, padding: '0px 0px 8px 0px' } }}
           options={extraOption ? [extraOption, ...options] : options}
           value={value}
           onChange={(_, newValue: unknown) => {
@@ -223,7 +233,22 @@ export default function Selector({
                 '& .MuiAutocomplete-noOptions': {
                   padding: '0px',
                 },
+                boxShadow: 'none',
+                border: (theme) => `1px solid ${theme.color.borders.border2}`,
+                borderTop: (theme) => (placement === 'top' ? `1px solid ${theme.color.borders.border2}` : 'none'),
+                borderBottom: (theme) => (placement === 'top' ? 'none' : `1px solid ${theme.color.borders.border2}`),
+                borderRadius: placement == 'top' ? '4px 4px 0px 0px' : '0px 0px 4px 4px',
               },
+            },
+            popper: {
+              modifiers: [
+                {
+                  name: 'onUpdatePlacement',
+                  enabled: true,
+                  phase: 'afterWrite',
+                  fn: handlePlacementChange,
+                },
+              ],
             },
           }}
           filterOptions={filterOption}
@@ -263,9 +288,12 @@ export default function Selector({
                 inputRef={setSelectorRef}
                 placeholder={placeholder}
                 borderColor="#EDEDF0"
+                padding="4px 12px 8px 12px"
+                basePadding="4px 12px 8px 12px"
                 sx={{
                   width: '200px',
                   visibility: { xs: 'none', sm: 'visible' },
+                  borderRadius: '4px',
                 }}
                 onChange={(e) => {
                   handleInputChange?.(e.target.value)

--- a/src/components/inputs/Selector.tsx
+++ b/src/components/inputs/Selector.tsx
@@ -191,7 +191,6 @@ export default function Selector({
         sx={{
           width: 'fit-content',
           zIndex: '9999',
-          borderRadius: '4px',
         }}
         placement="bottom-start"
       >
@@ -200,11 +199,10 @@ export default function Selector({
           onBlur={() => {
             setAnchorEl(null)
           }}
-          PopperComponent={({ style, ...props }) => <Popper {...props} style={{ ...style, height: 0 }} />} // always place popper at the bottom.
           blurOnSelect={true}
           openOnFocus
           onKeyDown={handleKeyDown}
-          ListboxProps={{ sx: { maxHeight: { xs: '175px', sm: '291px' }, padding: { xs: ' 0px', sm: '0px 0px 8px 0px' } } }}
+          ListboxProps={{ sx: { maxHeight: { xs: '175px', sm: '291px' }, padding: '0px 0px 8px 0px' } }}
           options={extraOption ? [extraOption, ...options] : options}
           value={value}
           onChange={(_, newValue: unknown) => {
@@ -225,13 +223,6 @@ export default function Selector({
                 '& .MuiAutocomplete-noOptions': {
                   padding: '0px',
                 },
-                boxShadow: 'none',
-                border: 'solid #EDEDF0',
-                borderWidth: '0px 1px 1px 1px',
-                borderTopLeftRadius: '0',
-                borderTopRightRadius: '0',
-                borderBottomLeftRadius: '4px',
-                borderBottomRightRadius: '4px',
               },
             },
           }}
@@ -272,12 +263,9 @@ export default function Selector({
                 inputRef={setSelectorRef}
                 placeholder={placeholder}
                 borderColor="#EDEDF0"
-                padding="0px"
-                basePadding="0px"
                 sx={{
                   width: '200px',
                   visibility: { xs: 'none', sm: 'visible' },
-                  borderRadius: '4px',
                 }}
                 onChange={(e) => {
                   handleInputChange?.(e.target.value)

--- a/src/components/inputs/Selector.tsx
+++ b/src/components/inputs/Selector.tsx
@@ -202,7 +202,7 @@ export default function Selector({
           blurOnSelect={true}
           openOnFocus
           onKeyDown={handleKeyDown}
-          ListboxProps={{ sx: { maxHeight: { xs: '175px', sm: '291px' }, padding: '0px 0px 8px 0px' } }}
+          ListboxProps={{ sx: { maxHeight: { xs: '175px', sm: '291px' }, padding: { xs: ' 0px', sm: '0px 0px 8px 0px' } } }}
           options={extraOption ? [extraOption, ...options] : options}
           value={value}
           onChange={(_, newValue: unknown) => {

--- a/src/components/inputs/Selector.tsx
+++ b/src/components/inputs/Selector.tsx
@@ -204,7 +204,7 @@ export default function Selector({
           blurOnSelect={true}
           openOnFocus
           onKeyDown={handleKeyDown}
-          ListboxProps={{ sx: { maxHeight: { xs: '175px', sm: '291px' }, padding: '0px 0px 8px 0px' } }}
+          ListboxProps={{ sx: { maxHeight: { xs: '175px', sm: '291px' }, padding: { xs: ' 0px', sm: '0px 0px 8px 0px' } } }}
           options={extraOption ? [extraOption, ...options] : options}
           value={value}
           onChange={(_, newValue: unknown) => {

--- a/src/components/inputs/TextField.tsx
+++ b/src/components/inputs/TextField.tsx
@@ -36,7 +36,6 @@ export const StyledTextField = styled(TextField, {
       '&::placeholder': {
         opacity: 1,
         fontSize: '12px',
-        color: theme.color.text.textSecondary,
       },
       fontSize: '12px',
     },


### PR DESCRIPTION
### Changes

- [x] Revert changes from OUT-1156 which created a big regression on the selector design.

### Testing 

![image](https://github.com/user-attachments/assets/1588f64c-5085-4484-9a55-d824ec5730b6)
![image](https://github.com/user-attachments/assets/63350ea4-33b7-433c-aa15-1c6b1e601afd)
