### PR TITLE
OUT-1328 | Images are not loading in task description, disappearing after upload

### DIFF
--- a/src/hoc/RealTime.tsx
+++ b/src/hoc/RealTime.tsx
@@ -89,6 +89,7 @@ export const RealTime = ({
       if (payload.new.workspaceId === tokenPayload?.workspaceId) {
         //if the updated task is out of scope for limited access iu
         if (user && userRole === AssigneeType.internalUser && InternalUsersSchema.parse(user).isClientAccessLimited) {
+          console.log('true')
           const assigneeSet = new Set(assignee.map((a) => a.id))
           if (payload.new.assigneeId && !assigneeSet.has(payload.new.assigneeId)) {
             const newTaskArr = tasks.filter((el) => el.id !== updatedTask.id)


### PR DESCRIPTION
## Changes

- [x] Added a client side fetching for updating assignee change from sidebar. This is being used instead of server actions. Server actions are of blocking behaviour which causes other consecutive server actions on hold if the previous actions takes time. handling assignee change on server actions takes too much time because of notification if an assignee is a company.



