### PR TITLE
OUT-1231 | Can not create template with the same name as the deleted template.

### DIFF
--- a/prisma/migrations/20250106090303_add_deleted_at_to_composite_unique_key_in_task_templates/migration.sql
+++ b/prisma/migrations/20250106090303_add_deleted_at_to_composite_unique_key_in_task_templates/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[title,workspaceId,deletedAt]` on the table `TaskTemplates` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropIndex
+DROP INDEX "TaskTemplates_title_workspaceId_key";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "TaskTemplates_title_workspaceId_deletedAt_key" ON "TaskTemplates"("title", "workspaceId", "deletedAt");

--- a/prisma/schema/taskTemplate.prisma
+++ b/prisma/schema/taskTemplate.prisma
@@ -11,8 +11,8 @@ model TaskTemplate {
   updatedAt   DateTime  @updatedAt
   deletedAt   DateTime?
 
-  scrapMedias     ScrapMedia[]
+  scrapMedias ScrapMedia[]
 
-  @@unique([title, workspaceId], name: "UQ_TaskTemplates_title_workspaceId")
+  @@unique([title, workspaceId, deletedAt], name: "UQ_TaskTemplates_title_workspaceId_deletedAt")
   @@map("TaskTemplates")
 }


### PR DESCRIPTION
### Changes

- [x] Add composite unique key on `title`, `workspaceId` and `deletedAt` allowing for multiple deleted templates for a workspace with same name 

## Testing criteria

Screenshot

![image](https://github.com/user-attachments/assets/74ce109d-8dae-417c-bf7f-92c9fb7cf125)
