### PR TITLE
OUT-1309 | Implement Confirmation Modal UI

### DIFF
--- a/src/app/detail/ui/Sidebar.tsx
+++ b/src/app/detail/ui/Sidebar.tsx
@@ -13,7 +13,7 @@ import { StyledBox, StyledModal } from './styledComponent'
 import { getAssigneeTypeCorrected } from '@/utils/getAssigneeTypeCorrected'
 import { UpdateTaskRequest } from '@/types/dto/tasks.dto'
 import { createDateFromFormattedDateString, formatDate } from '@/utils/dateHelper'
-import { selectTaskDetails, setShowConfirmAssignModal, setShowSidebar } from '@/redux/features/taskDetailsSlice'
+import { selectTaskDetails, toggleShowConfirmAssignModal, setShowSidebar } from '@/redux/features/taskDetailsSlice'
 import { ToggleButtonContainer } from './ToggleButtonContainer'
 import { NoAssignee } from '@/utils/noAssignee'
 import { WorkflowStateSelector } from '@/components/inputs/Selector-WorkflowState'
@@ -88,6 +88,17 @@ export const Sidebar = ({
   const windowWidth = useWindowWidth()
   const isMobile = windowWidth < 600 && windowWidth !== 0
 
+  const handleAssigneeChange = (assigneeValue: IAssigneeCombined) => {
+    updateAssigneeValue(assigneeValue)
+    const assigneeType = getAssigneeTypeCorrected(assigneeValue)
+    updateAssignee(assigneeType, assigneeValue?.id)
+  }
+
+  const handleConfirmAssigneeChange = (assigneeValue: IAssigneeCombined) => {
+    handleAssigneeChange(assigneeValue)
+    store.dispatch(toggleShowConfirmAssignModal())
+  }
+
   useEffect(() => {
     if (isMobile) {
       store.dispatch(setShowSidebar(false))
@@ -137,11 +148,9 @@ export const Sidebar = ({
             placeholder="Set assignee"
             getSelectedValue={(newValue) => {
               const assignee = newValue as IAssigneeCombined
-              // updateAssigneeValue(assignee)
-              // const assigneeType = getAssigneeTypeCorrected(assignee)
-              // updateAssignee(assigneeType, assignee?.id) //Conditionally open modal or just perform the action (commented part) without the modal based on the reassignment logic in the future.
+              // handleAssigneeChange(assignee) Conditionally open modal or just perform the action (commented part) without the modal based on the reassignment logic in the future.
               setSelectedAssignee(assignee)
-              store.dispatch(setShowConfirmAssignModal())
+              store.dispatch(toggleShowConfirmAssignModal())
             }}
             startIcon={
               (assigneeValue as IAssigneeCombined)?.name == 'No assignee' ? (
@@ -209,22 +218,19 @@ export const Sidebar = ({
         </Box>
         <StyledModal
           open={showConfirmAssignModal}
-          onClose={() => store.dispatch(setShowConfirmAssignModal())}
-          aria-labelledby="delete-task-modal"
-          aria-describedby="delete-task"
+          onClose={() => store.dispatch(toggleShowConfirmAssignModal())}
+          aria-labelledby="confirm-reassignment-modal"
+          aria-describedby="confirm-reassignment"
         >
           <ConfirmUI
             handleCancel={() => {
               setSelectedAssignee(undefined)
-              store.dispatch(setShowConfirmAssignModal())
+              store.dispatch(toggleShowConfirmAssignModal())
             }}
             handleConfirm={() => {
-              updateAssigneeValue(selectedAssignee)
               if (selectedAssignee) {
-                const assigneeType = getAssigneeTypeCorrected(selectedAssignee)
-                updateAssignee(assigneeType, selectedAssignee?.id)
+                handleConfirmAssigneeChange(selectedAssignee)
               }
-              store.dispatch(setShowConfirmAssignModal())
             }}
             buttonText="Reassign"
             description={`You're about to reassign this task from ${getAssigneeName(assigneeValue)} to ${getAssigneeName(selectedAssignee)}. This will give ${getAssigneeName(selectedAssignee)} access to all task comments and history.`}
@@ -303,11 +309,9 @@ export const Sidebar = ({
               placeholder="Set assignee"
               getSelectedValue={(newValue) => {
                 const assignee = newValue as IAssigneeCombined
-                // updateAssigneeValue(assignee)
-                // const assigneeType = getAssigneeTypeCorrected(assignee)
-                // updateAssignee(assigneeType, assignee?.id)  //Conditionally open modal or just perform the action (commented part) without the modal based on the reassignment logic in the future.
+                handleAssigneeChange(assignee) //Conditionally open modal or just perform the action (commented part) without the modal based on the reassignment logic in the future.
                 setSelectedAssignee(assignee)
-                store.dispatch(setShowConfirmAssignModal())
+                store.dispatch(toggleShowConfirmAssignModal())
               }}
               startIcon={
                 (assigneeValue as IAssigneeCombined)?.name == 'No assignee' ? (
@@ -395,22 +399,19 @@ export const Sidebar = ({
       </AppMargin>
       <StyledModal
         open={showConfirmAssignModal}
-        onClose={() => store.dispatch(setShowConfirmAssignModal())}
-        aria-labelledby="delete-task-modal"
-        aria-describedby="delete-task"
+        onClose={() => store.dispatch(toggleShowConfirmAssignModal())}
+        aria-labelledby="confirm-reassignment-modal"
+        aria-describedby="confirm-reassignment"
       >
         <ConfirmUI
           handleCancel={() => {
             setSelectedAssignee(undefined)
-            store.dispatch(setShowConfirmAssignModal())
+            store.dispatch(toggleShowConfirmAssignModal())
           }}
           handleConfirm={() => {
-            updateAssigneeValue(selectedAssignee)
             if (selectedAssignee) {
-              const assigneeType = getAssigneeTypeCorrected(selectedAssignee)
-              updateAssignee(assigneeType, selectedAssignee?.id)
+              handleConfirmAssigneeChange(selectedAssignee)
             }
-            store.dispatch(setShowConfirmAssignModal())
           }}
           buttonText="Reassign"
           description={`You're about to reassign this task from ${getAssigneeName(assigneeValue)} to ${getAssigneeName(selectedAssignee)}. This will give ${getAssigneeName(selectedAssignee)} access to all task comments and history.`}

--- a/src/app/detail/ui/Sidebar.tsx
+++ b/src/app/detail/ui/Sidebar.tsx
@@ -9,11 +9,11 @@ import { useHandleSelectorComponent } from '@/hooks/useHandleSelectorComponent'
 import { useSelector } from 'react-redux'
 import { selectTaskBoard } from '@/redux/features/taskBoardSlice'
 import { WorkflowStateResponse } from '@/types/dto/workflowStates.dto'
-import { StyledBox } from './styledComponent'
+import { StyledBox, StyledModal } from './styledComponent'
 import { getAssigneeTypeCorrected } from '@/utils/getAssigneeTypeCorrected'
 import { UpdateTaskRequest } from '@/types/dto/tasks.dto'
 import { createDateFromFormattedDateString, formatDate } from '@/utils/dateHelper'
-import { selectTaskDetails, setShowSidebar } from '@/redux/features/taskDetailsSlice'
+import { selectTaskDetails, setShowConfirmAssignModal, setShowSidebar } from '@/redux/features/taskDetailsSlice'
 import { ToggleButtonContainer } from './ToggleButtonContainer'
 import { NoAssignee } from '@/utils/noAssignee'
 import { WorkflowStateSelector } from '@/components/inputs/Selector-WorkflowState'
@@ -26,6 +26,7 @@ import { getAssigneeName, isAssigneeTextMatching } from '@/utils/assignee'
 import { DateStringSchema } from '@/types/date'
 import { useWindowWidth } from '@/hooks/useWindowWidth'
 import store from '@/redux/store'
+import { ConfirmUI } from '@/components/layouts/ConfirmUI'
 
 const StyledText = styled(Typography)(({ theme }) => ({
   color: theme.color.gray[500],
@@ -50,12 +51,13 @@ export const Sidebar = ({
   workflowDisabled?: false
 }) => {
   const { activeTask, token, workflowStates, assignee, previewMode } = useSelector(selectTaskBoard)
-  const { showSidebar } = useSelector(selectTaskDetails)
+  const { showSidebar, showConfirmAssignModal } = useSelector(selectTaskDetails)
   const [filteredAssignees, setFilteredAssignees] = useState(assignee)
   const [activeDebounceTimeoutId, setActiveDebounceTimeoutId] = useState<NodeJS.Timeout | null>(null)
   const [loading, setLoading] = useState(false)
   const [dueDate, setDueDate] = useState<Date | string | undefined>()
   const [inputStatusValue, setInputStatusValue] = useState('')
+  const [selectedAssignee, setSelectedAssignee] = useState<IAssigneeCombined | undefined>(undefined)
 
   const { renderingItem: _statusValue, updateRenderingItem: updateStatusValue } = useHandleSelectorComponent({
     // item: selectedWorkflowState,
@@ -135,9 +137,11 @@ export const Sidebar = ({
             placeholder="Set assignee"
             getSelectedValue={(newValue) => {
               const assignee = newValue as IAssigneeCombined
-              updateAssigneeValue(assignee)
-              const assigneeType = getAssigneeTypeCorrected(assignee)
-              updateAssignee(assigneeType, assignee?.id)
+              // updateAssigneeValue(assignee)
+              // const assigneeType = getAssigneeTypeCorrected(assignee)
+              // updateAssignee(assigneeType, assignee?.id) //Conditionally open modal or just perform the action (commented part) without the modal based on the reassignment logic in the future.
+              setSelectedAssignee(assignee)
+              store.dispatch(setShowConfirmAssignModal())
             }}
             startIcon={
               (assigneeValue as IAssigneeCombined)?.name == 'No assignee' ? (
@@ -203,6 +207,30 @@ export const Sidebar = ({
             padding={'3px 8px'}
           />
         </Box>
+        <StyledModal
+          open={showConfirmAssignModal}
+          onClose={() => store.dispatch(setShowConfirmAssignModal())}
+          aria-labelledby="delete-task-modal"
+          aria-describedby="delete-task"
+        >
+          <ConfirmUI
+            handleCancel={() => {
+              setSelectedAssignee(undefined)
+              store.dispatch(setShowConfirmAssignModal())
+            }}
+            handleConfirm={() => {
+              updateAssigneeValue(selectedAssignee)
+              if (selectedAssignee) {
+                const assigneeType = getAssigneeTypeCorrected(selectedAssignee)
+                updateAssignee(assigneeType, selectedAssignee?.id)
+              }
+              store.dispatch(setShowConfirmAssignModal())
+            }}
+            buttonText="Reassign"
+            description={`You're about to reassign this task from ${getAssigneeName(assigneeValue)} to ${getAssigneeName(selectedAssignee)}. This will give ${getAssigneeName(selectedAssignee)} access to all task comments and history.`}
+            title="Reassign task?"
+          />
+        </StyledModal>
       </Stack>
     )
   }
@@ -275,9 +303,11 @@ export const Sidebar = ({
               placeholder="Set assignee"
               getSelectedValue={(newValue) => {
                 const assignee = newValue as IAssigneeCombined
-                updateAssigneeValue(assignee)
-                const assigneeType = getAssigneeTypeCorrected(assignee)
-                updateAssignee(assigneeType, assignee?.id)
+                // updateAssigneeValue(assignee)
+                // const assigneeType = getAssigneeTypeCorrected(assignee)
+                // updateAssignee(assigneeType, assignee?.id)  //Conditionally open modal or just perform the action (commented part) without the modal based on the reassignment logic in the future.
+                setSelectedAssignee(assignee)
+                store.dispatch(setShowConfirmAssignModal())
               }}
               startIcon={
                 (assigneeValue as IAssigneeCombined)?.name == 'No assignee' ? (
@@ -363,6 +393,30 @@ export const Sidebar = ({
           </Box>
         </Stack>
       </AppMargin>
+      <StyledModal
+        open={showConfirmAssignModal}
+        onClose={() => store.dispatch(setShowConfirmAssignModal())}
+        aria-labelledby="delete-task-modal"
+        aria-describedby="delete-task"
+      >
+        <ConfirmUI
+          handleCancel={() => {
+            setSelectedAssignee(undefined)
+            store.dispatch(setShowConfirmAssignModal())
+          }}
+          handleConfirm={() => {
+            updateAssigneeValue(selectedAssignee)
+            if (selectedAssignee) {
+              const assigneeType = getAssigneeTypeCorrected(selectedAssignee)
+              updateAssignee(assigneeType, selectedAssignee?.id)
+            }
+            store.dispatch(setShowConfirmAssignModal())
+          }}
+          buttonText="Reassign"
+          description={`You're about to reassign this task from ${getAssigneeName(assigneeValue)} to ${getAssigneeName(selectedAssignee)}. This will give ${getAssigneeName(selectedAssignee)} access to all task comments and history.`}
+          title="Reassign task?"
+        />
+      </StyledModal>
     </Box>
   )
 }

--- a/src/components/layouts/ConfirmDeleteUI.tsx
+++ b/src/components/layouts/ConfirmDeleteUI.tsx
@@ -60,7 +60,7 @@ const UIContainer = styled(Box)(({ theme }) => ({
   left: '50%',
   transform: 'translate(-50%, -50%)',
   borderRadius: '4px',
-  backgroundColor: '#ffffff',
+  backgroundColor: theme.color.base.white,
   boxShadow: '0px 16px 70px 0px rgba(0, 0, 0, 0.50)',
   border: `1px solid ${theme.color.borders.border2}`,
 }))

--- a/src/components/layouts/ConfirmUI.tsx
+++ b/src/components/layouts/ConfirmUI.tsx
@@ -1,0 +1,64 @@
+'use client'
+
+import { StyledBox } from '@/app/detail/ui/styledComponent'
+import { AppMargin, SizeofAppMargin } from '@/hoc/AppMargin'
+import { Box, Stack, Typography, styled } from '@mui/material'
+import { SecondaryBtn } from '../buttons/SecondaryBtn'
+import { PrimaryBtn } from '../buttons/PrimaryBtn'
+
+interface Prop {
+  handleCancel: () => void
+  handleConfirm: () => void
+  buttonText: string
+  title?: string
+  description?: string
+}
+
+export const ConfirmUI = ({
+  handleCancel,
+  handleConfirm,
+  buttonText,
+  title,
+  description = `This action can't be undone.`,
+}: Prop) => {
+  return (
+    <UIContainer sx={{ width: { xs: '80%', sm: '540px' } }}>
+      <StyledBox>
+        <Stack direction="column" rowGap={4} sx={{ padding: '12px 12px 12px 20px' }}>
+          <Typography variant="lg">{title ? title : `Are you sure?`}</Typography>
+        </Stack>
+      </StyledBox>
+      <StyledBox>
+        <Stack direction="column" rowGap={4} sx={{ padding: '20px' }}>
+          <Typography variant="bodyMd">{description}</Typography>
+        </Stack>
+      </StyledBox>
+
+      <Stack direction="row" justifyContent="right" alignItems="center" sx={{ padding: '16px 20px' }}>
+        <Stack direction="row" columnGap={4}>
+          <SecondaryBtn
+            handleClick={handleCancel}
+            buttonContent={
+              <Typography variant="sm" sx={{ color: (theme) => theme.color.gray[700] }}>
+                Cancel
+              </Typography>
+            }
+          />
+          <PrimaryBtn handleClick={() => handleConfirm()} buttonText={buttonText} />
+        </Stack>
+      </Stack>
+    </UIContainer>
+  )
+}
+
+const UIContainer = styled(Box)(({ theme }) => ({
+  margin: '0 auto',
+  position: 'absolute',
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
+  borderRadius: '4px',
+  backgroundColor: '#ffffff',
+  boxShadow: '0px 16px 70px 0px rgba(0, 0, 0, 0.50)',
+  border: `1px solid ${theme.color.borders.border2}`,
+}))

--- a/src/components/layouts/ConfirmUI.tsx
+++ b/src/components/layouts/ConfirmUI.tsx
@@ -3,29 +3,29 @@
 import { StyledBox } from '@/app/detail/ui/styledComponent'
 import { AppMargin, SizeofAppMargin } from '@/hoc/AppMargin'
 import { Box, Stack, Typography, styled } from '@mui/material'
-import { SecondaryBtn } from '../buttons/SecondaryBtn'
-import { PrimaryBtn } from '../buttons/PrimaryBtn'
+import { SecondaryBtn } from '@/components/buttons/SecondaryBtn'
+import { PrimaryBtn } from '@/components/buttons/PrimaryBtn'
 
-interface Prop {
+interface ConfirmUIProps {
   handleCancel: () => void
   handleConfirm: () => void
   buttonText: string
-  title?: string
-  description?: string
+  title: string
+  description: string
 }
 
 export const ConfirmUI = ({
   handleCancel,
   handleConfirm,
   buttonText,
-  title,
+  title = 'Are you sure?',
   description = `This action can't be undone.`,
-}: Prop) => {
+}: ConfirmUIProps) => {
   return (
     <UIContainer sx={{ width: { xs: '80%', sm: '540px' } }}>
       <StyledBox>
         <Stack direction="column" rowGap={4} sx={{ padding: '12px 12px 12px 20px' }}>
-          <Typography variant="lg">{title ? title : `Are you sure?`}</Typography>
+          <Typography variant="lg">{title}</Typography>
         </Stack>
       </StyledBox>
       <StyledBox>
@@ -58,7 +58,7 @@ const UIContainer = styled(Box)(({ theme }) => ({
   left: '50%',
   transform: 'translate(-50%, -50%)',
   borderRadius: '4px',
-  backgroundColor: '#ffffff',
+  backgroundColor: theme.color.base.white,
   boxShadow: '0px 16px 70px 0px rgba(0, 0, 0, 0.50)',
   border: `1px solid ${theme.color.borders.border2}`,
 }))

--- a/src/redux/features/taskDetailsSlice.ts
+++ b/src/redux/features/taskDetailsSlice.ts
@@ -35,7 +35,7 @@ const taskDetailsSlice = createSlice({
     setTask: (state, action: { payload: TaskResponse }) => {
       state.task = action.payload
     },
-    setShowConfirmAssignModal: (state) => {
+    toggleShowConfirmAssignModal: (state) => {
       state.showConfirmAssignModal = !state.showConfirmAssignModal
     },
   },
@@ -43,7 +43,7 @@ const taskDetailsSlice = createSlice({
 
 export const selectTaskDetails = (state: RootState) => state.taskDetail
 
-export const { setShowConfirmDeleteModal, setShowSidebar, setAssigneeSuggestion, setTask, setShowConfirmAssignModal } =
+export const { setShowConfirmDeleteModal, setShowSidebar, setAssigneeSuggestion, setTask, toggleShowConfirmAssignModal } =
   taskDetailsSlice.actions
 
 export default taskDetailsSlice.reducer

--- a/src/redux/features/taskDetailsSlice.ts
+++ b/src/redux/features/taskDetailsSlice.ts
@@ -8,6 +8,7 @@ interface IInitialState {
   showSidebar: boolean
   assigneeSuggestions: IAssigneeSuggestions[]
   task: TaskResponse | undefined
+  showConfirmAssignModal: boolean
 }
 
 const initialState: IInitialState = {
@@ -15,6 +16,7 @@ const initialState: IInitialState = {
   showSidebar: true,
   assigneeSuggestions: [],
   task: undefined,
+  showConfirmAssignModal: false,
 }
 
 const taskDetailsSlice = createSlice({
@@ -33,11 +35,15 @@ const taskDetailsSlice = createSlice({
     setTask: (state, action: { payload: TaskResponse }) => {
       state.task = action.payload
     },
+    setShowConfirmAssignModal: (state) => {
+      state.showConfirmAssignModal = !state.showConfirmAssignModal
+    },
   },
 })
 
 export const selectTaskDetails = (state: RootState) => state.taskDetail
 
-export const { setShowConfirmDeleteModal, setShowSidebar, setAssigneeSuggestion, setTask } = taskDetailsSlice.actions
+export const { setShowConfirmDeleteModal, setShowSidebar, setAssigneeSuggestion, setTask, setShowConfirmAssignModal } =
+  taskDetailsSlice.actions
 
 export default taskDetailsSlice.reducer


### PR DESCRIPTION
## Changes

- [x] Implemented the new reassignment confirmation modal on reassignment of tasks.
- [x] Created ConfirmUI component, separated it from ConfirmDeleteUI for specific purposes in the future.
- [x] Implemented ConfirmUI component on each reassignment, in other PR, based on reassignment logic in PRD, confirmUI shall be invoked.

## Testing Criteria

- [LOOM](https://www.loom.com/share/fa98551f3be848429d12f982970fd87f). Tested on mobile view too. 