### PR TITLE
OUT-1247 | Fix template pop up heading alignment

### DIFF
--- a/src/app/manage-templates/ui/TemplateForm.tsx
+++ b/src/app/manage-templates/ui/TemplateForm.tsx
@@ -49,7 +49,7 @@ export const TemplateForm = ({ handleCreate }: { handleCreate: () => void }) => 
           justifyContent="space-between"
           sx={{
             border: (theme) => `1px solid ${theme.color.borders.borderDisabled}`,
-            padding: '14px 28px',
+            padding: '14px 20px',
           }}
         >
           {targetMethod === TargetMethod.POST ? (


### PR DESCRIPTION
## Changes

- [x] Change inconsistent padding causing misalignment. (20px value is set for template form content, and other forms like in Task Create)

## Testing Criteria

- [x] Screenshots

![image](https://github.com/user-attachments/assets/e89699a1-36c8-415f-b7f9-3e4304c65b01)
