### PR TITLE
OUT-1342 | Bold names in confirmation modal

### DIFF
--- a/src/app/detail/ui/Sidebar.tsx
+++ b/src/app/detail/ui/Sidebar.tsx
@@ -272,7 +272,16 @@ export const Sidebar = ({
               }
             }}
             buttonText="Reassign"
-            description={`You're about to reassign this task from ${getAssigneeName(assigneeValue)} to ${getAssigneeName(selectedAssignee)}. This will give ${getAssigneeName(selectedAssignee)} access to all task comments and history.`}
+            description={
+              <Typography variant="bodyMd">
+                {`You're about to reassign this task from `}
+                <strong>{getAssigneeName(assigneeValue)}</strong>
+                {` to `}
+                <strong>{getAssigneeName(selectedAssignee)}</strong>.{` This will give `}
+                <strong>{getAssigneeName(selectedAssignee)}</strong>
+                {` access to all task comments and history.`}
+              </Typography>
+            }
             title="Reassign task?"
           />
         </StyledModal>
@@ -458,7 +467,16 @@ export const Sidebar = ({
             }
           }}
           buttonText="Reassign"
-          description={`You're about to reassign this task from ${getAssigneeName(assigneeValue)} to ${getAssigneeName(selectedAssignee)}. This will give ${getAssigneeName(selectedAssignee)} access to all task comments and history.`}
+          description={
+            <Typography variant="bodyMd">
+              {`You're about to reassign this task from `}
+              <strong>{getAssigneeName(assigneeValue)}</strong>
+              {` to `}
+              <strong>{getAssigneeName(selectedAssignee)}</strong>.{` This will give `}
+              <strong>{getAssigneeName(selectedAssignee)}</strong>
+              {` access to all task comments and history.`}
+            </Typography>
+          }
           title="Reassign task?"
         />
       </StyledModal>

--- a/src/app/detail/ui/Sidebar.tsx
+++ b/src/app/detail/ui/Sidebar.tsx
@@ -273,14 +273,11 @@ export const Sidebar = ({
             }}
             buttonText="Reassign"
             description={
-              <Typography variant="bodyMd">
-                {`You're about to reassign this task from `}
-                <strong>{getAssigneeName(assigneeValue)}</strong>
-                {` to `}
-                <strong>{getAssigneeName(selectedAssignee)}</strong>.{` This will give `}
-                <strong>{getAssigneeName(selectedAssignee)}</strong>
-                {` access to all task comments and history.`}
-              </Typography>
+              <>
+                You&apos;re about to reassign this task from <strong>{getAssigneeName(assigneeValue)}</strong> to{' '}
+                <strong>{getAssigneeName(selectedAssignee)}</strong>. This will give{' '}
+                <strong>{getAssigneeName(selectedAssignee)}</strong> access to all task comments and history.
+              </>
             }
             title="Reassign task?"
           />
@@ -468,14 +465,11 @@ export const Sidebar = ({
           }}
           buttonText="Reassign"
           description={
-            <Typography variant="bodyMd">
-              {`You're about to reassign this task from `}
-              <strong>{getAssigneeName(assigneeValue)}</strong>
-              {` to `}
-              <strong>{getAssigneeName(selectedAssignee)}</strong>.{` This will give `}
-              <strong>{getAssigneeName(selectedAssignee)}</strong>
-              {` access to all task comments and history.`}
-            </Typography>
+            <>
+              You&apos;re about to reassign this task from <strong>{getAssigneeName(assigneeValue)}</strong> to{' '}
+              <strong>{getAssigneeName(selectedAssignee)}</strong>. This will give{' '}
+              <strong>{getAssigneeName(selectedAssignee)}</strong> access to all task comments and history.
+            </>
           }
           title="Reassign task?"
         />

--- a/src/components/layouts/ConfirmUI.tsx
+++ b/src/components/layouts/ConfirmUI.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { StyledBox, TypographyContainer } from '@/app/detail/ui/styledComponent'
+import { StyledBox } from '@/app/detail/ui/styledComponent'
 import { AppMargin, SizeofAppMargin } from '@/hoc/AppMargin'
 import { Box, Stack, Typography, styled } from '@mui/material'
 import { SecondaryBtn } from '@/components/buttons/SecondaryBtn'
@@ -12,7 +12,7 @@ interface ConfirmUIProps {
   handleConfirm: () => void
   buttonText: string
   title: string
-  description: ReactNode
+  description: ReactNode | string
 }
 
 export const ConfirmUI = ({
@@ -20,7 +20,7 @@ export const ConfirmUI = ({
   handleConfirm,
   buttonText,
   title = 'Are you sure?',
-  description = <Typography variant="bodyMd">{`This action can't be undone.`}</Typography>,
+  description = `This action can't be undone.`,
 }: ConfirmUIProps) => {
   return (
     <UIContainer sx={{ width: { xs: '80%', sm: '540px' } }}>
@@ -31,7 +31,7 @@ export const ConfirmUI = ({
       </StyledBox>
       <StyledBox>
         <Stack direction="column" rowGap={4} sx={{ padding: '20px' }}>
-          <TypographyContainer direction="row">{description}</TypographyContainer>
+          <Typography variant="bodyMd">{description}</Typography>
         </Stack>
       </StyledBox>
 

--- a/src/components/layouts/ConfirmUI.tsx
+++ b/src/components/layouts/ConfirmUI.tsx
@@ -1,17 +1,18 @@
 'use client'
 
-import { StyledBox } from '@/app/detail/ui/styledComponent'
+import { StyledBox, TypographyContainer } from '@/app/detail/ui/styledComponent'
 import { AppMargin, SizeofAppMargin } from '@/hoc/AppMargin'
 import { Box, Stack, Typography, styled } from '@mui/material'
 import { SecondaryBtn } from '@/components/buttons/SecondaryBtn'
 import { PrimaryBtn } from '@/components/buttons/PrimaryBtn'
+import { ReactNode } from 'react'
 
 interface ConfirmUIProps {
   handleCancel: () => void
   handleConfirm: () => void
   buttonText: string
   title: string
-  description: string
+  description: ReactNode
 }
 
 export const ConfirmUI = ({
@@ -19,7 +20,7 @@ export const ConfirmUI = ({
   handleConfirm,
   buttonText,
   title = 'Are you sure?',
-  description = `This action can't be undone.`,
+  description = <Typography variant="bodyMd">{`This action can't be undone.`}</Typography>,
 }: ConfirmUIProps) => {
   return (
     <UIContainer sx={{ width: { xs: '80%', sm: '540px' } }}>
@@ -30,7 +31,7 @@ export const ConfirmUI = ({
       </StyledBox>
       <StyledBox>
         <Stack direction="column" rowGap={4} sx={{ padding: '20px' }}>
-          <Typography variant="bodyMd">{description}</Typography>
+          <TypographyContainer direction="row">{description}</TypographyContainer>
         </Stack>
       </StyledBox>
 


### PR DESCRIPTION
## Changes

- [x] changed `confirmUI` to take in description as a `ReactNode`.
- [x] made assignee names bold for re assignment confirmation description.

## Testing Criteria

![image](https://github.com/user-attachments/assets/6958c299-62d8-481e-bd3f-5995e73dcc78)

