### PR TITLE
Qol: Remove task link from pr template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,15 +1,11 @@
-### Tasks
-
-- [Task](Task Link)
-
-### Changes
+## Changes
 
 - [ ] ...
 
-### Testing Criteria
+## Testing Criteria
 
 - [ ] Test Criterias (explain how you did testing for this PR mentioning all the cases you tested for) [Loom](video link going through the test criteria)
 
-### Notes
+## Notes
 
 - Dependencies on other PRs, any required changes in config/setup to test behaviour, or links to external documents, threads, etc -- if any of them are required


### PR DESCRIPTION
## Changes

- [x] Removed Tasks links section from PR template since linear's bot does that for us 
- [x] Make titles H2 so they are easier to read 