### PR TITLE
OUT-1339 | Selected assignee is not shown at the top of the Assignee Selector on page refresh

### DIFF
--- a/src/components/inputs/Selector.tsx
+++ b/src/components/inputs/Selector.tsx
@@ -111,7 +111,7 @@ export default function Selector<T extends keyof SelectorOptionsType>({
 
   const processedOptions = useMemo(() => {
     if (!currentOption) return options
-    if (!options.some((option) => option === currentOption)) return options
+    if (!options.some((option) => option.id === currentOption.id)) return options
     const filteredOptions = options.filter((option) => option.id !== currentOption.id)
     return [currentOption, ...filteredOptions]
   }, [currentOption, options]) // bring currentOption to the top of the selector options.


### PR DESCRIPTION
## Changes

- [x] added an absolute comparing mechanism by id instead of a reference check for checking weather currentOption is in list of option which previously returned always false in the first render. 

## Testing Criteria

- [LOOM](https://www.loom.com/share/aa00b8722f4d4fc3a380937ab5924875)
