### PR TITLE
OUT-1311, OUT-1326, OUT-1327 | Hide all activity logs before reassignment if task reassigned to access limited IU

### DIFF
--- a/src/app/api/activity-logs/const.ts
+++ b/src/app/api/activity-logs/const.ts
@@ -32,3 +32,5 @@ export const DBActivityLogSchema = z.object({
 })
 
 export const DBActivityLogArraySchema = z.array(DBActivityLogSchema)
+
+export type DBActivityLogArray = z.infer<typeof DBActivityLogArraySchema>

--- a/src/app/api/core/utils/withErrorHandler.ts
+++ b/src/app/api/core/utils/withErrorHandler.ts
@@ -32,7 +32,7 @@ export const withErrorHandler = (handler: RequestHandler): RequestHandler => {
       return await handler(req, params)
     } catch (error: unknown) {
       // Format error in a readable way
-      console.log('error here', error) // tryfix, delete this
+
       let formattedError = error
       if (error instanceof ZodError) {
         formattedError = error.format() as ZodFormattedError<string>

--- a/src/app/api/core/utils/withErrorHandler.ts
+++ b/src/app/api/core/utils/withErrorHandler.ts
@@ -32,6 +32,7 @@ export const withErrorHandler = (handler: RequestHandler): RequestHandler => {
       return await handler(req, params)
     } catch (error: unknown) {
       // Format error in a readable way
+      console.log('error here', error) // tryfix, delete this
       let formattedError = error
       if (error instanceof ZodError) {
         formattedError = error.format() as ZodFormattedError<string>

--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -132,7 +132,9 @@ export class TasksService extends BaseService {
         return currentInternalUser.companyAccessList?.includes(task.assigneeId)
       }
       const taskClient = clients.data?.find((client) => client.id === task.assigneeId)
+      console.log('testloghere', taskClient, taskClient?.companyId)
       const taskClientsCompanyId = z.string().parse(taskClient?.companyId)
+      console.log('testloghere2', taskClientsCompanyId)
       return currentInternalUser.companyAccessList?.includes(taskClientsCompanyId)
     })
   }

--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -132,10 +132,12 @@ export class TasksService extends BaseService {
         return currentInternalUser.companyAccessList?.includes(task.assigneeId)
       }
       const taskClient = clients.data?.find((client) => client.id === task.assigneeId)
-      console.log('testloghere', taskClient, taskClient?.companyId)
-      console.log(task)
+      // Case where client is deleted or a client does not have a companyID(older clients)
+      if (!taskClient || !taskClient.companyId) {
+        return false
+      }
       const taskClientsCompanyId = z.string().parse(taskClient?.companyId)
-      console.log('testloghere2', taskClientsCompanyId)
+
       return currentInternalUser.companyAccessList?.includes(taskClientsCompanyId)
     })
   }

--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -133,6 +133,7 @@ export class TasksService extends BaseService {
       }
       const taskClient = clients.data?.find((client) => client.id === task.assigneeId)
       console.log('testloghere', taskClient, taskClient?.companyId)
+      console.log(task)
       const taskClientsCompanyId = z.string().parse(taskClient?.companyId)
       console.log('testloghere2', taskClientsCompanyId)
       return currentInternalUser.companyAccessList?.includes(taskClientsCompanyId)

--- a/src/hoc/RealTime.tsx
+++ b/src/hoc/RealTime.tsx
@@ -66,9 +66,6 @@ export const RealTime = ({
       // Additionally, if user is a client, it can only access tasks assigned to that client or the client's company
       if (userRole === AssigneeType.client) {
         canUserAccessTask = canUserAccessTask && [userId, tokenPayload?.companyId].includes(payload.new.assigneeId)
-        if (!canUserAccessTask) {
-          redirectToBoard()
-        }
       }
       //check if the new task in this event belongs to the same workspaceId
       if (canUserAccessTask && showUnarchived) {

--- a/src/hoc/RealTime.tsx
+++ b/src/hoc/RealTime.tsx
@@ -51,7 +51,7 @@ export const RealTime = ({
       // If user is an internal user with client access limitations, they can only access tasks assigned to clients or company they have access to
       if (user && userRole === AssigneeType.internalUser && InternalUsersSchema.parse(user).isClientAccessLimited) {
         const assigneeSet = new Set(assignee.map((a) => a.id))
-        canUserAccessTask = canUserAccessTask && (payload.new.assigneeId ? assigneeSet.has(payload.new.assigneeId) : false)
+        canUserAccessTask = canUserAccessTask && (payload.new.assigneeId ? assigneeSet.has(payload.new.assigneeId) : false) //filtering out unassigned tasks with a fallback false value.
       }
       // Additionally, if user is a client, it can only access tasks assigned to that client or the client's company
       if (userRole === AssigneeType.client) {

--- a/src/utils/shouldConfirmBeforeReassign.ts
+++ b/src/utils/shouldConfirmBeforeReassign.ts
@@ -13,9 +13,6 @@ export const ShouldConfirmBeforeReassignment = (previousAssignee: IAssigneeCombi
   } // case when previous assignee is an IU with full access to clients.
 
   switch (currentAssigneeType) {
-    case AssigneeType.internalUser:
-      return false // add logic to return true/false for confirming before reassignment for IUs here
-
     case AssigneeType.client:
       return !previousAssigneeCompanyAccessList.includes(z.string().parse(currentAssignee.companyId))
 


### PR DESCRIPTION
## Changes

- [x] applied a logic while fetching activity logs for limited access ius :  if any of the reassignment logs starting from the latest contain previous client/company assignee out of scope for the logged in limited access IU. Then the logs and details before the reassignment log will be hidden for the IU.
- [x] fixed zod error causing application to crash when access is changed to limited for an iu from copilot dashboard.
- [x] applied logic in realtime component to hide tasks creation/update when the tasks assignee are out of scope for the logged in limited access IU.

## Testing Criteria 

- [LOOM](https://www.loom.com/share/6abd22d21f074164ae4ff9d4ea8413b2)


