### PR TITLE
OUT-1245 | Create task button is missing in list view on client details page

### DIFF
--- a/src/app/ui/TaskBoard.tsx
+++ b/src/app/ui/TaskBoard.tsx
@@ -210,6 +210,7 @@ export const TaskBoard = ({ mode }: TaskBoardProps) => {
                   columnName={list.name}
                   taskCount={taskCountForWorkflowStateId(list.id)}
                   display={!!filterTaskWithWorkflowStateId(list.id).length}
+                  showAddBtn={mode === UserRole.IU || !!previewMode}
                 >
                   {sortTaskByDescendingOrder<TaskResponse>(filterTaskWithWorkflowStateId(list.id)).map((task, index) => {
                     return (

--- a/src/components/cards/TaskRow.tsx
+++ b/src/components/cards/TaskRow.tsx
@@ -9,9 +9,18 @@ import { UserRole } from '@/app/api/core/types/user'
 
 interface TaskRowProps extends TaskWorkflowStateProps {
   display?: boolean
+  showAddBtn?: boolean
 }
 
-export const TaskRow = ({ workflowStateId, mode, children, columnName, taskCount, display = true }: TaskRowProps) => {
+export const TaskRow = ({
+  workflowStateId,
+  mode,
+  children,
+  columnName,
+  taskCount,
+  display = true,
+  showAddBtn,
+}: TaskRowProps) => {
   return display ? (
     <Box>
       <Box
@@ -33,9 +42,7 @@ export const TaskRow = ({ workflowStateId, mode, children, columnName, taskCount
                 {taskCount}
               </Typography>
             </Stack>
-            {mode === UserRole.IU && (
-              <AddBtn handleClick={() => handleAddBtnClicked(workflowStateId)} sx={{ paddingRight: '3px' }} />
-            )}
+            {showAddBtn && <AddBtn handleClick={() => handleAddBtnClicked(workflowStateId)} sx={{ paddingRight: '3px' }} />}
           </Stack>
         </AppMargin>
       </Box>


### PR DESCRIPTION
## Changes

- [x] Show AddBtn for client preview mode

## Testing Criteria

- [x] Screenshots

![image](https://github.com/user-attachments/assets/dd74a07f-ef7a-4616-b109-c5952ffc5dcc)

![image](https://github.com/user-attachments/assets/2e92ec2e-a53b-43ec-ab74-865788f92fce)
