### PR TITLE
fix: show menu on IU task details

### DIFF
--- a/src/app/detail/[task_id]/[user_type]/page.tsx
+++ b/src/app/detail/[task_id]/[user_type]/page.tsx
@@ -91,6 +91,8 @@ export default async function TaskDetailPage({
     return <DeletedTaskRedirectPage userType={tokenPayload.internalUserId ? UserRole.IU : UserRole.Client} token={token} />
   }
 
+  const showTaskMenu = params.user_type === UserType.INTERNAL_USER || !!getPreviewMode(tokenPayload)
+
   return (
     <DetailStateUpdate isRedirect={!!searchParams.isRedirect} token={token} tokenPayload={tokenPayload} task={task}>
       <RealTime tokenPayload={tokenPayload}>
@@ -102,8 +104,7 @@ export default async function TaskDetailPage({
                 <Stack direction="row" justifyContent="space-between">
                   <HeaderBreadcrumbs token={token} title={task?.label} userType={params.user_type} />
                   <Stack direction="row" alignItems="center" columnGap="8px">
-                    {params.user_type === UserType.INTERNAL_USER || (!!getPreviewMode(tokenPayload) && <MenuBoxContainer />)}
-
+                    {showTaskMenu && <MenuBoxContainer />}
                     <Stack direction="row" alignItems="center" columnGap="8px">
                       <ArchiveWrapper taskId={task_id} userType={user_type} />
 


### PR DESCRIPTION
### Tasks

- [Delete option missing for IU](https://linear.app/copilotplatforms/issue/OUT-1206/delete-option-missing-for-tasks-on-iu-end)

### Changes

Show the menu on task details when we see the user type is internal OR we are in preview mode (client/company details).

previously the logic we had was  
```
params.user_type === UserType.INTERNAL_USER || (!!getPreviewMode(tokenPayload) && <MenuBoxContainer />)
```
In the above is the user type is true, the `||` does not get executed and we render nothing. This is why the menu was not shown.

### Testing Criteria

- skipped, this is an attempt to follow up quickly on a bug found and I haven't setup my env fully for e2e testing.