### PR TITLE
OUT-1265 | Task details page should match designs, empty header

### DIFF
--- a/src/app/detail/[task_id]/[user_type]/page.tsx
+++ b/src/app/detail/[task_id]/[user_type]/page.tsx
@@ -92,18 +92,21 @@ export default async function TaskDetailPage({
         <Stack direction="row" sx={{ height: '100vh' }}>
           <ToggleController>
             <StyledBox>
-              <AppMargin size={SizeofAppMargin.HEADER} py="17.5px">
-                <Stack direction="row" justifyContent="space-between">
-                  <HeaderBreadcrumbs token={token} title={task?.label} userType={params.user_type} />
-                  <Stack direction="row" alignItems="center" columnGap="8px">
-                    <MenuBoxContainer role={tokenPayload.internalUserId ? UserRole.IU : UserRole.Client} />
+              {isPreviewMode ? (
+                <AppMargin size={SizeofAppMargin.HEADER} py="17.5px">
+                  <Stack direction="row" justifyContent="space-between">
+                    <HeaderBreadcrumbs token={token} title={task?.label} userType={params.user_type} />
                     <Stack direction="row" alignItems="center" columnGap="8px">
-                      <ArchiveWrapper taskId={task_id} userType={user_type} />
-                      <ToggleButtonContainer />
+                      <MenuBoxContainer role={tokenPayload.internalUserId ? UserRole.IU : UserRole.Client} />
+                      <Stack direction="row" alignItems="center" columnGap="8px">
+                        <ArchiveWrapper taskId={task_id} userType={user_type} />
+                      </Stack>
                     </Stack>
                   </Stack>
-                </Stack>
-              </AppMargin>
+                </AppMargin>
+              ) : (
+                <HeaderBreadcrumbs token={token} title={task?.label} userType={params.user_type} />
+              )}
             </StyledBox>
             <CustomScrollbar style={{ width: '8px' }}>
               <TaskDetailsContainer

--- a/src/app/detail/ui/Sidebar.tsx
+++ b/src/app/detail/ui/Sidebar.tsx
@@ -109,13 +109,6 @@ export const Sidebar = ({
             <Typography variant="sm" lineHeight={'21px'} fontSize={'13px'}>
               Properties
             </Typography>
-            <Box
-              sx={{
-                display: isMobile ? 'block' : 'none',
-              }}
-            >
-              <ToggleButtonContainer />
-            </Box>
           </Stack>
         </AppMargin>
       </StyledBox>
@@ -287,13 +280,6 @@ export const SidebarSkeleton = () => {
             <Typography variant="sm" lineHeight={'21px'} fontSize={'13px'}>
               Properties
             </Typography>
-            <Box
-              sx={{
-                display: isMobile ? 'block' : 'none',
-              }}
-            >
-              <ToggleButtonContainer />
-            </Box>
           </Stack>
         </AppMargin>
       </StyledBox>

--- a/src/app/detail/ui/ToggleButtonContainer.tsx
+++ b/src/app/detail/ui/ToggleButtonContainer.tsx
@@ -6,6 +6,9 @@ import store from '@/redux/store'
 import { Box } from '@mui/material'
 import { useSelector } from 'react-redux'
 
+/**
+ * @deprecated We have dropped support for toggle buttons
+ */
 export const ToggleButtonContainer = () => {
   const { showSidebar } = useSelector(selectTaskDetails)
   const { previewMode } = useSelector(selectTaskBoard)

--- a/src/components/buttons/ToggleBtn.tsx
+++ b/src/components/buttons/ToggleBtn.tsx
@@ -5,6 +5,9 @@ import { selectTaskDetails } from '@/redux/features/taskDetailsSlice'
 import { Stack } from '@mui/material'
 import { useSelector } from 'react-redux'
 
+/**
+ * @deprecated We have dropped support for toggle buttons
+ */
 export const ToggleBtn = ({ onClick }: { onClick: () => void }) => {
   const { showSidebar } = useSelector(selectTaskDetails)
 


### PR DESCRIPTION
## Changes

- [x] Remove header for task details, except for CRM preview
- [x] Deprecate toggle button and remove all instances of ToggleBtn usage (details + mobile sidebar) 

## Testing Criteria

- [x] Screencast

[Screencast from 2025-01-14 15-34-02.webm](https://github.com/user-attachments/assets/fc7924a8-f10c-4f15-956d-36531fb43807)

- [x] Preview mode ss:
![image](https://github.com/user-attachments/assets/98ed9bd9-f1ec-4bc7-9fdd-692e13f03112)
