### PR TITLE
OUT-1244 | Activity feed not updating for archived tasks after status change

### DIFF
--- a/src/app/detail/ui/ActivityWrapper.tsx
+++ b/src/app/detail/ui/ActivityWrapper.tsx
@@ -34,12 +34,11 @@ export const ActivityWrapper = ({
   task_id: string
   tokenPayload: Token
 }) => {
-  const { tasks } = useSelector(selectTaskBoard)
-  const task = tasks.find((task) => task.id === task_id)
+  const { activeTask } = useSelector(selectTaskBoard)
+  const task = activeTask
   const [lastUpdated, setLastUpdated] = useState(task?.lastActivityLogUpdated)
   const [optimisticUpdates, setOptimisticUpdates] = useState<OptimisticUpdate[]>([])
   const cacheKey = `/api/tasks/${task_id}/activity-logs?token=${token}`
-
   const { data: activities, isLoading } = useSWR(`/api/tasks/${task_id}/activity-logs?token=${token}`, fetcher, {
     refreshInterval: 0,
   })


### PR DESCRIPTION
### Changes

- [x] instead of checking updates in `tasks` array which contains all the task fetched according to archived/unarchived queries, added a functionality to check updates in `activeTask` which is the task the user is currently navigating on.

### Testing Criteria

- [LOOM](https://www.loom.com/share/9d5ae4e774324e158496eb22e0ac4dff)


