### PR TITLE
OUT-1333 | Total list of tasks is not being rendered for Client Access Limited IU

### DIFF
--- a/src/app/api/activity-logs/services/activity-log.service.ts
+++ b/src/app/api/activity-logs/services/activity-log.service.ts
@@ -11,10 +11,11 @@ import {
 } from '@api/activity-logs/const'
 import { CopilotAPI } from '@/utils/CopilotAPI'
 import { CommentService } from '@api/comment/comment.service'
-import { ClientsResponse, CompaniesResponse, InternalUsers, InternalUsersResponse } from '@/types/common'
+import { ClientsResponse, CompaniesResponse, CopilotListArgs, InternalUsers, InternalUsersResponse } from '@/types/common'
 import { LogResponse, LogResponseSchema } from '../schemas/LogResponseSchema'
 import APIError from '@api/core/exceptions/api'
 import httpStatus from 'http-status'
+import { MAX_FETCH_ASSIGNEE_COUNT } from '@/constants/users'
 
 export class ActivityLogService extends BaseService {
   constructor(user: User) {
@@ -47,12 +48,11 @@ export class ActivityLogService extends BaseService {
     const parsedActivityLogs = DBActivityLogArraySchema.parse(activityLogs)
     const copilotService = new CopilotAPI(this.user.token)
 
-    const maxLimitForFiltering = 10_000
-
+    const userOpts: CopilotListArgs = { limit: MAX_FETCH_ASSIGNEE_COUNT }
     const [internalUsers, clientUsers, companies] = await Promise.all([
-      copilotService.getInternalUsers({ limit: maxLimitForFiltering }),
-      copilotService.getClients({ limit: maxLimitForFiltering }),
-      copilotService.getCompanies({ limit: maxLimitForFiltering }),
+      copilotService.getInternalUsers(userOpts),
+      copilotService.getClients(userOpts),
+      copilotService.getCompanies(userOpts),
     ])
 
     let filteredActivityLogs = parsedActivityLogs

--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -22,6 +22,8 @@ type FilterByAssigneeId = {
   assigneeType: AssigneeType
 }
 
+const COPILOT_USER_PAGESIZE = 10_000
+
 export class TasksService extends BaseService {
   /**
    * Builds filter for "get" service methods.
@@ -119,8 +121,10 @@ export class TasksService extends BaseService {
     const currentInternalUser = await copilot.getInternalUser(this.user.internalUserId)
     if (!currentInternalUser.isClientAccessLimited) return tasks
 
-    const hasClientTasks = tasks.some((task) => task.assigneeType === AssigneeType.client)
-    const clients = hasClientTasks ? await copilot.getClients() : { data: [] }
+    const hasClientTasks = tasks.some(
+      (task) => task.assigneeType === AssigneeType.client || task.assigneeType === AssigneeType.company,
+    )
+    const clients = hasClientTasks ? await copilot.getClients({ limit: COPILOT_USER_PAGESIZE }) : { data: [] }
 
     return tasks.filter((task) => {
       // Allow IU to access unassigned tasks or tasks assigned to another IU within workspace

--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -120,9 +120,7 @@ export class TasksService extends BaseService {
     const currentInternalUser = await copilot.getInternalUser(this.user.internalUserId)
     if (!currentInternalUser.isClientAccessLimited) return tasks
 
-    const hasClientTasks = tasks.some(
-      (task) => task.assigneeType === AssigneeType.client || task.assigneeType === AssigneeType.company,
-    )
+    const hasClientTasks = tasks.some((task) => task.assigneeType === AssigneeType.client)
     const clients = hasClientTasks ? await copilot.getClients({ limit: MAX_FETCH_ASSIGNEE_COUNT }) : { data: [] }
 
     return tasks.filter((task) => {

--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -1,3 +1,4 @@
+import { MAX_FETCH_ASSIGNEE_COUNT } from '@/constants/users'
 import { ClientResponse, CompanyResponse, InternalUsers } from '@/types/common'
 import { CreateTaskRequest, UpdateTaskRequest } from '@/types/dto/tasks.dto'
 import { CopilotAPI } from '@/utils/CopilotAPI'
@@ -21,8 +22,6 @@ type FilterByAssigneeId = {
   assigneeId: string
   assigneeType: AssigneeType
 }
-
-const COPILOT_USER_PAGESIZE = 10_000
 
 export class TasksService extends BaseService {
   /**
@@ -124,7 +123,7 @@ export class TasksService extends BaseService {
     const hasClientTasks = tasks.some(
       (task) => task.assigneeType === AssigneeType.client || task.assigneeType === AssigneeType.company,
     )
-    const clients = hasClientTasks ? await copilot.getClients({ limit: COPILOT_USER_PAGESIZE }) : { data: [] }
+    const clients = hasClientTasks ? await copilot.getClients({ limit: MAX_FETCH_ASSIGNEE_COUNT }) : { data: [] }
 
     return tasks.filter((task) => {
       // Allow IU to access unassigned tasks or tasks assigned to another IU within workspace

--- a/src/app/api/users/users.service.ts
+++ b/src/app/api/users/users.service.ts
@@ -11,6 +11,7 @@ import { filterUsersByKeyword } from '@/utils/users'
 import { z } from 'zod'
 import { FilterOptionsKeywords } from '@/types/interfaces'
 import { orderByRecentlyCreatedAt } from '@/utils/ordering'
+import { MAX_FETCH_ASSIGNEE_COUNT } from '@/constants/users'
 
 class UsersService extends BaseService {
   private copilot: CopilotAPI
@@ -26,12 +27,11 @@ class UsersService extends BaseService {
     new PoliciesService(user).authorize(UserAction.Read, Resource.Users)
 
     const listArgs: CopilotListArgs = { limit, nextToken }
-    const maxLimitForFiltering = 10_000
 
     const [ius, clients, companies] = await Promise.all([
       this.copilot.getInternalUsers(listArgs),
-      this.copilot.getClients({ limit: maxLimitForFiltering, nextToken }),
-      this.copilot.getCompanies({ limit: maxLimitForFiltering, nextToken }),
+      this.copilot.getClients({ limit: MAX_FETCH_ASSIGNEE_COUNT, nextToken }),
+      this.copilot.getCompanies({ limit: MAX_FETCH_ASSIGNEE_COUNT, nextToken }),
     ])
 
     // Get current internal user as only IUs are authenticated to access this route

--- a/src/app/api/webhook/webhook.service.ts
+++ b/src/app/api/webhook/webhook.service.ts
@@ -11,6 +11,7 @@ import { getInProductNotificationDetails } from '@api/notification/notification.
 import { NotificationTaskActions } from '@api/core/types/tasks'
 import { NotificationService } from '@api/notification/notification.service'
 import User from '@api/core/models/User.model'
+import { MAX_FETCH_ASSIGNEE_COUNT } from '@/constants/users'
 
 class WebhookService extends BaseService {
   private copilot
@@ -76,7 +77,7 @@ class WebhookService extends BaseService {
     const bottleneck = new Bottleneck({ minTime: 250, maxConcurrent: 2 })
     const createNotificationPromises = []
 
-    const internalUsers = (await this.copilot.getInternalUsers({ limit: 10_000 })).data
+    const internalUsers = (await this.copilot.getInternalUsers({ limit: MAX_FETCH_ASSIGNEE_COUNT })).data
     const existingNotifications = await this.db.clientNotification.findMany({
       where: { clientId: assigneeId },
     })

--- a/src/cmd/load-testing/deleteClients.ts
+++ b/src/cmd/load-testing/deleteClients.ts
@@ -1,3 +1,4 @@
+import { MAX_FETCH_ASSIGNEE_COUNT } from '@/constants/users'
 import { CopilotAPI } from '@/utils/CopilotAPI'
 import Bottleneck from 'bottleneck'
 import dotenv from 'dotenv'
@@ -13,7 +14,7 @@ const run = async () => {
   const token = z.string().parse(process.env.LOAD_TESTING_COPILOT_TOKEN)
   const apiKey = z.string().parse(process.env.COPILOT_API_KEY)
   const copilot = new CopilotAPI(token, apiKey)
-  const clients = await copilot.getClients({ limit: 10_000 })
+  const clients = await copilot.getClients({ limit: MAX_FETCH_ASSIGNEE_COUNT })
 
   if (!clients.data) {
     throw new Error('No clients to delete')

--- a/src/constants/users.ts
+++ b/src/constants/users.ts
@@ -1,1 +1,1 @@
-export const MAX_FETCH_ASSIGNEE_COUNT = 5000
+export const MAX_FETCH_ASSIGNEE_COUNT = 10_000


### PR DESCRIPTION
## Changes

- [x] Raise assignee fetch limit
- [x] Clean code to use reusable constants instead 

## Testing Criteria

- [x] Notice that the task count in columns for IU & Notification count (total number of tasks) for Client is the same

![image](https://github.com/user-attachments/assets/84c7c95c-30d8-4e8b-b9b7-00079c85fb45)

![image](https://github.com/user-attachments/assets/5b2f4b9f-2e64-4d0d-af9d-cb331a640ffa)
