### PR TITLE
OUT-1276 | OUT-1278 | Wrong header elements showing on task details page + Fix secondary CTA icon

### DIFF
--- a/src/app/detail/[task_id]/[user_type]/page.tsx
+++ b/src/app/detail/[task_id]/[user_type]/page.tsx
@@ -105,7 +105,10 @@ export default async function TaskDetailPage({
                   </Stack>
                 </AppMargin>
               ) : (
-                <HeaderBreadcrumbs token={token} title={task?.label} userType={params.user_type} />
+                <>
+                  <HeaderBreadcrumbs token={token} title={task?.label} userType={params.user_type} />
+                  <ArchiveWrapper taskId={task_id} userType={user_type} />
+                </>
               )}
             </StyledBox>
             <CustomScrollbar style={{ width: '8px' }}>

--- a/src/hooks/app-bridge/useSecondaryCta.tsx
+++ b/src/hooks/app-bridge/useSecondaryCta.tsx
@@ -9,6 +9,7 @@ export const useSecondaryCta = (secondaryCta: Clickable | null, config?: Configu
       : {
           type: 'header.secondaryCta',
           label: secondaryCta.label,
+          icon: secondaryCta.icon,
           onClick: 'header.secondaryCta.onClick',
         }
 


### PR DESCRIPTION
## Changes

- [x] Add missing ArchiveWrapper to implement app bridge for task details page
- [x] Provide `icon` to secondary CTA button postMessage

## Testing Criteria

- [x] Screenshots

![image](https://github.com/user-attachments/assets/fc33a690-fd7e-46dc-aca6-1108abb4119e)
