### PR TITLE
OUT-1322 | Text on task properties should not be selectable

### DIFF
--- a/src/components/inputs/DatePickerComponent.tsx
+++ b/src/components/inputs/DatePickerComponent.tsx
@@ -101,7 +101,6 @@ export const DatePickerComponent = ({
                 whiteSpace: 'nowrap',
                 overflow: 'hidden',
                 maxWidth: '150px',
-                userSelect: 'none',
               }}
             >
               {value ? formatDate(value) : 'No due date'}

--- a/src/components/inputs/DatePickerComponent.tsx
+++ b/src/components/inputs/DatePickerComponent.tsx
@@ -101,6 +101,7 @@ export const DatePickerComponent = ({
                 whiteSpace: 'nowrap',
                 overflow: 'hidden',
                 maxWidth: '150px',
+                userSelect: 'none',
               }}
             >
               {value ? formatDate(value) : 'No due date'}

--- a/src/components/inputs/DatePickerComponent.tsx
+++ b/src/components/inputs/DatePickerComponent.tsx
@@ -96,7 +96,13 @@ export const DatePickerComponent = ({
               variant="md"
               mt="2px"
               lineHeight={'22px'}
-              sx={{ textOverflow: 'ellipsis', whiteSpace: 'nowrap', overflow: 'hidden', maxWidth: '150px' }}
+              sx={{
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+                overflow: 'hidden',
+                maxWidth: '150px',
+                userSelect: 'none',
+              }}
             >
               {value ? formatDate(value) : 'No due date'}
             </Typography>

--- a/src/components/inputs/DisplaySelector.tsx
+++ b/src/components/inputs/DisplaySelector.tsx
@@ -100,7 +100,7 @@ export const DisplaySelector = ({
             }}
           >
             <ListViewIcon />
-            <Typography variant="bodySm" fontSize={'12px'}>
+            <Typography variant="bodySm" fontSize={'12px'} sx={{ userSelect: 'none' }}>
               List
             </Typography>
           </IconContainer>
@@ -113,7 +113,7 @@ export const DisplaySelector = ({
             }}
           >
             <BoardViewIcon />
-            <Typography variant="bodySm" fontSize={'12px'}>
+            <Typography variant="bodySm" fontSize={'12px'} sx={{ userSelect: 'none' }}>
               Board
             </Typography>
           </IconContainer>

--- a/src/components/inputs/Selector-WorkflowState.tsx
+++ b/src/components/inputs/Selector-WorkflowState.tsx
@@ -78,6 +78,7 @@ export const WorkflowStateSelector = ({
                   overflow: 'hidden',
                   display: { xs: responsiveNoHide ? 'block' : 'none', sm: 'block' },
                   lineHeight: '22px',
+                  userSelect: 'none',
                 }}
               >
                 {value?.name as ReactNode}

--- a/src/components/inputs/Selector-WorkflowState.tsx
+++ b/src/components/inputs/Selector-WorkflowState.tsx
@@ -78,7 +78,6 @@ export const WorkflowStateSelector = ({
                   overflow: 'hidden',
                   display: { xs: responsiveNoHide ? 'block' : 'none', sm: 'block' },
                   lineHeight: '22px',
-                  userSelect: 'none',
                 }}
               >
                 {value?.name as ReactNode}

--- a/src/components/inputs/Selector.tsx
+++ b/src/components/inputs/Selector.tsx
@@ -199,7 +199,6 @@ export default function Selector<T extends keyof SelectorOptionsType>({
                 overflow: 'hidden',
                 maxWidth: '150px',
                 display: { xs: responsiveNoHide ? 'block' : 'none', sm: 'block' },
-                userSelect: 'none',
               }}
             >
               {buttonContent}

--- a/src/components/inputs/Selector.tsx
+++ b/src/components/inputs/Selector.tsx
@@ -199,6 +199,7 @@ export default function Selector<T extends keyof SelectorOptionsType>({
                 overflow: 'hidden',
                 maxWidth: '150px',
                 display: { xs: responsiveNoHide ? 'block' : 'none', sm: 'block' },
+                userSelect: 'none',
               }}
             >
               {buttonContent}

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -4,6 +4,15 @@ import { Inter } from 'next/font/google'
 const inter = Inter({ subsets: ['latin'] })
 
 export const theme = createTheme({
+  components: {
+    MuiTypography: {
+      styleOverrides: {
+        root: {
+          userSelect: 'none', //preventing user to select texts all over the app
+        },
+      },
+    },
+  },
   spacing: 4,
   breakpoints: {
     values: {

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -4,15 +4,6 @@ import { Inter } from 'next/font/google'
 const inter = Inter({ subsets: ['latin'] })
 
 export const theme = createTheme({
-  components: {
-    MuiTypography: {
-      styleOverrides: {
-        root: {
-          userSelect: 'none', //preventing user to select texts all over the app
-        },
-      },
-    },
-  },
   spacing: 4,
   breakpoints: {
     values: {


### PR DESCRIPTION
## Changes

- [x] Disabled text selections on button-less selectors' values with `userSelect : 'none'`

## Testing Criteria
- [LOOM](https://www.loom.com/share/89cff42d34e8472cb25b56acd93af7b5)
