### PR TITLE
OUT-1275 | Breadcrumbs are not shown for task details page on client side

### DIFF
--- a/src/app/client/page.tsx
+++ b/src/app/client/page.tsx
@@ -50,7 +50,8 @@ async function getTokenPayload(token: string): Promise<Token> {
   const payload = TokenSchema.parse(await copilotClient.getTokenPayload())
   return payload as Token
 }
-export async function getWorkspace(token: string): Promise<WorkspaceResponse> {
+
+async function getWorkspace(token: string): Promise<WorkspaceResponse> {
   const copilot = new CopilotAPI(token)
   return await copilot.getWorkspace()
 }

--- a/src/app/client/page.tsx
+++ b/src/app/client/page.tsx
@@ -7,12 +7,13 @@ import { createMultipleAttachments } from '@/app/actions'
 import { getViewSettings } from '@/app/page'
 import { ModalNewTaskForm } from '@/app/ui/Modal_NewTaskForm'
 import { TaskBoard } from '@/app/ui/TaskBoard'
+import { TaskBoardAppBridge } from '@/app/ui/TaskBoardAppBridge'
 import { SilentError } from '@/components/templates/SilentError'
 import { apiUrl } from '@/config'
 import { ClientSideStateUpdate } from '@/hoc/ClientSideStateUpdate'
 import { DndWrapper } from '@/hoc/DndWrapper'
 import { RealTime } from '@/hoc/RealTime'
-import { Token, TokenSchema } from '@/types/common'
+import { Token, TokenSchema, WorkspaceResponse } from '@/types/common'
 import { CreateAttachmentRequest } from '@/types/dto/attachments.dto'
 import { TaskResponse } from '@/types/dto/tasks.dto'
 import { WorkflowStateResponse } from '@/types/dto/workflowStates.dto'
@@ -49,6 +50,10 @@ async function getTokenPayload(token: string): Promise<Token> {
   const payload = TokenSchema.parse(await copilotClient.getTokenPayload())
   return payload as Token
 }
+export async function getWorkspace(token: string): Promise<WorkspaceResponse> {
+  const copilot = new CopilotAPI(token)
+  return await copilot.getWorkspace()
+}
 
 export default async function ClientPage({ searchParams }: { searchParams: { token: string } }) {
   const token = searchParams.token
@@ -56,11 +61,12 @@ export default async function ClientPage({ searchParams }: { searchParams: { tok
     return <SilentError message="Please provide a Valid Token" />
   }
   redirectIfTaskCta(searchParams, UserType.CLIENT_USER)
-  const [workflowStates, tasks, viewSettings, tokenPayload] = await Promise.all([
+  const [workflowStates, tasks, viewSettings, tokenPayload, workspace] = await Promise.all([
     await getAllWorkflowStates(token),
     await getAllTasks(token),
     getViewSettings(token),
     getTokenPayload(token),
+    getWorkspace(token),
   ])
 
   const previewMode = getPreviewMode(tokenPayload)
@@ -87,6 +93,7 @@ export default async function ClientPage({ searchParams }: { searchParams: { tok
         <Suspense fallback={null}>
           <TemplatesFetcher token={token} />
         </Suspense>
+        <TaskBoardAppBridge token={token} role={UserRole.Client} portalUrl={workspace.portalUrl} />
         <RealTime tokenPayload={tokenPayload}>
           <DndWrapper>
             <TaskBoard mode={UserRole.Client} />

--- a/src/app/detail/[task_id]/[user_type]/page.tsx
+++ b/src/app/detail/[task_id]/[user_type]/page.tsx
@@ -51,7 +51,7 @@ async function getOneTask(token: string, taskId: string): Promise<TaskResponse> 
   return data.task
 }
 
-export async function getWorkspace(token: string): Promise<WorkspaceResponse> {
+async function getWorkspace(token: string): Promise<WorkspaceResponse> {
   const copilot = new CopilotAPI(token)
   return await copilot.getWorkspace()
 }

--- a/src/app/ui/TaskBoardAppBridge.tsx
+++ b/src/app/ui/TaskBoardAppBridge.tsx
@@ -36,11 +36,13 @@ export const TaskBoardAppBridge = ({ token, role, portalUrl }: TaskBoardAppBridg
   }
 
   usePrimaryCta(
-    {
-      label: 'Create task',
-      icon: Icons.PLUS,
-      onClick: handleTaskCreate,
-    },
+    role == UserRole.Client
+      ? null
+      : {
+          label: 'Create task',
+          icon: Icons.PLUS,
+          onClick: handleTaskCreate,
+        },
     { portalUrl },
   )
 
@@ -48,13 +50,15 @@ export const TaskBoardAppBridge = ({ token, role, portalUrl }: TaskBoardAppBridg
   useSecondaryCta(null, { portalUrl })
 
   useActionsMenu(
-    [
-      {
-        label: 'Manage templates',
-        icon: Icons.TEMPLATES,
-        onClick: handleManageTemplatesClick,
-      },
-    ],
+    role == UserRole.Client
+      ? []
+      : [
+          {
+            label: 'Manage templates',
+            icon: Icons.TEMPLATES,
+            onClick: handleManageTemplatesClick,
+          },
+        ],
     { portalUrl },
   )
   useBreadcrumbs([], { portalUrl })

--- a/src/components/layouts/HeaderBreadcrumbs.tsx
+++ b/src/components/layouts/HeaderBreadcrumbs.tsx
@@ -16,10 +16,12 @@ export const HeaderBreadcrumbs = ({
   token,
   title,
   userType,
+  portalUrl,
 }: {
   token: string | undefined
   title: string
   userType: UserType
+  portalUrl?: string
 }) => {
   const { previewMode } = useSelector(selectTaskBoard)
   const router = useRouter()
@@ -33,16 +35,18 @@ export const HeaderBreadcrumbs = ({
     }
     return tasksLinks[userType]
   }
-
-  useBreadcrumbs([
-    {
-      label: 'Tasks',
-      onClick: () => router.push(`/?token=${token}`),
-    },
-    {
-      label: title,
-    },
-  ])
+  useBreadcrumbs(
+    [
+      {
+        label: 'Tasks',
+        onClick: () => router.push(getTasksLink(userType) + `?token=${token}`),
+      },
+      {
+        label: title,
+      },
+    ],
+    { portalUrl },
+  )
 
   if (!previewMode) {
     return null


### PR DESCRIPTION
## Changes

- [x] added `TaskBoardAppBridge` for client route and handled cta calls conditionally for ius and cus.
- [x] Modified `HeaderBreadcrumbs` to accept portalUrl and use it for cta calls. 

## Testing Criteria

- [LOOM](https://www.loom.com/share/83314d3ad2ba456d97a1803fe03a8c3a)
