### PR TITLE
OUT-1307 | Show the previously selected assignee at the top of the Assignee Selector

### DIFF
--- a/src/app/detail/ui/Sidebar.tsx
+++ b/src/app/detail/ui/Sidebar.tsx
@@ -186,6 +186,7 @@ export const Sidebar = ({
             cursor="default"
             filterOption={(x: unknown) => x}
             responsiveNoHide
+            currentOption={assigneeValue}
           />
         </Box>
         <Box sx={{}}>
@@ -333,6 +334,7 @@ export const Sidebar = ({
               cursor={'default'}
               disableOutline
               responsiveNoHide
+              currentOption={assigneeValue}
             />
           </Box>
         </Stack>

--- a/src/components/inputs/Selector.tsx
+++ b/src/components/inputs/Selector.tsx
@@ -22,7 +22,7 @@ export enum SelectorType {
   TEMPLATE_SELECTOR = 'templateSelected',
 }
 type SelectorOptionsType = {
-  [K in keyof typeof SelectorType as `${(typeof SelectorType)[K]}`]: K extends 'ASSIGNEE_SELECTOR'
+  [K in keyof typeof SelectorType as (typeof SelectorType)[K]]: K extends 'ASSIGNEE_SELECTOR'
     ? IAssigneeCombined
     : K extends 'STATUS_SELECTOR'
       ? WorkflowStateResponse
@@ -63,7 +63,7 @@ interface Prop<T extends keyof SelectorOptionsType> {
   listAutoHeightMax?: string
   useClickHandler?: boolean
   cursor?: Property.Cursor
-  currentOption?: SelectorOptionsType[T]
+  currentOption?: SelectorOptionsType[T] //option which shall be at the top of the selector without any grouping
 }
 
 export default function Selector<T extends keyof SelectorOptionsType>({
@@ -113,11 +113,11 @@ export default function Selector<T extends keyof SelectorOptionsType>({
     if (!currentOption) return options
     const filteredOptions = options.filter((option) => option.id !== currentOption.id)
     return [currentOption, ...filteredOptions]
-  }, [currentOption, options])
+  }, [currentOption, options]) // bring currentOption to the top of the selector options.
 
   const standaloneOptionIds = useMemo(() => {
     return currentOption ? new Set([currentOption.id]) : new Set()
-  }, [currentOption])
+  }, [currentOption]) //differentiate currentOption from the rest of the option to remove any kind of grouping.
 
   function detectSelectorType(option: unknown) {
     if (selectorType === SelectorType.ASSIGNEE_SELECTOR) {

--- a/src/components/inputs/Selector.tsx
+++ b/src/components/inputs/Selector.tsx
@@ -36,7 +36,7 @@ interface Prop<T extends keyof SelectorOptionsType> {
   startIcon: ReactNode
   value: unknown
   selectorType: T
-  options: SelectorOptionsType[T][]
+  options: SelectorOptionsType[T][] | IExtraOption[]
   buttonContent: ReactNode
   inputStatusValue: string
   setInputStatusValue: React.Dispatch<React.SetStateAction<string>>

--- a/src/components/inputs/Selector.tsx
+++ b/src/components/inputs/Selector.tsx
@@ -2,7 +2,7 @@ import { Box, Button, Popper, Stack, Typography } from '@mui/material'
 import { StyledAutocomplete } from '@/components/inputs/Autocomplete'
 import { statusIcons } from '@/utils/iconMatcher'
 import { useFocusableInput } from '@/hooks/useFocusableInput'
-import { HTMLAttributes, ReactNode, useEffect, useState } from 'react'
+import { HTMLAttributes, ReactNode, useEffect, useMemo, useState } from 'react'
 import { StyledTextField } from './TextField'
 import { WorkflowStateResponse } from '@/types/dto/workflowStates.dto'
 import { IAssigneeCombined, Sizes, IExtraOption, ITemplate, UserTypesName } from '@/types/interfaces'
@@ -21,13 +21,22 @@ export enum SelectorType {
   STATUS_SELECTOR = 'statusSelector',
   TEMPLATE_SELECTOR = 'templateSelected',
 }
+type SelectorOptionsType = {
+  [K in keyof typeof SelectorType as `${(typeof SelectorType)[K]}`]: K extends 'ASSIGNEE_SELECTOR'
+    ? IAssigneeCombined
+    : K extends 'STATUS_SELECTOR'
+      ? WorkflowStateResponse
+      : K extends 'TEMPLATE_SELECTOR'
+        ? ITemplate
+        : never
+}
 
-interface Prop {
+interface Prop<T extends keyof SelectorOptionsType> {
   getSelectedValue: (value: unknown) => void
   startIcon: ReactNode
   value: unknown
-  selectorType: SelectorType
-  options: unknown[]
+  selectorType: T
+  options: SelectorOptionsType[T][]
   buttonContent: ReactNode
   inputStatusValue: string
   setInputStatusValue: React.Dispatch<React.SetStateAction<string>>
@@ -54,9 +63,10 @@ interface Prop {
   listAutoHeightMax?: string
   useClickHandler?: boolean
   cursor?: Property.Cursor
+  currentOption?: SelectorOptionsType[T]
 }
 
-export default function Selector({
+export default function Selector<T extends keyof SelectorOptionsType>({
   getSelectedValue,
   startIcon,
   value,
@@ -84,7 +94,8 @@ export default function Selector({
   listAutoHeightMax,
   useClickHandler,
   cursor,
-}: Prop) {
+  currentOption,
+}: Prop<T>) {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
 
   const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
@@ -97,6 +108,16 @@ export default function Selector({
   const id = open ? 'autocomplete-popper' : ''
 
   const setSelectorRef = useFocusableInput(open)
+
+  const processedOptions = useMemo(() => {
+    if (!currentOption) return options
+    const filteredOptions = options.filter((option) => option.id !== currentOption.id)
+    return [currentOption, ...filteredOptions]
+  }, [currentOption, options])
+
+  const standaloneOptionIds = useMemo(() => {
+    return currentOption ? new Set([currentOption.id]) : new Set()
+  }, [currentOption])
 
   function detectSelectorType(option: unknown) {
     if (selectorType === SelectorType.ASSIGNEE_SELECTOR) {
@@ -218,7 +239,7 @@ export default function Selector({
           openOnFocus
           onKeyDown={handleKeyDown}
           ListboxProps={{ sx: { maxHeight: { xs: '175px', sm: '291px' }, padding: '0px 0px 8px 0px' } }}
-          options={extraOption ? [extraOption, ...options] : options}
+          options={extraOption ? [extraOption, ...processedOptions] : processedOptions}
           value={value}
           onChange={(_, newValue: unknown) => {
             if (newValue && !useClickHandler) {
@@ -229,9 +250,12 @@ export default function Selector({
           }}
           ListboxComponent={ListWithEndOption}
           getOptionLabel={(option: unknown) => detectSelectorType(option)}
-          groupBy={(option: unknown) =>
-            selectorType === SelectorType.ASSIGNEE_SELECTOR ? UserTypesName[(option as IAssigneeCombined).type] : ''
-          }
+          groupBy={(option: unknown) => {
+            if (standaloneOptionIds.has((option as SelectorOptionsType[typeof selectorType]).id)) {
+              return UserTypesName['standalone']
+            }
+            return selectorType === SelectorType.ASSIGNEE_SELECTOR ? UserTypesName[(option as IAssigneeCombined).type] : ''
+          }}
           slotProps={{
             paper: {
               sx: {
@@ -258,30 +282,37 @@ export default function Selector({
           }}
           filterOptions={filterOption}
           renderGroup={(params) => {
+            if (!params.children) return <></>
+
             const hasNoAssignee =
               Array.isArray(params?.children) &&
               params?.children?.some((child) => child?.props?.props?.key === 'No assignee')
-            if (!params.children) return <></>
-
-            return hasNoAssignee ? (
-              <Box key={params.key}> {params.children}</Box>
-            ) : (
-              <Box key={params.key} component="li">
-                <Stack direction="row" alignItems="center" columnGap={2}>
-                  <Typography
-                    variant={'sm'}
-                    sx={{
-                      color: (theme) => theme.color.gray[500],
-                      marginLeft: '18px',
-                      padding: '2px 0px',
-                      lineHeight: '24px',
-                    }}
-                  >
-                    {params.group}
-                  </Typography>
-                </Stack>
-                {params.children}
-              </Box>
+            if (params.group === UserTypesName['standalone']) {
+              return params.children
+            }
+            return (
+              <>
+                {hasNoAssignee ? (
+                  <Box key={params.key}>{params.children}</Box>
+                ) : (
+                  <Box key={params.key} component="li">
+                    <Stack direction="row" alignItems="center" columnGap={2}>
+                      <Typography
+                        variant={'sm'}
+                        sx={{
+                          color: (theme) => theme.color.gray[500],
+                          marginLeft: '18px',
+                          padding: '2px 0px',
+                          lineHeight: '24px',
+                        }}
+                      >
+                        {params.group}
+                      </Typography>
+                    </Stack>
+                    {params.children}
+                  </Box>
+                )}
+              </>
             )
           }}
           inputValue={inputStatusValue}

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -171,4 +171,5 @@ export const UserTypesName = {
   internalUsers: 'Internal users',
   clients: 'Clients',
   companies: 'Companies',
+  standalone: 'Standalone', // for options in selector component which shall not be grouped
 }


### PR DESCRIPTION
## Changes

- [x] added currentOption prop for selector component. If currentOption prop is provided, it renders a standalone option without any group in the autocomplete options.
- [x] used generic type for options in selector component. Some refactoring work are still left. 

## Testing Criteria

![image](https://github.com/user-attachments/assets/b91f9432-49a1-44a6-97db-251f98eda2a2)


