### PR TITLE
OUT-1246 | Incorrect empty state is shown for tasks on client details page

### DIFF
--- a/src/app/ui/TaskBoard.tsx
+++ b/src/app/ui/TaskBoard.tsx
@@ -83,7 +83,7 @@ export const TaskBoard = ({ mode }: TaskBoardProps) => {
     filterOptions &&
     !filterOptions.type &&
     !filterOptions.keyword &&
-    !filterOptions.assignee &&
+    (!filterOptions.assignee || previewMode) &&
     showUnarchived &&
     !showArchived
 
@@ -109,7 +109,6 @@ export const TaskBoard = ({ mode }: TaskBoardProps) => {
       </>
     )
   }
-
   return (
     <>
       <TaskDataFetcher token={token ?? ''} />

--- a/src/components/layouts/EmptyState/DashboardEmptyState.tsx
+++ b/src/components/layouts/EmptyState/DashboardEmptyState.tsx
@@ -47,7 +47,7 @@ const DashboardEmptyState = ({ userType }: { userType: UserRole }) => {
                 {userType == UserRole.IU ? " You don't have any tasks yet" : 'No tasks assigned'}
               </Typography>
               <Typography variant="bodyLg" sx={{ color: (theme) => theme.color.gray[500] }}>
-                {userType == UserRole.IU
+                {userType == UserRole.IU && !previewMode
                   ? 'Tasks will be shown here after they’re created. You can create a new task below.'
                   : 'Tasks will show here once they’ve been assigned to you. '}
               </Typography>


### PR DESCRIPTION
### Changes

- [x] `userHasNoFilter` check to display `DashboardEmptyState` was always being true because of assignee filter applied. Added a condition to make it false on preview mode. 

### Testing Criteria

![image](https://github.com/user-attachments/assets/4cc4f24e-162d-469b-92e2-0f49a18c87f1)

### Notes

- We can see in the image that although we have the text : "_You don't have any tasks yet Tasks will show here once they’ve been assigned to you._", I've added create task button too, which should be in client view but it is a functionality for CRM's tasks app. 
