### PR TITLE
OUT-1259 | Implement CTA buttons for Task Details Page

### DIFF
--- a/src/app/detail/[task_id]/[user_type]/page.tsx
+++ b/src/app/detail/[task_id]/[user_type]/page.tsx
@@ -96,10 +96,7 @@ export default async function TaskDetailPage({
                 <Stack direction="row" justifyContent="space-between">
                   <HeaderBreadcrumbs token={token} title={task?.label} userType={params.user_type} />
                   <Stack direction="row" alignItems="center" columnGap="8px">
-                    <MenuBoxContainer
-                      isPreviewMode={isPreviewMode}
-                      role={tokenPayload.internalUserId ? UserRole.IU : UserRole.Client}
-                    />
+                    <MenuBoxContainer role={tokenPayload.internalUserId ? UserRole.IU : UserRole.Client} />
                     <Stack direction="row" alignItems="center" columnGap="8px">
                       <ArchiveWrapper taskId={task_id} userType={user_type} />
                       <ToggleButtonContainer />

--- a/src/app/detail/ui/ArchiveWrapper.tsx
+++ b/src/app/detail/ui/ArchiveWrapper.tsx
@@ -71,5 +71,5 @@ export const ArchiveWrapper = ({ taskId, userType }: { taskId: string; userType:
     return <ArchiveBtn isArchived={isArchived} handleClick={handleToggleArchive} />
   }
 
-  return <DetailAppBridge handleToggleArchive={handleToggleArchive} />
+  return <DetailAppBridge isArchived={isArchived} handleToggleArchive={handleToggleArchive} />
 }

--- a/src/app/detail/ui/DetailAppBridge.tsx
+++ b/src/app/detail/ui/DetailAppBridge.tsx
@@ -3,31 +3,45 @@
 import { Clickable, Icons } from '@/hooks/app-bridge/types'
 import { useActionsMenu } from '@/hooks/app-bridge/useActionsMenu'
 import { usePrimaryCta } from '@/hooks/app-bridge/usePrimaryCta'
+import { useSecondaryCta } from '@/hooks/app-bridge/useSecondaryCta'
 import { setShowConfirmDeleteModal } from '@/redux/features/taskDetailsSlice'
 import store from '@/redux/store'
 
 interface DetailAppBridgeProps {
+  isArchived: boolean
   handleToggleArchive: () => void
   portalUrl?: string
 }
 
-export const DetailAppBridge = ({ handleToggleArchive, portalUrl }: DetailAppBridgeProps) => {
+export const DetailAppBridge = ({ isArchived, handleToggleArchive, portalUrl }: DetailAppBridgeProps) => {
   const handleDelete = () => store.dispatch(setShowConfirmDeleteModal())
 
   usePrimaryCta(null, { portalUrl })
+  useSecondaryCta(
+    isArchived
+      ? {
+          label: 'Unarchive',
+          icon: Icons.ARCHIVE,
+          onClick: handleToggleArchive,
+        }
+      : null,
+    { portalUrl },
+  )
 
   const items: Clickable[] = [
-    {
-      label: 'Archive task',
-      icon: Icons.ARCHIVE,
-      onClick: handleToggleArchive,
-    },
     {
       label: 'Delete task',
       icon: Icons.TRASH,
       onClick: handleDelete,
     },
   ]
+  if (!isArchived) {
+    items.unshift({
+      label: 'Archive task',
+      icon: Icons.ARCHIVE,
+      onClick: handleToggleArchive,
+    })
+  }
 
   useActionsMenu(items, { portalUrl })
 

--- a/src/app/detail/ui/MenuBoxContainer.tsx
+++ b/src/app/detail/ui/MenuBoxContainer.tsx
@@ -4,16 +4,19 @@ import { UserRole } from '@/app/api/core/types/user'
 import { ListBtn } from '@/components/buttons/ListBtn'
 import { MenuBox } from '@/components/inputs/MenuBox'
 import { TrashIcon } from '@/icons'
+import { selectTaskBoard } from '@/redux/features/taskBoardSlice'
 import { setShowConfirmDeleteModal } from '@/redux/features/taskDetailsSlice'
 import store from '@/redux/store'
+import { useSelector } from 'react-redux'
 
 interface MenuBoxContainerProps {
   role: UserRole
-  isPreviewMode: boolean
 }
 
-export const MenuBoxContainer = ({ role, isPreviewMode }: MenuBoxContainerProps) => {
-  if ((role === UserRole.IU && !isPreviewMode) || role === UserRole.Client) {
+export const MenuBoxContainer = ({ role }: MenuBoxContainerProps) => {
+  const { previewMode } = useSelector(selectTaskBoard)
+
+  if ((role === UserRole.IU && !previewMode) || role === UserRole.Client) {
     return null
   }
 

--- a/src/app/detail/ui/ToggleButtonContainer.tsx
+++ b/src/app/detail/ui/ToggleButtonContainer.tsx
@@ -1,10 +1,20 @@
 'use client'
 import { ToggleBtn } from '@/components/buttons/ToggleBtn'
+import { selectTaskBoard } from '@/redux/features/taskBoardSlice'
 import { selectTaskDetails, setShowSidebar } from '@/redux/features/taskDetailsSlice'
 import store from '@/redux/store'
+import { Box } from '@mui/material'
 import { useSelector } from 'react-redux'
 
 export const ToggleButtonContainer = () => {
   const { showSidebar } = useSelector(selectTaskDetails)
+  const { previewMode } = useSelector(selectTaskBoard)
+  if (!previewMode) {
+    return (
+      <Box sx={{ width: '72vw', display: 'flex', justifyContent: 'flex-end' }}>
+        <ToggleBtn onClick={() => store.dispatch(setShowSidebar(!showSidebar))} />
+      </Box>
+    )
+  }
   return <ToggleBtn onClick={() => store.dispatch(setShowSidebar(!showSidebar))} />
 }

--- a/src/app/ui/TaskBoardAppBridge.tsx
+++ b/src/app/ui/TaskBoardAppBridge.tsx
@@ -4,6 +4,7 @@ import { Icons } from '@/hooks/app-bridge/types'
 import { useActionsMenu } from '@/hooks/app-bridge/useActionsMenu'
 import { useBreadcrumbs } from '@/hooks/app-bridge/useBreadcrumbs'
 import { usePrimaryCta } from '@/hooks/app-bridge/usePrimaryCta'
+import { useSecondaryCta } from '@/hooks/app-bridge/useSecondaryCta'
 import { setShowModal } from '@/redux/features/createTaskSlice'
 import store from '@/redux/store'
 import { UserRole } from '@api/core/types/user'
@@ -33,6 +34,9 @@ export const TaskBoardAppBridge = ({ token, role, portalUrl }: TaskBoardAppBridg
     },
     { portalUrl },
   )
+
+  // Unset "Unarchive" button from tasks details if redirected to board from an archived task
+  useSecondaryCta(null, { portalUrl })
 
   useActionsMenu(
     [

--- a/src/components/layouts/HeaderBreadcrumbs.tsx
+++ b/src/components/layouts/HeaderBreadcrumbs.tsx
@@ -3,9 +3,11 @@
 import { StyledKeyboardIcon, StyledTypography } from '@/app/detail/ui/styledComponent'
 import { SecondaryBtn } from '@/components/buttons/SecondaryBtn'
 import { CustomLink } from '@/hoc/CustomLink'
+import { useBreadcrumbs } from '@/hooks/app-bridge/useBreadcrumbs'
 import { selectTaskBoard } from '@/redux/features/taskBoardSlice'
 import { UserType } from '@/types/interfaces'
 import { Stack, Typography } from '@mui/material'
+import { useRouter } from 'next/navigation'
 import { useSelector } from 'react-redux'
 
 type ValidTasksBoardLink = '/' | '/client'
@@ -20,6 +22,7 @@ export const HeaderBreadcrumbs = ({
   userType: UserType
 }) => {
   const { previewMode } = useSelector(selectTaskBoard)
+  const router = useRouter()
 
   const getTasksLink = (userType: UserType): ValidTasksBoardLink => {
     if (previewMode) return '/client'
@@ -29,6 +32,20 @@ export const HeaderBreadcrumbs = ({
       [UserType.CLIENT_USER]: '/client',
     }
     return tasksLinks[userType]
+  }
+
+  useBreadcrumbs([
+    {
+      label: 'Tasks',
+      onClick: () => router.push(`/?token=${token}`),
+    },
+    {
+      label: title,
+    },
+  ])
+
+  if (!previewMode) {
+    return null
   }
 
   return (


### PR DESCRIPTION
## Changes

- [x] Add support for Archive / Unarchive secondary button
- [x] Only show "Unarchive" button in real time for tasks when they are archived
- [x] Remove Archive menu option in real time when task is archived. 

## Testing Criteria

- [x] Screencast

[Screencast from 2025-01-13 17-50-11.webm](https://github.com/user-attachments/assets/42c82bef-eb9e-49c0-8f04-433ff9beb17d)
