### PR TITLE
OUT-1220 | Add ordering to Activity Logs so that creation events are sorted in order

### DIFF
--- a/src/app/api/activity-logs/services/activity-log.service.ts
+++ b/src/app/api/activity-logs/services/activity-log.service.ts
@@ -30,7 +30,13 @@ export class ActivityLogService extends BaseService {
                 AND C."deletedAt" IS NULL AND C."parentId" IS NULL
             )
           )
-        ORDER BY "ActivityLogs"."createdAt";
+        ORDER BY "ActivityLogs"."createdAt",
+          CASE
+            WHEN "type" = 'TASK_CREATED' THEN 1
+            WHEN "type" = 'TASK_ASSIGNED' THEN 2
+            WHEN "type" = 'DUE_DATE_CHANGED' THEN 2
+            ELSE 2
+          END;
     `
     const parsedActivityLogs = DBActivityLogArraySchema.parse(activityLogs)
 

--- a/src/app/api/activity-logs/services/activity-log.service.ts
+++ b/src/app/api/activity-logs/services/activity-log.service.ts
@@ -34,8 +34,8 @@ export class ActivityLogService extends BaseService {
           CASE
             WHEN "type" = 'TASK_CREATED' THEN 1
             WHEN "type" = 'TASK_ASSIGNED' THEN 2
-            WHEN "type" = 'DUE_DATE_CHANGED' THEN 2
-            ELSE 2
+            WHEN "type" = 'DUE_DATE_CHANGED' THEN 3
+            ELSE 4
           END;
     `
     const parsedActivityLogs = DBActivityLogArraySchema.parse(activityLogs)


### PR DESCRIPTION
### Changes

- [x] Add proper ActivityLog secondary ordering query

### Testing Criteria

- [x] Screenshot

Edit: ignore the "2" "2" for fallbacks
![Screenshot from 2025-01-02 17-36-35](https://github.com/user-attachments/assets/89588600-3e40-4c22-ba2d-0f5b9615bd91)
