### PR TITLE
OUT-1180 | Hover state is not centered around the kebab menu in comments

### DIFF
--- a/src/components/cards/CommentCard.tsx
+++ b/src/components/cards/CommentCard.tsx
@@ -114,6 +114,8 @@ export const CommentCard = ({
                     />
                   }
                   isSecondary
+                  width={'22px'}
+                  height={'22px'}
                 />
               )}
             </Stack>


### PR DESCRIPTION
### Changes

- [x] Adjusted the height and width of the hover state of kebab menu in comments according to the design in figma. 

### Testing Criteria

![image](https://github.com/user-attachments/assets/09aa1edb-b906-4cda-aca9-1e6050a738ce)

