### PR TITLE
OUT-1226 | Revert automatic Task Assigned activity log on tasks

### DIFF
--- a/src/app/api/tasks/tasks.logger.ts
+++ b/src/app/api/tasks/tasks.logger.ts
@@ -30,9 +30,6 @@ export class TasksActivityLogger extends BaseService {
 
   async logNewTask() {
     await this.logTaskCreated()
-    if (this.task.assigneeId) {
-      await this.logTaskAssigneeUpdated()
-    }
   }
 
   async logTaskUpdated(prevTask: Task & { workflowState: WorkflowState }) {

--- a/src/cmd/fill-activity-logs/fillTaskAssigned.ts
+++ b/src/cmd/fill-activity-logs/fillTaskAssigned.ts
@@ -41,27 +41,3 @@ export const fillTaskAssigned = async () => {
 
   await db.activityLog.createMany({ data })
 }
-
-/** //remove the comment below
- * cmd script to delete 'X assigned task to Y' activity logs for tasks
- */
-// export const revertTaskAssigned = async () => {
-//   const db = DBClient.getInstance()
-//   // Gets all activity logs of type TASK_ASSIGNED
-//   const activityLogs = await db.activityLog.findMany({
-//     where: { type: ActivityType.TASK_ASSIGNED },
-//   })
-//   if (!activityLogs.length) {
-//     console.info('No TASK_ASSIGNED activity logs found!')
-//     return
-//   }
-//   console.warn(`⚠️ ${activityLogs.length} TASK_ASSIGNED activity logs will be deleted!`)
-
-//   const activityLogIds = activityLogs.map((log) => log.id)
-
-//   await db.activityLog.deleteMany({
-//     where: { id: { in: activityLogIds } },
-//   })
-
-//   console.info('All TASK_ASSIGNED activity logs have been deleted!')
-// }

--- a/src/cmd/fill-activity-logs/fillTaskAssigned.ts
+++ b/src/cmd/fill-activity-logs/fillTaskAssigned.ts
@@ -41,3 +41,27 @@ export const fillTaskAssigned = async () => {
 
   await db.activityLog.createMany({ data })
 }
+
+/** //remove the comment below
+ * cmd script to delete 'X assigned task to Y' activity logs for tasks
+ */
+// export const revertTaskAssigned = async () => {
+//   const db = DBClient.getInstance()
+//   // Gets all activity logs of type TASK_ASSIGNED
+//   const activityLogs = await db.activityLog.findMany({
+//     where: { type: ActivityType.TASK_ASSIGNED },
+//   })
+//   if (!activityLogs.length) {
+//     console.info('No TASK_ASSIGNED activity logs found!')
+//     return
+//   }
+//   console.warn(`⚠️ ${activityLogs.length} TASK_ASSIGNED activity logs will be deleted!`)
+
+//   const activityLogIds = activityLogs.map((log) => log.id)
+
+//   await db.activityLog.deleteMany({
+//     where: { id: { in: activityLogIds } },
+//   })
+
+//   console.info('All TASK_ASSIGNED activity logs have been deleted!')
+// }


### PR DESCRIPTION
### Changes

- [x] removed logic that removes auto creation of activity log of task assigned on task creation.

### Testing Criteria

![image](https://github.com/user-attachments/assets/d3156a1f-e232-424f-afeb-d9be25020387)
![image](https://github.com/user-attachments/assets/3f21cae3-2f0e-4fb9-9f7a-de0a8c0f8f3e)
![image](https://github.com/user-attachments/assets/7faf2c6b-f3a1-46a8-ace9-57eb654eeb21)

