### PR TITLE
OUT-1299 | Remove '+ Create task' button from header for empty state

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -112,11 +112,9 @@ export default async function Main({ searchParams }: { searchParams: { token: st
         <TemplatesFetcher token={token} />
       </Suspense>
 
-      <TaskBoardAppBridge token={token} role={UserRole.IU} portalUrl={workspace.portalUrl} />
-
       <RealTime tokenPayload={tokenPayload}>
         <DndWrapper>
-          <TaskBoard mode={UserRole.IU} />
+          <TaskBoard mode={UserRole.IU} workspace={workspace} />
         </DndWrapper>
         <ModalNewTaskForm
           handleCreateMultipleAttachments={async (attachments: CreateAttachmentRequest[]) => {

--- a/src/app/ui/TaskBoard.tsx
+++ b/src/app/ui/TaskBoard.tsx
@@ -33,7 +33,7 @@ import { TaskBoardAppBridge } from '@/app/ui/TaskBoardAppBridge'
 
 interface TaskBoardProps {
   mode: UserRole
-  workspace: WorkspaceResponse
+  workspace?: WorkspaceResponse
 }
 export const TaskBoard = ({ mode, workspace }: TaskBoardProps) => {
   const {
@@ -117,7 +117,7 @@ export const TaskBoard = ({ mode, workspace }: TaskBoardProps) => {
           <TaskBoardAppBridge
             token={token ?? ''}
             role={UserRole.IU}
-            portalUrl={workspace.portalUrl}
+            portalUrl={workspace?.portalUrl}
             isTaskBoardEmpty={true}
           />
         )}
@@ -132,7 +132,7 @@ export const TaskBoard = ({ mode, workspace }: TaskBoardProps) => {
   return (
     <>
       <TaskDataFetcher token={token ?? ''} />
-      {mode == UserRole.IU && <TaskBoardAppBridge token={token ?? ''} role={UserRole.IU} portalUrl={workspace.portalUrl} />}
+      {mode == UserRole.IU && <TaskBoardAppBridge token={token ?? ''} role={UserRole.IU} portalUrl={workspace?.portalUrl} />}
       {showHeader && <Header showCreateTaskButton={mode === UserRole.IU || !!previewMode} showMenuBox={!previewMode} />}
       <FilterBar
         mode={mode}

--- a/src/app/ui/TaskBoard.tsx
+++ b/src/app/ui/TaskBoard.tsx
@@ -28,11 +28,14 @@ import { clientUpdateTask } from '@/app/detail/[task_id]/[user_type]/actions'
 import { TaskDataFetcher } from '@/app/_fetchers/TaskDataFetcher'
 import { NoFilteredTasksState } from '@/components/layouts/EmptyState/NoFilteredTasksState'
 import { useFilter } from '@/hooks/useFilter'
+import { WorkspaceResponse } from '@/types/common'
+import { TaskBoardAppBridge } from '@/app/ui/TaskBoardAppBridge'
 
 interface TaskBoardProps {
   mode: UserRole
+  workspace: WorkspaceResponse
 }
-export const TaskBoard = ({ mode }: TaskBoardProps) => {
+export const TaskBoard = ({ mode, workspace }: TaskBoardProps) => {
   const {
     workflowStates,
     tasks,
@@ -110,6 +113,15 @@ export const TaskBoard = ({ mode }: TaskBoardProps) => {
     return (
       <>
         <TaskDataFetcher token={token ?? ''} />
+        {mode == UserRole.IU && (
+          <TaskBoardAppBridge
+            token={token ?? ''}
+            role={UserRole.IU}
+            portalUrl={workspace.portalUrl}
+            isTaskBoardEmpty={true}
+          />
+        )}
+
         <DashboardEmptyState userType={mode} />
       </>
     )
@@ -120,6 +132,7 @@ export const TaskBoard = ({ mode }: TaskBoardProps) => {
   return (
     <>
       <TaskDataFetcher token={token ?? ''} />
+      {mode == UserRole.IU && <TaskBoardAppBridge token={token ?? ''} role={UserRole.IU} portalUrl={workspace.portalUrl} />}
       {showHeader && <Header showCreateTaskButton={mode === UserRole.IU || !!previewMode} showMenuBox={!previewMode} />}
       <FilterBar
         mode={mode}

--- a/src/app/ui/TaskBoardAppBridge.tsx
+++ b/src/app/ui/TaskBoardAppBridge.tsx
@@ -15,9 +15,10 @@ interface TaskBoardAppBridgeProps {
   token: string
   role: UserRole
   portalUrl?: string
+  isTaskBoardEmpty?: boolean
 }
 
-export const TaskBoardAppBridge = ({ token, role, portalUrl }: TaskBoardAppBridgeProps) => {
+export const TaskBoardAppBridge = ({ token, role, portalUrl, isTaskBoardEmpty = false }: TaskBoardAppBridgeProps) => {
   const router = useRouter()
 
   const [awake, setAwake] = useState(false)
@@ -36,7 +37,7 @@ export const TaskBoardAppBridge = ({ token, role, portalUrl }: TaskBoardAppBridg
   }
 
   usePrimaryCta(
-    role == UserRole.Client
+    role == UserRole.Client || isTaskBoardEmpty
       ? null
       : {
           label: 'Create task',


### PR DESCRIPTION
## Changes

- [x] added workspace in redux/authSlice.
- [x] fetched portal url from workspace from selectAuthSlice.
- [x] Create task in header removed on empty task board.

## Testing Criteria

![image](https://github.com/user-attachments/assets/b0844ccf-9922-414c-bc64-35e1fc8ae749)
![image](https://github.com/user-attachments/assets/77e89436-d547-4fa5-b14f-e8d650e30e6a)
