### PR TITLE
OUT-1254 | OUT-1255 | Implement "Create task" button & "Manage templates" menu option for Tasks Board

### DIFF
--- a/src/app/ui/TaskBoard.tsx
+++ b/src/app/ui/TaskBoard.tsx
@@ -113,10 +113,13 @@ export const TaskBoard = ({ mode }: TaskBoardProps) => {
       </>
     )
   }
+
+  const showHeader = !!previewMode
+
   return (
     <>
       <TaskDataFetcher token={token ?? ''} />
-      <Header showCreateTaskButton={mode === UserRole.IU || !!previewMode} showMenuBox={!previewMode} />
+      {showHeader && <Header showCreateTaskButton={mode === UserRole.IU || !!previewMode} showMenuBox={!previewMode} />}
       <FilterBar
         mode={mode}
         updateViewModeSetting={async (payload: CreateViewSettingsDTO) => {

--- a/src/app/ui/TaskBoardAppBridge.tsx
+++ b/src/app/ui/TaskBoardAppBridge.tsx
@@ -1,0 +1,48 @@
+'use client'
+
+import { Icons } from '@/hooks/app-bridge/types'
+import { useActionsMenu } from '@/hooks/app-bridge/useActionsMenu'
+import { usePrimaryCta } from '@/hooks/app-bridge/usePrimaryCta'
+import { setShowModal } from '@/redux/features/createTaskSlice'
+import store from '@/redux/store'
+import { UserRole } from '@api/core/types/user'
+import { useRouter } from 'next/navigation'
+
+interface TaskBoardAppBridgeProps {
+  token: string
+  role: UserRole
+  portalUrl?: string
+}
+
+export const TaskBoardAppBridge = ({ token, role, portalUrl }: TaskBoardAppBridgeProps) => {
+  const router = useRouter()
+
+  const handleTaskCreate = () => {
+    store.dispatch(setShowModal())
+  }
+  const handleManageTemplatesClick = () => {
+    router.push(`/manage-templates?token=${token}`)
+  }
+
+  usePrimaryCta(
+    {
+      label: 'Create task',
+      icon: Icons.PLUS,
+      onClick: handleTaskCreate,
+    },
+    { portalUrl },
+  )
+
+  useActionsMenu(
+    [
+      {
+        label: 'Manage templates',
+        icon: Icons.ARCHIVE,
+        onClick: handleManageTemplatesClick,
+      },
+    ],
+    { portalUrl },
+  )
+
+  return <></>
+}

--- a/src/hooks/app-bridge/types.ts
+++ b/src/hooks/app-bridge/types.ts
@@ -1,5 +1,10 @@
 // Icons defined for app bridge
-export type Icons = 'Archive' | 'Plus' | 'Templates' | 'Trash'
+export enum Icons {
+  ARCHIVE = 'Archive',
+  PLUS = 'Plus',
+  TEMPLATES = 'Templates',
+  TRASH = 'Trash',
+}
 
 export interface BreadcrumbsPayload {
   items: {

--- a/src/hooks/app-bridge/types.ts
+++ b/src/hooks/app-bridge/types.ts
@@ -1,0 +1,43 @@
+// Icons defined for app bridge
+export type Icons = 'Archive' | 'Plus' | 'Templates' | 'Trash'
+
+export interface BreadcrumbsPayload {
+  items: {
+    label: string
+    onClick: string
+  }[]
+  type: 'header.breadcrumbs'
+}
+
+export interface PrimaryCtaPayload {
+  icon?: Icons
+  label: string
+  onClick?: string
+  type: 'header.primaryCta'
+}
+
+export interface SecondaryCtaPayload {
+  icon?: Icons
+  label: string
+  onClick?: string
+  type: 'header.secondaryCta'
+}
+
+export interface ActionsMenuPayload {
+  items: {
+    label: string
+    onClick: string
+    icon?: Icons
+  }[]
+  type: 'header.actionsMenu'
+}
+
+export interface Clickable {
+  label: string
+  onClick?: () => void
+  icon?: Icons
+}
+
+export interface Configurable {
+  portalUrl?: string
+}

--- a/src/hooks/app-bridge/useActionsMenu.tsx
+++ b/src/hooks/app-bridge/useActionsMenu.tsx
@@ -1,0 +1,55 @@
+import { ActionsMenuPayload, Clickable, Configurable } from '@/hooks/app-bridge/types'
+import { useEffect, useMemo } from 'react'
+
+const getActionMenuItemId = (idx: number) => `header.actionsMenu.${idx}`
+
+export function useActionsMenu(actions: Clickable[], config?: Configurable) {
+  const callbackRefs = useMemo(() => {
+    return actions.reduce<Record<string, () => void>>((acc, { onClick }, idx) => {
+      if (onClick) acc[getActionMenuItemId(idx)] = onClick
+      return acc
+    }, {})
+  }, [actions])
+
+  useEffect(() => {
+    const payload: ActionsMenuPayload = {
+      type: 'header.actionsMenu',
+      items: actions.map(({ label, onClick, icon }, idx) => ({
+        onClick: onClick ? getActionMenuItemId(idx) : '',
+        label,
+        icon,
+      })),
+    }
+
+    window.parent.postMessage(payload, 'https://dashboard.copilot.com')
+    if (config?.portalUrl) {
+      window.parent.postMessage(payload, ensureHttps(config.portalUrl))
+    }
+
+    const handleMessage = (event: MessageEvent) => {
+      if (
+        event.data.type === 'header.actionsMenu.onClick' &&
+        typeof event.data.id === 'string' &&
+        callbackRefs[event.data.id]
+      ) {
+        callbackRefs[event.data.id]()
+      }
+    }
+
+    addEventListener('message', handleMessage)
+
+    return () => {
+      removeEventListener('message', handleMessage)
+    }
+  }, [actions, callbackRefs, config?.portalUrl])
+
+  useEffect(() => {
+    const handleUnload = () => {
+      window.parent.postMessage({ type: 'header.actionsMenu', items: [] }, 'https://dashboard.copilot.com')
+    }
+    addEventListener('beforeunload', handleUnload)
+    return () => {
+      removeEventListener('beforeunload', handleUnload)
+    }
+  }, [])
+}

--- a/src/hooks/app-bridge/useActionsMenu.tsx
+++ b/src/hooks/app-bridge/useActionsMenu.tsx
@@ -1,4 +1,5 @@
 import { ActionsMenuPayload, Clickable, Configurable } from '@/hooks/app-bridge/types'
+import { ensureHttps } from '@/utils/https'
 import { useEffect, useMemo } from 'react'
 
 const getActionMenuItemId = (idx: number) => `header.actionsMenu.${idx}`

--- a/src/hooks/app-bridge/useBreadcrumbs.tsx
+++ b/src/hooks/app-bridge/useBreadcrumbs.tsx
@@ -1,4 +1,5 @@
 import { BreadcrumbsPayload, Clickable, Configurable } from '@/hooks/app-bridge/types'
+import { ensureHttps } from '@/utils/https'
 import { useEffect, useMemo } from 'react'
 
 const getBreadcrumbId = (idx: number) => `header.breadcrumbs.${idx}`

--- a/src/hooks/app-bridge/useBreadcrumbs.tsx
+++ b/src/hooks/app-bridge/useBreadcrumbs.tsx
@@ -1,0 +1,44 @@
+import { BreadcrumbsPayload, Clickable, Configurable } from '@/hooks/app-bridge/types'
+import { useEffect, useMemo } from 'react'
+
+const getBreadcrumbId = (idx: number) => `header.breadcrumbs.${idx}`
+
+export const useBreadcrumbs = (breadcrumbs: Clickable[], config?: Configurable) => {
+  const callbackRefs = useMemo(() => {
+    return breadcrumbs.reduce<Record<string, () => void>>((acc, { onClick }, idx) => {
+      if (onClick) acc[getBreadcrumbId(idx)] = onClick
+      return acc
+    }, {})
+  }, [breadcrumbs])
+
+  useEffect(() => {
+    const payload: BreadcrumbsPayload = {
+      type: 'header.breadcrumbs',
+      items: breadcrumbs.map(({ label, onClick }, idx) => ({
+        onClick: onClick ? getBreadcrumbId(idx) : '',
+        label,
+      })),
+    }
+
+    window.parent.postMessage(payload, 'https://dashboard.copilot.com')
+    if (config?.portalUrl) {
+      window.parent.postMessage(payload, ensureHttps(config.portalUrl))
+    }
+
+    const handleMessage = (event: MessageEvent) => {
+      if (
+        event.data.type === 'header.breadcrumbs.onClick' &&
+        typeof event.data.id === 'string' &&
+        callbackRefs[event.data.id]
+      ) {
+        callbackRefs[event.data.id]()
+      }
+    }
+
+    addEventListener('message', handleMessage)
+
+    return () => {
+      removeEventListener('message', handleMessage)
+    }
+  }, [breadcrumbs, callbackRefs, config?.portalUrl])
+}

--- a/src/hooks/app-bridge/usePrimaryCta.tsx
+++ b/src/hooks/app-bridge/usePrimaryCta.tsx
@@ -1,0 +1,45 @@
+import { Clickable, Configurable, PrimaryCtaPayload } from '@/hooks/app-bridge/types'
+import { useEffect } from 'react'
+
+export const usePrimaryCta = (primaryCta: Clickable | null, config?: Configurable) => {
+  useEffect(() => {
+    const payload: PrimaryCtaPayload | Pick<PrimaryCtaPayload, 'type'> = !primaryCta
+      ? { type: 'header.primaryCta' }
+      : {
+          icon: primaryCta.icon,
+          label: primaryCta.label,
+          onClick: 'header.primaryCta.onClick',
+          type: 'header.primaryCta',
+        }
+
+    window.parent.postMessage(payload, 'https://dashboard.copilot.com')
+    if (config?.portalUrl) {
+      window.parent.postMessage(payload, ensureHttps(config.portalUrl))
+    }
+
+    const handleMessage = (event: MessageEvent) => {
+      if (event.data.type === 'header.primaryCta.onClick' && typeof event.data.id === 'string' && primaryCta?.onClick) {
+        primaryCta.onClick()
+      }
+    }
+
+    addEventListener('message', handleMessage)
+
+    return () => {
+      removeEventListener('message', handleMessage)
+    }
+  }, [primaryCta, config?.portalUrl])
+
+  useEffect(() => {
+    const handleUnload = () => {
+      window.parent.postMessage({ type: 'header.primaryCta' }, 'https://dashboard.copilot.com')
+      if (config?.portalUrl) {
+        window.parent.postMessage({ type: 'header.primaryCta' }, ensureHttps(config.portalUrl))
+      }
+    }
+    addEventListener('beforeunload', handleUnload)
+    return () => {
+      removeEventListener('beforeunload', handleUnload)
+    }
+  }, [config?.portalUrl])
+}

--- a/src/hooks/app-bridge/usePrimaryCta.tsx
+++ b/src/hooks/app-bridge/usePrimaryCta.tsx
@@ -1,4 +1,5 @@
 import { Clickable, Configurable, PrimaryCtaPayload } from '@/hooks/app-bridge/types'
+import { ensureHttps } from '@/utils/https'
 import { useEffect } from 'react'
 
 export const usePrimaryCta = (primaryCta: Clickable | null, config?: Configurable) => {

--- a/src/hooks/app-bridge/useSecondaryCta.tsx
+++ b/src/hooks/app-bridge/useSecondaryCta.tsx
@@ -1,4 +1,5 @@
 import { Clickable, Configurable, SecondaryCtaPayload } from '@/hooks/app-bridge/types'
+import { ensureHttps } from '@/utils/https'
 import { useEffect } from 'react'
 
 export const useSecondaryCta = (secondaryCta: Clickable | null, config?: Configurable) => {

--- a/src/hooks/app-bridge/useSecondaryCta.tsx
+++ b/src/hooks/app-bridge/useSecondaryCta.tsx
@@ -1,0 +1,44 @@
+import { Clickable, Configurable, SecondaryCtaPayload } from '@/hooks/app-bridge/types'
+import { useEffect } from 'react'
+
+export const useSecondaryCta = (secondaryCta: Clickable | null, config?: Configurable) => {
+  useEffect(() => {
+    const payload: SecondaryCtaPayload | Pick<SecondaryCtaPayload, 'type'> = !secondaryCta
+      ? { type: 'header.secondaryCta' }
+      : {
+          type: 'header.secondaryCta',
+          label: secondaryCta.label,
+          onClick: 'header.secondaryCta.onClick',
+        }
+
+    window.parent.postMessage(payload, 'https://dashboard.copilot.com')
+    if (config?.portalUrl) {
+      window.parent.postMessage(payload, ensureHttps(config.portalUrl))
+    }
+
+    const handleMessage = (event: MessageEvent) => {
+      if (event.data.type === 'header.secondaryCta.onClick' && typeof event.data.id === 'string' && secondaryCta?.onClick) {
+        secondaryCta.onClick()
+      }
+    }
+
+    addEventListener('message', handleMessage)
+
+    return () => {
+      removeEventListener('message', handleMessage)
+    }
+  }, [secondaryCta, config?.portalUrl])
+
+  useEffect(() => {
+    const handleUnload = () => {
+      window.parent.postMessage({ type: 'header.secondaryCta' }, 'https://dashboard.copilot.com')
+      if (config?.portalUrl) {
+        window.parent.postMessage({ type: 'header.secondaryCta' }, ensureHttps(config.portalUrl))
+      }
+    }
+    addEventListener('beforeunload', handleUnload)
+    return () => {
+      removeEventListener('beforeunload', handleUnload)
+    }
+  }, [config?.portalUrl])
+}

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -59,6 +59,7 @@ export const WorkspaceResponseSchema = z.object({
   font: z.string().optional(),
   metaTitle: z.string().optional(),
   metaDescription: z.string().optional(),
+  portalUrl: z.string().optional(),
 })
 export type WorkspaceResponse = z.infer<typeof WorkspaceResponseSchema>
 

--- a/src/utils/https.ts
+++ b/src/utils/https.ts
@@ -1,0 +1,9 @@
+export const ensureHttps = (url: string) => {
+  if (url.startsWith('https://')) {
+    return url
+  }
+  if (url.startsWith('http://')) {
+    return url.replace('http://', 'https://')
+  }
+  return `https://${url}`
+}


### PR DESCRIPTION
## Changes

- [x] Add necessary utilities to implement app bridge (`app-bridge/use*`)
- [x] Implement usePrimaryCta to show "Create task" button
- [x] Implement useActionsMenu to show "Manage templates" action menu
- [x] Remove header from IU & CU task board. Only show header in preview mode since app bridge is not supported.  

### Testing Criteria

- [x] Screencast

[Screencast from 2025-01-10 15-20-13.webm](https://github.com/user-attachments/assets/3c67504d-1788-4ccc-932d-cca1635d2224)

## NOTE:
Design is not up to us - it is implemented from the copilot side.