### PR TITLE
OUT-1202 | Filters and selector reappearing

### DIFF
--- a/src/app/manage-templates/ui/Header.tsx
+++ b/src/app/manage-templates/ui/Header.tsx
@@ -23,8 +23,8 @@ export const ManageTemplateHeader = ({ token }: { token: string }) => {
           <HeaderBreadcrumbs
             title="Manage templates"
             token={token}
-            // Treat user as client if previewMode, else only IU is allowed to manage templates for now
-            userType={previewMode ? UserType.CLIENT_USER : UserType.INTERNAL_USER}
+            // Treat user as IU since only they are allowed to manage templates for now
+            userType={UserType.INTERNAL_USER}
           />
           {templates?.length ? (
             <>

--- a/src/app/manage-templates/ui/Header.tsx
+++ b/src/app/manage-templates/ui/Header.tsx
@@ -1,13 +1,12 @@
 'use client'
 import { AppMargin, SizeofAppMargin } from '@/hoc/AppMargin'
-import { Box, Stack, Typography } from '@mui/material'
-import { SecondaryBtn } from '@/components/buttons/SecondaryBtn'
+import { Box, Stack } from '@mui/material'
 import { PrimaryBtn } from '@/components/buttons/PrimaryBtn'
 import { PlusIcon } from '@/icons'
-import { StyledBox, StyledKeyboardIcon, StyledTypography } from '@/app/detail/ui/styledComponent'
+import { StyledBox } from '@/app/detail/ui/styledComponent'
 import store from '@/redux/store'
 import { selectCreateTemplate, setShowTemplateModal } from '@/redux/features/templateSlice'
-import { TargetMethod } from '@/types/interfaces'
+import { TargetMethod, UserType } from '@/types/interfaces'
 import { useSelector } from 'react-redux'
 import { selectTaskBoard } from '@/redux/features/taskBoardSlice'
 import { IconBtn } from '@/components/buttons/IconBtn'
@@ -16,11 +15,17 @@ import { HeaderBreadcrumbs } from '@/components/layouts/HeaderBreadcrumbs'
 
 export const ManageTemplateHeader = ({ token }: { token: string }) => {
   const { templates } = useSelector(selectCreateTemplate)
+  const { previewMode } = useSelector(selectTaskBoard)
   return (
     <StyledBox>
       <AppMargin size={SizeofAppMargin.HEADER} py="17.5px">
         <Stack direction="row" justifyContent="space-between" alignItems="center">
-          <HeaderBreadcrumbs title="Manage templates" token={token} />
+          <HeaderBreadcrumbs
+            title="Manage templates"
+            token={token}
+            // Treat user as client if previewMode, else only IU is allowed to manage templates for now
+            userType={previewMode ? UserType.CLIENT_USER : UserType.INTERNAL_USER}
+          />
           {templates?.length ? (
             <>
               <Box

--- a/src/components/layouts/Header.tsx
+++ b/src/components/layouts/Header.tsx
@@ -1,14 +1,13 @@
 'use client'
 
-import { Box, Stack, Typography } from '@mui/material'
-import { PrimaryBtn } from '../buttons/PrimaryBtn'
-
-import { AppMargin, SizeofAppMargin } from '@/hoc/AppMargin'
-import store from '@/redux/store'
-import { setShowModal } from '@/redux/features/createTaskSlice'
-import { IconBtn } from '../buttons/IconBtn'
-import { AddIcon, AddLargeIcon } from '@/icons'
 import { MenuBoxContainer } from '@/app/ui/MenuBoxContainer'
+import { IconBtn } from '@/components/buttons/IconBtn'
+import { PrimaryBtn } from '@/components/buttons/PrimaryBtn'
+import { AppMargin, SizeofAppMargin } from '@/hoc/AppMargin'
+import { AddIcon, AddLargeIcon } from '@/icons'
+import { setShowModal } from '@/redux/features/createTaskSlice'
+import store from '@/redux/store'
+import { Box, Stack, Typography } from '@mui/material'
 
 interface HeaderProps {
   showCreateTaskButton: boolean

--- a/src/components/layouts/HeaderBreadcrumbs.tsx
+++ b/src/components/layouts/HeaderBreadcrumbs.tsx
@@ -8,7 +8,7 @@ import { UserType } from '@/types/interfaces'
 import { Stack, Typography } from '@mui/material'
 import { useSelector } from 'react-redux'
 
-type ValidTasksBoardLinks = '/' | '/client'
+type ValidTasksBoardLink = '/' | '/client'
 
 export const HeaderBreadcrumbs = ({
   token,
@@ -21,10 +21,10 @@ export const HeaderBreadcrumbs = ({
 }) => {
   const { previewMode } = useSelector(selectTaskBoard)
 
-  const getTasksLink = (userType: UserType): ValidTasksBoardLinks => {
+  const getTasksLink = (userType: UserType): ValidTasksBoardLink => {
     if (previewMode) return '/client'
 
-    const tasksLinks: Record<UserType, ValidTasksBoardLinks> = {
+    const tasksLinks: Record<UserType, ValidTasksBoardLink> = {
       [UserType.INTERNAL_USER]: '/',
       [UserType.CLIENT_USER]: '/client',
     }

--- a/src/components/layouts/HeaderBreadcrumbs.tsx
+++ b/src/components/layouts/HeaderBreadcrumbs.tsx
@@ -13,11 +13,16 @@ export const HeaderBreadcrumbs = ({
 }: {
   token: string | undefined
   title: string
-  userType?: UserType
+  userType: UserType
 }) => {
+  const tasksLinks = {
+    [UserType.INTERNAL_USER]: '/',
+    [UserType.CLIENT_USER]: '/client',
+  }
+
   return (
     <Stack direction="row" alignItems="center" columnGap={3}>
-      <CustomLink href={{ pathname: userType === UserType.CLIENT_USER ? `/client` : `/`, query: { token } }}>
+      <CustomLink href={{ pathname: tasksLinks[userType], query: { token } }}>
         <SecondaryBtn
           buttonContent={
             <StyledTypography variant="sm" lineHeight={'21px'} sx={{ fontSize: '13px' }}>

--- a/src/components/layouts/HeaderBreadcrumbs.tsx
+++ b/src/components/layouts/HeaderBreadcrumbs.tsx
@@ -3,8 +3,12 @@
 import { StyledKeyboardIcon, StyledTypography } from '@/app/detail/ui/styledComponent'
 import { SecondaryBtn } from '@/components/buttons/SecondaryBtn'
 import { CustomLink } from '@/hoc/CustomLink'
+import { selectTaskBoard } from '@/redux/features/taskBoardSlice'
 import { UserType } from '@/types/interfaces'
 import { Stack, Typography } from '@mui/material'
+import { useSelector } from 'react-redux'
+
+type ValidTasksBoardLinks = '/' | '/client'
 
 export const HeaderBreadcrumbs = ({
   token,
@@ -15,14 +19,21 @@ export const HeaderBreadcrumbs = ({
   title: string
   userType: UserType
 }) => {
-  const tasksLinks = {
-    [UserType.INTERNAL_USER]: '/',
-    [UserType.CLIENT_USER]: '/client',
+  const { previewMode } = useSelector(selectTaskBoard)
+
+  const getTasksLink = (userType: UserType): ValidTasksBoardLinks => {
+    if (previewMode) return '/client'
+
+    const tasksLinks: Record<UserType, ValidTasksBoardLinks> = {
+      [UserType.INTERNAL_USER]: '/',
+      [UserType.CLIENT_USER]: '/client',
+    }
+    return tasksLinks[userType]
   }
 
   return (
     <Stack direction="row" alignItems="center" columnGap={3}>
-      <CustomLink href={{ pathname: tasksLinks[userType], query: { token } }}>
+      <CustomLink href={{ pathname: getTasksLink(userType), query: { token } }}>
         <SecondaryBtn
           buttonContent={
             <StyledTypography variant="sm" lineHeight={'21px'} sx={{ fontSize: '13px' }}>


### PR DESCRIPTION
### Changes

- [x] Fix logic for tasks board linking (userType was sent as undefined)
- [x] Fix header not accounting for preview mode (centralized in HeaderBreadcrumbs itself)

### Testing Criteria

- [x] Screencast

[Screencast from 2024-12-26 12-43-54.webm](https://github.com/user-attachments/assets/a83591cd-70f5-4946-8565-10bc8bb140da)
