### PR TITLE
OUT-1282 | Delete action menu item text is not red

### DIFF
--- a/src/app/detail/ui/DetailAppBridge.tsx
+++ b/src/app/detail/ui/DetailAppBridge.tsx
@@ -33,6 +33,7 @@ export const DetailAppBridge = ({ isArchived, handleToggleArchive, portalUrl }: 
       label: 'Delete task',
       icon: Icons.TRASH,
       onClick: handleDelete,
+      color: 'red',
     },
   ]
   if (!isArchived) {

--- a/src/app/manage-templates/ui/TemplateForm.tsx
+++ b/src/app/manage-templates/ui/TemplateForm.tsx
@@ -50,13 +50,17 @@ export const TemplateForm = ({ handleCreate }: { handleCreate: () => void }) => 
           justifyContent="space-between"
           sx={{
             border: (theme) => `1px solid ${theme.color.borders.borderDisabled}`,
-            padding: '12px 28px',
+            padding: '14px 20px',
           }}
         >
           {targetMethod === TargetMethod.POST ? (
-            <Typography variant="lg">Create template</Typography>
+            <Typography variant="md" fontSize={'15px'} lineHeight={'18.15px'}>
+              Create template
+            </Typography>
           ) : (
-            <Typography variant="lg">Edit template</Typography>
+            <Typography variant="md" fontSize={'15px'} lineHeight={'18.15px'}>
+              Edit template
+            </Typography>
           )}
           <Close
             sx={{ color: (theme) => theme.color.gray[500], cursor: 'pointer', width: 20, height: 20 }}
@@ -67,7 +71,7 @@ export const TemplateForm = ({ handleCreate }: { handleCreate: () => void }) => 
           />
         </Stack>
 
-        <AppMargin size={SizeofAppMargin.MEDIUM} py="12px">
+        <AppMargin size={SizeofAppMargin.MEDIUM} py="16px">
           <NewTaskFormInputs />
         </AppMargin>
         <NewTaskFooter handleCreate={handleCreate} targetMethod={targetMethod} />

--- a/src/app/manage-templates/ui/TemplateForm.tsx
+++ b/src/app/manage-templates/ui/TemplateForm.tsx
@@ -50,17 +50,13 @@ export const TemplateForm = ({ handleCreate }: { handleCreate: () => void }) => 
           justifyContent="space-between"
           sx={{
             border: (theme) => `1px solid ${theme.color.borders.borderDisabled}`,
-            padding: '14px 20px',
+            padding: '12px 28px',
           }}
         >
           {targetMethod === TargetMethod.POST ? (
-            <Typography variant="md" fontSize={'15px'} lineHeight={'18.15px'}>
-              Create template
-            </Typography>
+            <Typography variant="lg">Create template</Typography>
           ) : (
-            <Typography variant="md" fontSize={'15px'} lineHeight={'18.15px'}>
-              Edit template
-            </Typography>
+            <Typography variant="lg">Edit template</Typography>
           )}
           <Close
             sx={{ color: (theme) => theme.color.gray[500], cursor: 'pointer', width: 20, height: 20 }}
@@ -71,7 +67,7 @@ export const TemplateForm = ({ handleCreate }: { handleCreate: () => void }) => 
           />
         </Stack>
 
-        <AppMargin size={SizeofAppMargin.MEDIUM} py="16px">
+        <AppMargin size={SizeofAppMargin.MEDIUM} py="12px">
           <NewTaskFormInputs />
         </AppMargin>
         <NewTaskFooter handleCreate={handleCreate} targetMethod={targetMethod} />

--- a/src/hooks/app-bridge/types.ts
+++ b/src/hooks/app-bridge/types.ts
@@ -33,6 +33,7 @@ export interface ActionsMenuPayload {
     label: string
     onClick: string
     icon?: Icons
+    color?: string
   }[]
   type: 'header.actionsMenu'
 }
@@ -41,6 +42,7 @@ export interface Clickable {
   label: string
   onClick?: () => void
   icon?: Icons
+  color?: string
 }
 
 export interface Configurable {

--- a/src/hooks/app-bridge/useActionsMenu.tsx
+++ b/src/hooks/app-bridge/useActionsMenu.tsx
@@ -15,10 +15,11 @@ export function useActionsMenu(actions: Clickable[], config?: Configurable) {
   useEffect(() => {
     const payload: ActionsMenuPayload = {
       type: 'header.actionsMenu',
-      items: actions.map(({ label, onClick, icon }, idx) => ({
+      items: actions.map(({ label, onClick, icon, color }, idx) => ({
         onClick: onClick ? getActionMenuItemId(idx) : '',
         label,
         icon,
+        color,
       })),
     }
 


### PR DESCRIPTION
## Changes

- [x] Added `color` type in `Clickable` and `ActionsMenuPayload` interfaces.
- [x] Added red color for delete option of tasks in the App Bridge Actions Menu. 

## Testing Criteria

![image](https://github.com/user-attachments/assets/5ad23370-19a0-4dba-9974-6ac2e98ff5e6)

