### PR TITLE
OUT-1238 | Make validate-count robust by removing duplicate notifications for a single task

### DIFF
--- a/src/cmd/fill-activity-logs/index.ts
+++ b/src/cmd/fill-activity-logs/index.ts
@@ -1,11 +1,11 @@
-import { fillTaskCreated } from './fillTaskCreated'
+// import { fillTaskCreated } from './fillTaskCreated'
 // Use to fill "X created task Y" records for tasks without them
-fillTaskCreated()
+// fillTaskCreated()
 
 // import { fillTaskAssigned } from './fillTaskAssigned'
 // Use to fill "X assigned task to Y" activity logs for tasks without them
 // fillTaskAssigned()
 
-// import { fillWorkflowStateUpdated } from './fillWorkflowStateUpdated'
+import { fillWorkflowStateUpdated } from './fillWorkflowStateUpdated'
 // Use to fill "X changed status from Y to Z" activity logs for tasks with old corrupted details
-// fillWorkflowStateUpdated()
+fillWorkflowStateUpdated()

--- a/src/cmd/fill-activity-logs/index.ts
+++ b/src/cmd/fill-activity-logs/index.ts
@@ -1,11 +1,11 @@
-// import { fillTaskCreated } from './fillTaskCreated'
+import { fillTaskCreated } from './fillTaskCreated'
 // Use to fill "X created task Y" records for tasks without them
-// fillTaskCreated()
+fillTaskCreated()
 
 // import { fillTaskAssigned } from './fillTaskAssigned'
 // Use to fill "X assigned task to Y" activity logs for tasks without them
 // fillTaskAssigned()
 
-import { fillWorkflowStateUpdated } from './fillWorkflowStateUpdated'
+// import { fillWorkflowStateUpdated } from './fillWorkflowStateUpdated'
 // Use to fill "X changed status from Y to Z" activity logs for tasks with old corrupted details
-fillWorkflowStateUpdated()
+// fillWorkflowStateUpdated()

--- a/src/types/client-notifications.ts
+++ b/src/types/client-notifications.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod'
+
+export const DuplicateNotificationsQuerySchema = z.object({
+  taskId: z.string().uuid(),
+  rowCount: z.bigint(),
+  latestCreatedAt: z.date(),
+})


### PR DESCRIPTION
### Changes

- [x] Add logic to disallow and remove any and all duplicate notifications for tasks.

### Testing Criteria

- [x] Screencast

[Screencast from 2025-01-07 19-15-04.webm](https://github.com/user-attachments/assets/f11ac89c-aba1-482c-a059-04f787ac92d8)
