### PR TITLE
OUT-1273, OUT-1274 | Incorrect icon is shown for 'Manage templates' option, Breadcrumbs 'Manage templates' is clickable

### DIFF
--- a/src/app/manage-templates/ui/ManageTemplatesAppBridge.tsx
+++ b/src/app/manage-templates/ui/ManageTemplatesAppBridge.tsx
@@ -22,7 +22,7 @@ export const ManageTemplatesAppBridge = ({ token, role, portalUrl }: TaskBoardAp
     store.dispatch(setShowTemplateModal({ targetMethod: TargetMethod.POST }))
   }
 
-  const handleBreadcrumbsClick = () => {
+  const handleNavigation = () => {
     router.push(`/?token=${token}`)
   }
 
@@ -38,11 +38,15 @@ export const ManageTemplatesAppBridge = ({ token, role, portalUrl }: TaskBoardAp
   useBreadcrumbs(
     [
       {
+        label: 'Tasks',
+        onClick: handleNavigation,
+      },
+      {
         label: 'Manage templates',
-        onClick: handleBreadcrumbsClick,
       },
     ],
     { portalUrl },
   )
+
   return <></>
 }

--- a/src/app/ui/TaskBoardAppBridge.tsx
+++ b/src/app/ui/TaskBoardAppBridge.tsx
@@ -51,7 +51,7 @@ export const TaskBoardAppBridge = ({ token, role, portalUrl }: TaskBoardAppBridg
     [
       {
         label: 'Manage templates',
-        icon: Icons.ARCHIVE,
+        icon: Icons.TEMPLATES,
         onClick: handleManageTemplatesClick,
       },
     ],


### PR DESCRIPTION
## Changes

- [x] used proper icon for manage template option in the board page. 
- [x] removed onClick navigation function from manage templates breadcrumb in manage templates page. Inserted a Tasks breadcrumb for the navigation in manage templates page.Right now we are displaying 2 tasks breadcrumbs. It looks something like : 
![image](https://github.com/user-attachments/assets/7d69ee91-a118-4fd8-ad19-0e6077013243)
 
## Testing Criteria

![image](https://github.com/user-attachments/assets/77769d27-8c5b-44d7-9103-b269559612a4)

