### PR TITLE
OUT-1169 | Improve loading experience of tasks empty state

### DIFF
--- a/src/app/ui/TaskBoard.tsx
+++ b/src/app/ui/TaskBoard.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { Box, Stack } from '@mui/material'
 import { TaskCard } from '@/components/cards/TaskCard'
 import { TaskColumn } from '@/components/cards/TaskColumn'
@@ -88,7 +88,19 @@ export const TaskBoard = ({ mode }: TaskBoardProps) => {
 
   const isNoTasksWithFilter = tasks && !userHasNoFilter && !filteredTasks.length
 
-  if (tasks && tasks.length === 0 && userHasNoFilter) {
+  const [hasInitialized, setHasInitialized] = useState(false)
+
+  useEffect(() => {
+    if (!isTasksLoading && !hasInitialized) {
+      setHasInitialized(true)
+    }
+  }, [isTasksLoading])
+
+  if (!hasInitialized) {
+    return <TaskDataFetcher token={token ?? ''} />
+  } //fix this logic as soon as copilot API natively supports access scopes by creating an endpoint which shows the count of filteredTask and total tasks.
+
+  if (tasks && tasks.length === 0 && userHasNoFilter && !isTasksLoading) {
     return (
       <>
         <TaskDataFetcher token={token ?? ''} />
@@ -107,7 +119,7 @@ export const TaskBoard = ({ mode }: TaskBoardProps) => {
           await updateViewModeSettings(z.string().parse(token), payload)
         }}
       />
-      {isNoTasksWithFilter && !isTasksLoading && <NoFilteredTasksState />}
+      {isNoTasksWithFilter && <NoFilteredTasksState />}
 
       {!isNoTasksWithFilter && viewBoardSettings === View.BOARD_VIEW && (
         <Box sx={{ padding: '12px 12px' }}>

--- a/src/app/ui/TaskBoard.tsx
+++ b/src/app/ui/TaskBoard.tsx
@@ -88,7 +88,7 @@ export const TaskBoard = ({ mode }: TaskBoardProps) => {
 
   const isNoTasksWithFilter = tasks && !userHasNoFilter && !filteredTasks.length
 
-  if (tasks && tasks.length === 0 && userHasNoFilter && !isTasksLoading) {
+  if (tasks && tasks.length === 0 && userHasNoFilter) {
     return (
       <>
         <TaskDataFetcher token={token ?? ''} />
@@ -107,7 +107,6 @@ export const TaskBoard = ({ mode }: TaskBoardProps) => {
           await updateViewModeSettings(z.string().parse(token), payload)
         }}
       />
-
       {isNoTasksWithFilter && !isTasksLoading && <NoFilteredTasksState />}
 
       {!isNoTasksWithFilter && viewBoardSettings === View.BOARD_VIEW && (
@@ -171,7 +170,6 @@ export const TaskBoard = ({ mode }: TaskBoardProps) => {
           </Stack>
         </Box>
       )}
-
       {!isNoTasksWithFilter && viewBoardSettings === View.LIST_VIEW && (
         <Stack
           sx={{


### PR DESCRIPTION


### Changes

- [x] introduced hasInitialized state to not show filterBar when there are no tasks and the task api is currently loading.

### Testing Criteria

- [LOOM](https://www.loom.com/share/d9273f28e1264892a4a6575f2c8f2e2e)

