### PR TITLE
OUT-1230 | Prevent passing unrecognized props to the DOM from custom components

### DIFF
--- a/src/components/inputs/TextField.tsx
+++ b/src/components/inputs/TextField.tsx
@@ -3,7 +3,8 @@
 import { TextField, styled } from '@mui/material'
 
 export const StyledTextField = styled(TextField, {
-  shouldForwardProp: (prop) => prop !== 'padding',
+  shouldForwardProp: (prop) =>
+    prop !== 'basePadding' && prop !== 'padding' && prop !== 'borderColor' && prop !== 'borderLess',
 })<{ basePadding?: string; padding?: string; borderColor?: string; borderLess?: boolean }>(
   ({ basePadding, padding, borderColor, borderLess, theme }) => ({
     '& .MuiInputBase-root': {


### PR DESCRIPTION
### Changes

- [x] `basePadding`, `borderColor` and `borderLess` prop from `StyledTextField` are not forwarded to the DOM.

### Testing Criteria

- [x] No design regression are noticed on components using `StyledTextField` after applying the changes

