### PR TITLE
OUT-1307 | Show the previously selected assignee at the top of the Assignee Selector

### DIFF
--- a/src/app/detail/ui/Sidebar.tsx
+++ b/src/app/detail/ui/Sidebar.tsx
@@ -186,6 +186,7 @@ export const Sidebar = ({
             cursor="default"
             filterOption={(x: unknown) => x}
             responsiveNoHide
+            currentOption={assigneeValue}
           />
         </Box>
         <Box sx={{}}>
@@ -333,6 +334,7 @@ export const Sidebar = ({
               cursor={'default'}
               disableOutline
               responsiveNoHide
+              currentOption={assigneeValue}
             />
           </Box>
         </Stack>

--- a/src/components/inputs/Selector.tsx
+++ b/src/components/inputs/Selector.tsx
@@ -38,6 +38,7 @@ interface Prop<T extends keyof SelectorOptionsType> {
   selectorType: T
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
   options: SelectorOptionsType[T][] | IExtraOption[]
 =======
   options: SelectorOptionsType[T][]
@@ -45,6 +46,9 @@ interface Prop<T extends keyof SelectorOptionsType> {
 =======
   options: SelectorOptionsType[T][] | IExtraOption[]
 >>>>>>> 766eafb4 (fix(OUT-1307) : options prop in selector component now accepts IExtraOption[] type too.)
+=======
+  options: SelectorOptionsType[T][]
+>>>>>>> 51b304fb (feat(OUT-1307) :)
   buttonContent: ReactNode
   inputStatusValue: string
   setInputStatusValue: React.Dispatch<React.SetStateAction<string>>
@@ -74,7 +78,10 @@ interface Prop<T extends keyof SelectorOptionsType> {
   cursor?: Property.Cursor
 =======
   cursor?: Property.Cursor | undefined
+<<<<<<< HEAD
 >>>>>>> 05b1d87c (feat(OUT-1307) :)
+=======
+>>>>>>> 51b304fb (feat(OUT-1307) :)
   currentOption?: SelectorOptionsType[T]
 }
 

--- a/src/components/inputs/Selector.tsx
+++ b/src/components/inputs/Selector.tsx
@@ -36,7 +36,11 @@ interface Prop<T extends keyof SelectorOptionsType> {
   startIcon: ReactNode
   value: unknown
   selectorType: T
+<<<<<<< HEAD
   options: SelectorOptionsType[T][] | IExtraOption[]
+=======
+  options: SelectorOptionsType[T][]
+>>>>>>> 05b1d87c (feat(OUT-1307) :)
   buttonContent: ReactNode
   inputStatusValue: string
   setInputStatusValue: React.Dispatch<React.SetStateAction<string>>
@@ -62,7 +66,11 @@ interface Prop<T extends keyof SelectorOptionsType> {
   endOptionHref?: string
   listAutoHeightMax?: string
   useClickHandler?: boolean
+<<<<<<< HEAD
   cursor?: Property.Cursor
+=======
+  cursor?: Property.Cursor | undefined
+>>>>>>> 05b1d87c (feat(OUT-1307) :)
   currentOption?: SelectorOptionsType[T]
 }
 

--- a/src/components/inputs/Selector.tsx
+++ b/src/components/inputs/Selector.tsx
@@ -36,19 +36,7 @@ interface Prop<T extends keyof SelectorOptionsType> {
   startIcon: ReactNode
   value: unknown
   selectorType: T
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
   options: SelectorOptionsType[T][] | IExtraOption[]
-=======
-  options: SelectorOptionsType[T][]
->>>>>>> 05b1d87c (feat(OUT-1307) :)
-=======
-  options: SelectorOptionsType[T][] | IExtraOption[]
->>>>>>> 766eafb4 (fix(OUT-1307) : options prop in selector component now accepts IExtraOption[] type too.)
-=======
-  options: SelectorOptionsType[T][]
->>>>>>> 51b304fb (feat(OUT-1307) :)
   buttonContent: ReactNode
   inputStatusValue: string
   setInputStatusValue: React.Dispatch<React.SetStateAction<string>>
@@ -74,14 +62,7 @@ interface Prop<T extends keyof SelectorOptionsType> {
   endOptionHref?: string
   listAutoHeightMax?: string
   useClickHandler?: boolean
-<<<<<<< HEAD
   cursor?: Property.Cursor
-=======
-  cursor?: Property.Cursor | undefined
-<<<<<<< HEAD
->>>>>>> 05b1d87c (feat(OUT-1307) :)
-=======
->>>>>>> 51b304fb (feat(OUT-1307) :)
   currentOption?: SelectorOptionsType[T]
 }
 

--- a/src/components/inputs/Selector.tsx
+++ b/src/components/inputs/Selector.tsx
@@ -37,10 +37,14 @@ interface Prop<T extends keyof SelectorOptionsType> {
   value: unknown
   selectorType: T
 <<<<<<< HEAD
+<<<<<<< HEAD
   options: SelectorOptionsType[T][] | IExtraOption[]
 =======
   options: SelectorOptionsType[T][]
 >>>>>>> 05b1d87c (feat(OUT-1307) :)
+=======
+  options: SelectorOptionsType[T][] | IExtraOption[]
+>>>>>>> 766eafb4 (fix(OUT-1307) : options prop in selector component now accepts IExtraOption[] type too.)
   buttonContent: ReactNode
   inputStatusValue: string
   setInputStatusValue: React.Dispatch<React.SetStateAction<string>>

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -171,4 +171,5 @@ export const UserTypesName = {
   internalUsers: 'Internal users',
   clients: 'Clients',
   companies: 'Companies',
+  standalone: 'Standalone', // for options in selector component which shall not be grouped
 }


### PR DESCRIPTION
## Changes

- [x] added currentOption prop for selector component. If currentOption prop is provided, it renders a standalone option without any group in the autocomplete options.
- [x] used generic type for options in selector component. Some refactoring work are still left. 

## Testing Criteria

![image](https://github.com/user-attachments/assets/b91f9432-49a1-44a6-97db-251f98eda2a2)


