### PR TITLE
OUT-1154, OUT-1167 | Task creation modal doesn't persist with applied template details

### DIFF
--- a/src/app/ui/Modal_NewTaskForm.tsx
+++ b/src/app/ui/Modal_NewTaskForm.tsx
@@ -40,10 +40,6 @@ export const ModalNewTaskForm = ({
     // await bulkRemoveAttachments(attachments)
   }
 
-  // useEffect(() => {
-  //   store.dispatch(setCreateTaskFields({ targetField: 'description', value: '' }))
-  // }, [showModal])
-
   return (
     <Modal
       open={showModal}

--- a/src/app/ui/Modal_NewTaskForm.tsx
+++ b/src/app/ui/Modal_NewTaskForm.tsx
@@ -40,9 +40,9 @@ export const ModalNewTaskForm = ({
     // await bulkRemoveAttachments(attachments)
   }
 
-  useEffect(() => {
-    store.dispatch(setCreateTaskFields({ targetField: 'description', value: '' }))
-  }, [showModal])
+  // useEffect(() => {
+  //   store.dispatch(setCreateTaskFields({ targetField: 'description', value: '' }))
+  // }, [showModal])
 
   return (
     <Modal


### PR DESCRIPTION
### Changes

- [x] Applied abort controller functionality to cancel ongoing request of applying templates which was incomplete before. 
- [x] Task description and workflowState will persist even if template is deleted while navigating back and forth from new task form and template board.

### Testing Criteria

- [LOOM](https://www.loom.com/share/93037ecd385c4a16b41e8645839b72bb)
