### PR TITLE
OUT-1321 | Reassignment modal should close after click on assignees name

### DIFF
--- a/src/components/inputs/Selector.tsx
+++ b/src/components/inputs/Selector.tsx
@@ -171,7 +171,7 @@ export default function Selector<T extends keyof SelectorOptionsType>({
 
   return (
     <Stack direction="column">
-      <Box onClick={handleClick} aria-describedby={id}>
+      <Box onMouseDown={handleClick} aria-describedby={id}>
         {disableOutline ? (
           <Stack
             direction="row"


### PR DESCRIPTION
## Changes

- [x] used onMouseDown instead of onClick to open the popper for selectors. 

## Testing Criteria

- [LOOM](https://www.loom.com/share/1db382973b224d1aa39ed1d8ab3fcf72)
