### PR TITLE
OUT-1216 | Activity feed updates sometimes take ~30 sec to show

### DIFF
--- a/src/app/api/tasks/tasks.logger.ts
+++ b/src/app/api/tasks/tasks.logger.ts
@@ -1,3 +1,4 @@
+import { TasksService } from '@/app/api/tasks/tasks.service'
 import { ArchivedStateUpdatedSchema } from '@api/activity-logs/schemas/ArchiveStateUpdatedSchema'
 import { DueDateChangedSchema } from '@api/activity-logs/schemas/DueDateChangedSchema'
 import { TaskAssignedSchema } from '@api/activity-logs/schemas/TaskAssignedSchema'
@@ -35,6 +36,7 @@ export class TasksActivityLogger extends BaseService {
   }
 
   async logTaskUpdated(prevTask: Task & { workflowState: WorkflowState }) {
+    const tasksService = new TasksService(this.user)
     if (this.task.assigneeId !== prevTask.assigneeId) {
       await this.logTaskAssigneeUpdated(prevTask)
     }
@@ -50,6 +52,7 @@ export class TasksActivityLogger extends BaseService {
     if (this.task.title.trim() !== prevTask.title.trim()) {
       await this.logTitleUpdated(prevTask)
     }
+    await tasksService.setNewLastActivityLogUpdated(this.task.id)
   }
 
   private async logWorkflowStateUpdated(prevTask: Task & { workflowState: WorkflowState }) {


### PR DESCRIPTION
### Changes

- [x] updated ```lastActivityLog``` timestamp in tasks table when new activity log is created. This process was applied for comment creation only but required in other activitylogs creation too.
### Testing Criteria

- [LOOM](https://www.loom.com/share/bfe98686b23c46a2a562b0babf5c7778?focus_title=1&muted=1&from_recorder=1)

