### PR TITLE
OUT-1293 | Tasks details page breadcrumbs not working in client's end on the first load

### DIFF
--- a/src/hooks/app-bridge/useBreadcrumbs.tsx
+++ b/src/hooks/app-bridge/useBreadcrumbs.tsx
@@ -21,10 +21,7 @@ export const useBreadcrumbs = (breadcrumbs: Clickable[], config?: Configurable) 
       })),
     }
 
-    window.parent.postMessage(payload, 'https://dashboard.copilot.com')
-    if (config?.portalUrl) {
-      window.parent.postMessage(payload, ensureHttps(config.portalUrl))
-    }
+    window.parent.postMessage(payload, config?.portalUrl ?? 'https://dashboard.copilot.com')
 
     const handleMessage = (event: MessageEvent) => {
       if (


### PR DESCRIPTION
## Changes

- [x] 2 postMessage covered in a single line instead of two lines

