### PR TITLE
OUT-1263 | Implement Breadcrumbs for Task Details Page

### DIFF
--- a/src/app/detail/[task_id]/[user_type]/page.tsx
+++ b/src/app/detail/[task_id]/[user_type]/page.tsx
@@ -96,10 +96,7 @@ export default async function TaskDetailPage({
                 <Stack direction="row" justifyContent="space-between">
                   <HeaderBreadcrumbs token={token} title={task?.label} userType={params.user_type} />
                   <Stack direction="row" alignItems="center" columnGap="8px">
-                    <MenuBoxContainer
-                      isPreviewMode={isPreviewMode}
-                      role={tokenPayload.internalUserId ? UserRole.IU : UserRole.Client}
-                    />
+                    <MenuBoxContainer role={tokenPayload.internalUserId ? UserRole.IU : UserRole.Client} />
                     <Stack direction="row" alignItems="center" columnGap="8px">
                       <ArchiveWrapper taskId={task_id} userType={user_type} />
                       <ToggleButtonContainer />

--- a/src/app/detail/ui/MenuBoxContainer.tsx
+++ b/src/app/detail/ui/MenuBoxContainer.tsx
@@ -4,16 +4,19 @@ import { UserRole } from '@/app/api/core/types/user'
 import { ListBtn } from '@/components/buttons/ListBtn'
 import { MenuBox } from '@/components/inputs/MenuBox'
 import { TrashIcon } from '@/icons'
+import { selectTaskBoard } from '@/redux/features/taskBoardSlice'
 import { setShowConfirmDeleteModal } from '@/redux/features/taskDetailsSlice'
 import store from '@/redux/store'
+import { useSelector } from 'react-redux'
 
 interface MenuBoxContainerProps {
   role: UserRole
-  isPreviewMode: boolean
 }
 
-export const MenuBoxContainer = ({ role, isPreviewMode }: MenuBoxContainerProps) => {
-  if ((role === UserRole.IU && !isPreviewMode) || role === UserRole.Client) {
+export const MenuBoxContainer = ({ role }: MenuBoxContainerProps) => {
+  const { previewMode } = useSelector(selectTaskBoard)
+
+  if ((role === UserRole.IU && !previewMode) || role === UserRole.Client) {
     return null
   }
 

--- a/src/app/detail/ui/ToggleButtonContainer.tsx
+++ b/src/app/detail/ui/ToggleButtonContainer.tsx
@@ -1,10 +1,20 @@
 'use client'
 import { ToggleBtn } from '@/components/buttons/ToggleBtn'
+import { selectTaskBoard } from '@/redux/features/taskBoardSlice'
 import { selectTaskDetails, setShowSidebar } from '@/redux/features/taskDetailsSlice'
 import store from '@/redux/store'
+import { Box } from '@mui/material'
 import { useSelector } from 'react-redux'
 
 export const ToggleButtonContainer = () => {
   const { showSidebar } = useSelector(selectTaskDetails)
+  const { previewMode } = useSelector(selectTaskBoard)
+  if (!previewMode) {
+    return (
+      <Box sx={{ width: '72vw', display: 'flex', justifyContent: 'flex-end' }}>
+        <ToggleBtn onClick={() => store.dispatch(setShowSidebar(!showSidebar))} />
+      </Box>
+    )
+  }
   return <ToggleBtn onClick={() => store.dispatch(setShowSidebar(!showSidebar))} />
 }

--- a/src/components/layouts/HeaderBreadcrumbs.tsx
+++ b/src/components/layouts/HeaderBreadcrumbs.tsx
@@ -3,9 +3,11 @@
 import { StyledKeyboardIcon, StyledTypography } from '@/app/detail/ui/styledComponent'
 import { SecondaryBtn } from '@/components/buttons/SecondaryBtn'
 import { CustomLink } from '@/hoc/CustomLink'
+import { useBreadcrumbs } from '@/hooks/app-bridge/useBreadcrumbs'
 import { selectTaskBoard } from '@/redux/features/taskBoardSlice'
 import { UserType } from '@/types/interfaces'
 import { Stack, Typography } from '@mui/material'
+import { useRouter } from 'next/navigation'
 import { useSelector } from 'react-redux'
 
 type ValidTasksBoardLink = '/' | '/client'
@@ -20,6 +22,7 @@ export const HeaderBreadcrumbs = ({
   userType: UserType
 }) => {
   const { previewMode } = useSelector(selectTaskBoard)
+  const router = useRouter()
 
   const getTasksLink = (userType: UserType): ValidTasksBoardLink => {
     if (previewMode) return '/client'
@@ -29,6 +32,20 @@ export const HeaderBreadcrumbs = ({
       [UserType.CLIENT_USER]: '/client',
     }
     return tasksLinks[userType]
+  }
+
+  useBreadcrumbs([
+    {
+      label: 'Tasks',
+      onClick: () => router.push(`/?token=${token}`),
+    },
+    {
+      label: title,
+    },
+  ])
+
+  if (!previewMode) {
+    return null
   }
 
   return (


### PR DESCRIPTION
## Changes

- [x] Add breadcrumbs for Task Details Page

## Testing Criteria

- [x] Screencast

[Screencast from 2025-01-13 17-19-45.webm](https://github.com/user-attachments/assets/d698416f-6265-4c7b-9a1e-90999fb352b4)
