### PR TITLE
OUT-1191, OUT-1192, OUT-1193 | Add support for DueDate in Activity Logs

### DIFF
--- a/prisma/migrations/20241227091629_add_due_date_changed_enum_prop_for_activity_log/migration.sql
+++ b/prisma/migrations/20241227091629_add_due_date_changed_enum_prop_for_activity_log/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "ActivityType" ADD VALUE 'DUE_DATE_CHANGED';

--- a/prisma/schema/activityLog.prisma
+++ b/prisma/schema/activityLog.prisma
@@ -3,6 +3,7 @@ enum ActivityType {
   TASK_ASSIGNED
   WORKFLOW_STATE_UPDATED
   COMMENT_ADDED
+  DUE_DATE_CHANGED
 }
 
 model ActivityLog {

--- a/src/app/api/activity-logs/const.ts
+++ b/src/app/api/activity-logs/const.ts
@@ -4,12 +4,14 @@ import { TaskAssignedSchema } from '@api/activity-logs/schemas/TaskAssignedSchem
 import { WorkflowStateUpdatedSchema } from '@api/activity-logs/schemas/WorkflowStateUpdatedSchema'
 import { CommentAddedSchema } from '@api/activity-logs/schemas/CommentAddedSchema'
 import { z } from 'zod'
+import { DueDateChangedSchema } from '@/app/api/activity-logs/schemas/DueDateChangedSchema'
 
 export const SchemaByActivityType = {
   [ActivityType.TASK_CREATED]: TaskCreatedSchema,
   [ActivityType.TASK_ASSIGNED]: TaskAssignedSchema,
   [ActivityType.WORKFLOW_STATE_UPDATED]: WorkflowStateUpdatedSchema,
   [ActivityType.COMMENT_ADDED]: CommentAddedSchema,
+  [ActivityType.DUE_DATE_CHANGED]: DueDateChangedSchema,
 }
 
 export const DBActivityLogDetailsSchema = z.record(z.string(), z.unknown())

--- a/src/app/api/activity-logs/schemas/DueDateChangedSchema.ts
+++ b/src/app/api/activity-logs/schemas/DueDateChangedSchema.ts
@@ -1,6 +1,7 @@
+import { DateStringSchema } from '@/types/date'
 import { z } from 'zod'
 
 export const DueDateChangedSchema = z.object({
-  oldValue: z.string().nullish(),
-  newValue: z.string().nullish(),
+  oldValue: DateStringSchema.nullish(),
+  newValue: DateStringSchema.nullish(),
 })

--- a/src/app/api/activity-logs/schemas/DueDateChangedSchema.ts
+++ b/src/app/api/activity-logs/schemas/DueDateChangedSchema.ts
@@ -1,0 +1,6 @@
+import { z } from 'zod'
+
+export const DueDateChangedSchema = z.object({
+  oldValue: z.string().nullish(),
+  newValue: z.string().nullish(),
+})

--- a/src/app/api/tasks/tasks.logger.ts
+++ b/src/app/api/tasks/tasks.logger.ts
@@ -1,3 +1,4 @@
+import { DueDateChangedSchema } from '@/app/api/activity-logs/schemas/DueDateChangedSchema'
 import { TaskAssignedSchema } from '@api/activity-logs/schemas/TaskAssignedSchema'
 import { WorkflowStateUpdatedSchema } from '@api/activity-logs/schemas/WorkflowStateUpdatedSchema'
 import { ActivityLogger } from '@api/activity-logs/services/activity-logger.service'
@@ -30,6 +31,9 @@ export class TasksActivityLogger extends BaseService {
     if (this.task.workflowStateId !== prevTask?.workflowStateId) {
       await this.logWorkflowStateUpdated(prevTask)
     }
+    if (this.task.dueDate !== prevTask.dueDate) {
+      await this.logDueDateChanged(prevTask)
+    }
   }
 
   private async logWorkflowStateUpdated(prevTask: Task & { workflowState: WorkflowState }) {
@@ -38,6 +42,16 @@ export class TasksActivityLogger extends BaseService {
       WorkflowStateUpdatedSchema.parse({
         oldValue: prevTask.workflowState.id,
         newValue: this.task.workflowState.id,
+      }),
+    )
+  }
+
+  private async logDueDateChanged(prevTask: Task) {
+    await this.activityLogger.log(
+      ActivityType.DUE_DATE_CHANGED,
+      DueDateChangedSchema.parse({
+        oldValue: prevTask.dueDate,
+        newValue: this.task.dueDate,
       }),
     )
   }

--- a/src/app/detail/ui/ActivityLog.tsx
+++ b/src/app/detail/ui/ActivityLog.tsx
@@ -9,6 +9,8 @@ import { useSelector } from 'react-redux'
 import { selectTaskBoard } from '@/redux/features/taskBoardSlice'
 import { CopilotAvatar } from '@/components/atoms/CopilotAvatar'
 import { IAssigneeCombined } from '@/types/interfaces'
+import { DueDateChangedSchema } from '@/app/api/activity-logs/schemas/DueDateChangedSchema'
+import { DueDateFormatter } from '@/utils/dueDateFormatter'
 
 interface Prop {
   log: LogResponse
@@ -31,7 +33,12 @@ export const ActivityLog = ({ log }: Prop) => {
         ]
       : log.type == ActivityType.TASK_ASSIGNED
         ? [getAssignedToName(TaskAssignedResponseSchema.parse(log.details))]
-        : []
+        : log.type == ActivityType.DUE_DATE_CHANGED
+          ? [
+              DueDateChangedSchema.parse(log.details)?.oldValue ?? '',
+              DueDateChangedSchema.parse(log.details)?.newValue ?? '',
+            ]
+          : []
 
   const activityDescription: { [key in ActivityType]: (...args: string[]) => React.ReactNode } = {
     [ActivityType.TASK_CREATED]: () => (
@@ -52,6 +59,22 @@ export const ActivityLog = ({ log }: Prop) => {
         <BoldTypography>{from}</BoldTypography>
         <StyledTypography> to </StyledTypography>
         <BoldTypography>{to}.</BoldTypography>
+      </>
+    ),
+    [ActivityType.DUE_DATE_CHANGED]: (from: string, to: string) => (
+      <>
+        <StyledTypography> changed due date </StyledTypography>
+        {from && (
+          <>
+            <StyledTypography> from </StyledTypography> <BoldTypography> {DueDateFormatter(from)}</BoldTypography>
+          </>
+        )}
+        <StyledTypography> to</StyledTypography>
+        <BoldTypography> {DueDateFormatter(to)}</BoldTypography>
+        <StyledTypography>
+          {' '}
+          <span>&#x2022;</span>
+        </StyledTypography>
       </>
     ),
     [ActivityType.COMMENT_ADDED]: () => null,

--- a/src/components/layouts/DueDateLayout.tsx
+++ b/src/components/layouts/DueDateLayout.tsx
@@ -5,6 +5,7 @@ import isTomorrow from 'dayjs/plugin/isTomorrow'
 import { useCallback } from 'react'
 import { createDateFromFormattedDateString } from '@/utils/dateHelper'
 import { DateString } from '@/types/date'
+import { DueDateFormatter } from '@/utils/dueDateFormatter'
 
 dayjs.extend(isToday)
 dayjs.extend(isTomorrow)
@@ -18,36 +19,7 @@ export const DueDateLayout = ({ dateString, isDone }: DueDateLayoutProp) => {
   const date = createDateFromFormattedDateString(dateString)
   const now = dayjs()
   const calculateFormattedDueDate = useCallback(() => {
-    const parsedDate = dayjs(date)
-
-    if (parsedDate.isToday()) {
-      return 'Today'
-    } else if (parsedDate.isTomorrow()) {
-      return 'Tomorrow'
-    } else {
-      const monthFormats: { [key: string]: string } = {
-        January: 'Jan',
-        February: 'Feb',
-        March: 'March',
-        April: 'April',
-        May: 'May',
-        June: 'June',
-        July: 'July',
-        August: 'Aug',
-        September: 'Sep',
-        October: 'Oct',
-        November: 'Nov',
-        December: 'Dec',
-      }
-
-      const month = parsedDate.format('MMMM')
-      const day = parsedDate.format('D')
-      const year = parsedDate.format('YYYY')
-
-      const formattedMonth = month.length <= 5 ? month : monthFormats[month]
-
-      return `${formattedMonth} ${day}, ${year}`
-    }
+    return DueDateFormatter(date, true)
   }, [date])
 
   const formattedDueDate = calculateFormattedDueDate()

--- a/src/utils/dueDateFormatter.ts
+++ b/src/utils/dueDateFormatter.ts
@@ -1,0 +1,27 @@
+import dayjs from 'dayjs'
+
+export const DueDateFormatter = (date: string) => {
+  const parsedDate = dayjs(date)
+  const monthFormats: { [key: string]: string } = {
+    January: 'Jan',
+    February: 'Feb',
+    March: 'March',
+    April: 'April',
+    May: 'May',
+    June: 'June',
+    July: 'July',
+    August: 'Aug',
+    September: 'Sep',
+    October: 'Oct',
+    November: 'Nov',
+    December: 'Dec',
+  }
+
+  const month = parsedDate.format('MMMM')
+  const day = parsedDate.format('D')
+  const year = parsedDate.format('YYYY')
+
+  const formattedMonth = month.length <= 5 ? month : monthFormats[month]
+
+  return `${formattedMonth} ${day}, ${year}`
+}

--- a/src/utils/dueDateFormatter.ts
+++ b/src/utils/dueDateFormatter.ts
@@ -1,7 +1,15 @@
 import dayjs from 'dayjs'
 
-export const DueDateFormatter = (date: string) => {
+export const DueDateFormatter = (date: string | Date, isRelativeDate: boolean = false) => {
   const parsedDate = dayjs(date)
+  if (isRelativeDate) {
+    if (parsedDate.isToday()) {
+      return 'Today'
+    }
+    if (parsedDate.isTomorrow()) {
+      return 'Tomorrow'
+    }
+  }
   const monthFormats: { [key: string]: string } = {
     January: 'Jan',
     February: 'Feb',


### PR DESCRIPTION
### Changes

- [x] added methods in task logger to support ```ActivityType.DUE_DATE_CHANGED``` to support due date changed in activity logs.
- [x] Added ```DUE_DATE_CHANGED``` ActivityType enum in database layer with a new migration.  
- [x] Integrated logic in ui components to support visualization of due date change activity logs in activity feed according to the design in figma. 

### Testing Criteria

![Screenshot from 2024-12-27 15-32-08](https://github.com/user-attachments/assets/88377243-aa3d-4ffd-ada1-351dffe61849)



