### PR TITLE
OUT-1341 | OUT-1320 | Fix design issues with Assignee Selector

### DIFF
--- a/src/components/inputs/Selector.tsx
+++ b/src/components/inputs/Selector.tsx
@@ -326,7 +326,7 @@ export default function Selector<T extends keyof SelectorOptionsType>({
                 placeholder={placeholder}
                 borderColor="#EDEDF0"
                 padding="4px 12px 8px 12px"
-                basePadding="4px 12px 8px 12px"
+                basePadding="8px 12px 8px 12px"
                 sx={{
                   width: '200px',
                   visibility: { xs: 'none', sm: 'visible' },

--- a/src/components/inputs/Selector.tsx
+++ b/src/components/inputs/Selector.tsx
@@ -184,7 +184,7 @@ export default function Selector<T extends keyof SelectorOptionsType>({
               justifyContent: { xs: 'flex-start', sm: 'flex-start' },
               cursor: disabled ? 'auto' : (cursor ?? 'pointer'),
               borderRadius: '4px',
-              padding: '4px 8px',
+              padding: '8px 8px',
               ':hover': {
                 backgroundColor: disabled ? 'none' : (theme) => theme.color.gray[100],
               },


### PR DESCRIPTION
## Changes

- [x] Fix padding issue for selector textinput
- [x] Fix assignee selector height which is highlighted in hover state

## Testing Criteria

- [x] Add 4px more base padding (total 4 + 4) for OUT-1341
![image](https://github.com/user-attachments/assets/a7342d90-856c-42d2-b462-3ffd5b6499c9)
![image](https://github.com/user-attachments/assets/882051d2-afaf-436a-9ba3-c0b2b6cb2e28)

- [x] Adjust height of reassignment selector
![image](https://github.com/user-attachments/assets/0a527f8e-1e04-4856-9aa3-3fa9b2d0fa32)
![image](https://github.com/user-attachments/assets/446f4759-a756-4e77-b186-aed448f27577)
