### PR TITLE
OUT-1219, OUT-1225 | Double animations on comments.

### DIFF
--- a/src/app/detail/[task_id]/[user_type]/actions.ts
+++ b/src/app/detail/[task_id]/[user_type]/actions.ts
@@ -96,7 +96,7 @@ export const postComment = async (token: string, payload: CreateComment) => {
     body: JSON.stringify(payload),
   })
   const data = await res.json()
-  return data
+  return data.comment
   // revalidateTag('getActivities')
 }
 

--- a/src/app/detail/[task_id]/[user_type]/actions.ts
+++ b/src/app/detail/[task_id]/[user_type]/actions.ts
@@ -91,10 +91,12 @@ export const deleteAttachment = async (token: string, id: string) => {
 }
 
 export const postComment = async (token: string, payload: CreateComment) => {
-  await fetch(`${apiUrl}/api/comment?token=${token}`, {
+  const res = await fetch(`${apiUrl}/api/comment?token=${token}`, {
     method: 'POST',
     body: JSON.stringify(payload),
   })
+  const data = await res.json()
+  return data
   // revalidateTag('getActivities')
 }
 

--- a/src/app/detail/ui/ActivityLog.tsx
+++ b/src/app/detail/ui/ActivityLog.tsx
@@ -117,7 +117,7 @@ export const ActivityLog = ({ log }: Prop) => {
   const activityUser = assignee.find((el) => el.id === log?.initiator?.id)
 
   return (
-    <Stack direction="row" columnGap={4} position="relative" sx={{ padding: '12px 0px 12px 0px' }}>
+    <Stack direction="row" columnGap={4} position="relative" sx={{ margin: '12px 0px 12px 0px' }}>
       <VerticalLine />
       <CopilotAvatar
         width="24px"

--- a/src/app/detail/ui/ActivityWrapper.tsx
+++ b/src/app/detail/ui/ActivityWrapper.tsx
@@ -67,10 +67,15 @@ export const ActivityWrapper = ({
   }, [assignee, currentUserId])
 
   const getStableId = (log: LogResponse) => {
-    const matchingUpdate = optimisticUpdates.find((update) => update.serverId === log.id || update.tempId === log.id)
-    return matchingUpdate?.tempId || log.id
-  }
+    if (log.type === ActivityType.COMMENT_ADDED) {
+      const matchingUpdate = optimisticUpdates.find(
+        (update) => update.serverId === log.details.id || update.tempId === log.id,
+      )
 
+      return matchingUpdate?.tempId || z.string().parse(log.details.id) || log.id
+    }
+    return log.id
+  }
   // Handle comment creation
   const handleCreateComment = async (postCommentPayload: CreateComment) => {
     const tempId = generateRandomString('temp-comment')

--- a/src/app/detail/ui/ActivityWrapper.tsx
+++ b/src/app/detail/ui/ActivityWrapper.tsx
@@ -69,10 +69,11 @@ export const ActivityWrapper = ({
   const getStableId = (log: LogResponse) => {
     if (log.type === ActivityType.COMMENT_ADDED) {
       const matchingUpdate = optimisticUpdates.find(
-        (update) => update.serverId === log.details.id || update.tempId === log.id,
+        (update) => update.tempId === log.id || (log.details.id && update.serverId === log.details.id),
       )
-
-      return matchingUpdate?.tempId || z.string().parse(log.details.id) || log.id
+      if (matchingUpdate) {
+        return matchingUpdate?.tempId
+      }
     }
     return log.id
   }

--- a/src/app/detail/ui/Comments.tsx
+++ b/src/app/detail/ui/Comments.tsx
@@ -16,7 +16,7 @@ interface Prop {
 
 export const Comments = ({ comment, createComment, deleteComment, task_id, stableId }: Prop) => {
   return (
-    <Stack id={stableId} direction="row" columnGap={2} position="relative" sx={{ padding: '11px 0px 11px 0px' }}>
+    <Stack id={stableId} direction="row" columnGap={2} position="relative" sx={{ margin: '11px 0px 11px 0px' }}>
       <VerticalLine />
       <CopilotAvatar
         width="24px"


### PR DESCRIPTION
### Changes

- [x] used ```tempId``` for animation key by creating a map state for optimistic data and comparing to use the ```tempId```, only for  those users who created the comment, once they refresh the page, the created comments will have their actual ```log.id``` as animation key. Also, users who are connected in realtime will have ```log.id``` as animation key.


### Testing Criteria

- [LOOM](https://www.loom.com/share/d112b003f1c1421db92a4c4d3ea59367)

