### PR TITLE
OUT-1272 | No filtered task screen showing on tasks app for a split second on first load.

### DIFF
--- a/src/app/_fetchers/TaskDataFetcher.tsx
+++ b/src/app/_fetchers/TaskDataFetcher.tsx
@@ -7,7 +7,7 @@ import { useSelector } from 'react-redux'
 import useSWR from 'swr'
 
 export const TaskDataFetcher = ({ token }: { token: string }) => {
-  const { showArchived, showUnarchived, tasks } = useSelector(selectTaskBoard)
+  const { showArchived, showUnarchived } = useSelector(selectTaskBoard)
 
   const latestArchivedOptions = useRef({ showArchived, showUnarchived })
 
@@ -35,6 +35,7 @@ export const TaskDataFetcher = ({ token }: { token: string }) => {
     const currentQueryString = buildQueryString(token, currentArchivedOptions)
     if (token) {
       try {
+        store.dispatch(setIsTasksLoading(true))
         await mutate().then((data) => {
           if (currentQueryString === buildQueryString(token, latestArchivedOptions.current)) {
             if (data) {

--- a/src/app/ui/TaskBoard.tsx
+++ b/src/app/ui/TaskBoard.tsx
@@ -92,7 +92,7 @@ export const TaskBoard = ({ mode }: TaskBoardProps) => {
     archivedOptions.showUnarchived &&
     !archivedOptions.showArchived
 
-  const isNoTasksWithFilter = tasks && !userHasNoFilter && !filteredTasks.length
+  const isNoTasksWithFilter = !filteredTasks.length && (!tasks.length || !userHasNoFilter)
 
   const [hasInitialized, setHasInitialized] = useState(false)
   useEffect(() => {
@@ -113,6 +113,8 @@ export const TaskBoard = ({ mode }: TaskBoardProps) => {
       </>
     )
   }
+
+  const showHeader = !!previewMode
   return (
     <>
       <TaskDataFetcher token={token ?? ''} />
@@ -123,9 +125,9 @@ export const TaskBoard = ({ mode }: TaskBoardProps) => {
           await updateViewModeSettings(z.string().parse(token), payload)
         }}
       />
-      {!filteredTasks.length && <NoFilteredTasksState />}
+      {isNoTasksWithFilter && <NoFilteredTasksState />}
 
-      {!isNoTasksWithFilter && viewBoardSettings === View.BOARD_VIEW && (
+      {filteredTasks.length && tasks.length && viewBoardSettings === View.BOARD_VIEW && (
         <Box sx={{ padding: '12px 12px' }}>
           <Stack
             columnGap={2}
@@ -187,7 +189,7 @@ export const TaskBoard = ({ mode }: TaskBoardProps) => {
           </Stack>
         </Box>
       )}
-      {!isNoTasksWithFilter && viewBoardSettings === View.LIST_VIEW && (
+      {filteredTasks.length && tasks.length && viewBoardSettings === View.LIST_VIEW && (
         <Stack
           sx={{
             flexDirection: 'column',

--- a/src/app/ui/TaskBoard.tsx
+++ b/src/app/ui/TaskBoard.tsx
@@ -129,7 +129,7 @@ export const TaskBoard = ({ mode }: TaskBoardProps) => {
       />
       {isNoTasksWithFilter && <NoFilteredTasksState />}
 
-      {filteredTasks.length && tasks.length && viewBoardSettings === View.BOARD_VIEW && (
+      {filteredTasks.length && tasks.length && viewBoardSettings === View.BOARD_VIEW ? (
         <Box sx={{ padding: '12px 12px' }}>
           <Stack
             columnGap={2}
@@ -190,8 +190,8 @@ export const TaskBoard = ({ mode }: TaskBoardProps) => {
             ))}
           </Stack>
         </Box>
-      )}
-      {filteredTasks.length && tasks.length && viewBoardSettings === View.LIST_VIEW && (
+      ) : null}
+      {filteredTasks.length && tasks.length && viewBoardSettings === View.LIST_VIEW ? (
         <Stack
           sx={{
             flexDirection: 'column',
@@ -246,7 +246,7 @@ export const TaskBoard = ({ mode }: TaskBoardProps) => {
             ))}
           </CustomScrollbar>
         </Stack>
-      )}
+      ) : null}
       <CustomDragLayer>
         <CardDragLayer />
       </CustomDragLayer>

--- a/src/app/ui/TaskBoard.tsx
+++ b/src/app/ui/TaskBoard.tsx
@@ -27,6 +27,7 @@ import { UserRole } from '@api/core/types/user'
 import { clientUpdateTask } from '@/app/detail/[task_id]/[user_type]/actions'
 import { TaskDataFetcher } from '@/app/_fetchers/TaskDataFetcher'
 import { NoFilteredTasksState } from '@/components/layouts/EmptyState/NoFilteredTasksState'
+import { useFilter } from '@/hooks/useFilter'
 
 interface TaskBoardProps {
   mode: UserRole
@@ -83,7 +84,7 @@ export const TaskBoard = ({ mode }: TaskBoardProps) => {
   }
 
   const getCardHref = (task: { id: string }) => `/detail/${task.id}/${mode === UserRole.IU ? 'iu' : 'cu'}`
-
+  useFilter(viewSettingsTemp ? viewSettingsTemp.filterOptions : filterOptions)
   const userHasNoFilter =
     filterOptions &&
     !filterOptions.type &&
@@ -92,7 +93,7 @@ export const TaskBoard = ({ mode }: TaskBoardProps) => {
     archivedOptions.showUnarchived &&
     !archivedOptions.showArchived
 
-  const isNoTasksWithFilter = !filteredTasks.length && (!tasks.length || !userHasNoFilter)
+  const isNoTasksWithFilter = (!tasks.length || !userHasNoFilter) && !filteredTasks.length
 
   const [hasInitialized, setHasInitialized] = useState(false)
   useEffect(() => {
@@ -113,7 +114,6 @@ export const TaskBoard = ({ mode }: TaskBoardProps) => {
       </>
     )
   }
-
   const showHeader = !!previewMode
   return (
     <>

--- a/src/app/ui/TaskBoard.tsx
+++ b/src/app/ui/TaskBoard.tsx
@@ -129,7 +129,7 @@ export const TaskBoard = ({ mode }: TaskBoardProps) => {
       />
       {isNoTasksWithFilter && <NoFilteredTasksState />}
 
-      {filteredTasks.length && tasks.length && viewBoardSettings === View.BOARD_VIEW ? (
+      {!!filteredTasks.length && !!tasks.length && viewBoardSettings === View.BOARD_VIEW && (
         <Box sx={{ padding: '12px 12px' }}>
           <Stack
             columnGap={2}
@@ -190,8 +190,8 @@ export const TaskBoard = ({ mode }: TaskBoardProps) => {
             ))}
           </Stack>
         </Box>
-      ) : null}
-      {filteredTasks.length && tasks.length && viewBoardSettings === View.LIST_VIEW ? (
+      )}
+      {!!filteredTasks.length && !!tasks.length && viewBoardSettings === View.LIST_VIEW && (
         <Stack
           sx={{
             flexDirection: 'column',
@@ -246,7 +246,7 @@ export const TaskBoard = ({ mode }: TaskBoardProps) => {
             ))}
           </CustomScrollbar>
         </Stack>
-      ) : null}
+      )}
       <CustomDragLayer>
         <CardDragLayer />
       </CustomDragLayer>

--- a/src/components/layouts/FilterBar.tsx
+++ b/src/components/layouts/FilterBar.tsx
@@ -3,7 +3,7 @@
 import { Box, IconButton, Stack } from '@mui/material'
 import { useEffect, useState } from 'react'
 import store from '@/redux/store'
-import { setFilterOptions, setViewSettingsTemp, setViewSettings } from '@/redux/features/taskBoardSlice'
+import { setFilterOptions, setViewSettingsTemp, setViewSettings, setIsTasksLoading } from '@/redux/features/taskBoardSlice'
 import SearchBar from '@/components/searchBar'
 import Selector, { SelectorType } from '@/components/inputs/Selector'
 import { useHandleSelectorComponent } from '@/hooks/useHandleSelectorComponent'
@@ -305,6 +305,7 @@ export const FilterBar = ({ mode, updateViewModeSetting }: FilterBarProps) => {
               }}
               archivedOptions={archivedOptions}
               handleArchivedOptionsChange={(archivedOptions) => {
+                store.dispatch(setIsTasksLoading(true))
                 store.dispatch(
                   setViewSettings({
                     viewMode: viewMode,
@@ -469,6 +470,7 @@ export const FilterBar = ({ mode, updateViewModeSetting }: FilterBarProps) => {
                 }}
                 archivedOptions={archivedOptions}
                 handleArchivedOptionsChange={(archivedOptions) => {
+                  store.dispatch(setIsTasksLoading(true))
                   store.dispatch(
                     setViewSettings({
                       viewMode: viewMode,

--- a/src/components/layouts/FilterBar.tsx
+++ b/src/components/layouts/FilterBar.tsx
@@ -115,7 +115,6 @@ export const FilterBar = ({ mode, updateViewModeSetting }: FilterBarProps) => {
     type: SelectorType.ASSIGNEE_SELECTOR,
     mode: HandleSelectorComponentModes.CreateTaskFieldUpdate,
   })
-  useFilter(viewSettingsTemp ? viewSettingsTemp.filterOptions : filterOptions)
   const filterButtons = [
     {
       name: 'My tasks',


### PR DESCRIPTION
## Changes

- [x] changed conditions to show no tasks on filter page and board/list page. 
- [x] transferred useFilter hook from `FilterBar` to `TaskBoard`.

## Testing Criteria

- [LOOM](https://www.loom.com/share/1a708936fba24253bfeb481d0729b11c)


