### PR TITLE
OUT-1232 | Fix heading 'Templates' alignment in mobile view

### DIFF
--- a/src/app/manage-templates/ui/Header.tsx
+++ b/src/app/manage-templates/ui/Header.tsx
@@ -18,7 +18,7 @@ export const ManageTemplateHeader = ({ token }: { token: string }) => {
   const { previewMode } = useSelector(selectTaskBoard)
   return (
     <StyledBox>
-      <AppMargin size={SizeofAppMargin.HEADER} py="17.5px">
+      <AppMargin size={SizeofAppMargin.HEADER} py="14px">
         <Stack direction="row" justifyContent="space-between" alignItems="center">
           <HeaderBreadcrumbs
             title="Manage templates"
@@ -47,6 +47,7 @@ export const ManageTemplateHeader = ({ token }: { token: string }) => {
                     store.dispatch(setShowTemplateModal({ targetMethod: TargetMethod.POST }))
                   }}
                   icon={<Add sx={{ color: '#fff' }} />}
+                  padding="4px"
                 />
               </Box>
             </>

--- a/src/app/manage-templates/ui/TemplateBoard.tsx
+++ b/src/app/manage-templates/ui/TemplateBoard.tsx
@@ -40,9 +40,16 @@ export const TemplateBoard = ({
     <>
       {templates.length ? (
         <Box id="templates-box" sx={{ maxWidth: '384px', marginTop: '32px', marginLeft: 'auto', marginRight: 'auto' }}>
-          <Typography variant="xl" lineHeight={'28px'}>
-            Templates
-          </Typography>
+          <Box
+            sx={{
+              width: { xs: '90%', sm: '100%' },
+              margin: '0 auto',
+            }}
+          >
+            <Typography variant="xl" lineHeight={'28px'}>
+              Templates
+            </Typography>
+          </Box>
 
           <Stack
             direction="column"


### PR DESCRIPTION
### Changes

- [x] Adjustments on manage templates page's header aligning properties to the design in figma. 
- [x] Templates board title alignment on smaller screens.  

### Testing Criteria

![image](https://github.com/user-attachments/assets/bb2dc671-fe8c-4040-8cb1-7640027cf51a)
![image](https://github.com/user-attachments/assets/a87f8735-4e92-41cf-ac53-b730c9532d2f)


