### PR TITLE
OUT-1338, OUT-1337 | Duplicate activity logs are shown when task reassigned

### DIFF
--- a/src/app/detail/ui/Sidebar.tsx
+++ b/src/app/detail/ui/Sidebar.tsx
@@ -107,16 +107,22 @@ export const Sidebar = ({
 
   const handleAssigneeChangeSWR = async (assignee: IAssigneeCombined) => {
     try {
-      await mutate(async () => {
-        await fetch(`/api/tasks/${task_id}?token=${token}`, {
-          method: 'PATCH',
-          body: JSON.stringify({
-            assigneeType: getAssigneeTypeCorrected(assignee),
-            assigneeId: assignee.id,
-          }),
-        })
-      })
-      return
+      await mutate(
+        `/api/tasks/${task_id}`,
+        async () => {
+          const response = await fetch(`/api/tasks/${task_id}?token=${token}`, {
+            method: 'PATCH',
+            body: JSON.stringify({
+              assigneeType: getAssigneeTypeCorrected(assignee),
+              assigneeId: assignee.id,
+            }),
+          })
+          return await response.json()
+        },
+        {
+          revalidate: false,
+        },
+      )
     } catch (error) {
       console.error('Failed to change assignee:', error)
     }


### PR DESCRIPTION
## Changes

- [x] added a cache key and turned off re validation which was sending double requests for reassignment using client side fetcher.  

## Testing Criteria

![image](https://github.com/user-attachments/assets/7b5516ee-5c8b-484b-9200-0c0a643780fd)
![image](https://github.com/user-attachments/assets/3c57e6f5-7f93-46cd-b2f0-e839c7930b30)


