### PR TITLE
OUT-1345 | Add ability to navigate selector component with keyboard

### DIFF
--- a/src/app/ui/NewTaskForm.tsx
+++ b/src/app/ui/NewTaskForm.tsx
@@ -394,7 +394,7 @@ const NewTaskFooter = ({
         }}
       >
         <Typography variant="sm">
-          <Box display="flex" gap="4px" alignItems="center">
+          <Box display="flex" gap="4px" alignItems="center" sx={{ color: (theme) => theme.color.gray[600] }}>
             Manage templates
             <ArrowRightIcon />
           </Box>

--- a/src/components/inputs/ListBoxComponent.tsx
+++ b/src/components/inputs/ListBoxComponent.tsx
@@ -2,9 +2,8 @@ import { useKeyboardScroll } from '@/hooks/useKeyboardScroll'
 import { Box, useMediaQuery } from '@mui/material'
 import { useRouter } from 'next/navigation'
 import React, { useRef } from 'react'
-import Scrollbars from 'react-custom-scrollbars'
-
-export type ListboxComponentProps = React.HTMLAttributes<HTMLElement> & {
+import Scrollbars, { ScrollbarProps } from 'react-custom-scrollbars'
+export type ListComponentProps = React.HTMLAttributes<HTMLElement> & {
   children: React.ReactNode
   role: string
   endOption?: React.ReactNode
@@ -12,23 +11,24 @@ export type ListboxComponentProps = React.HTMLAttributes<HTMLElement> & {
   autoHeightMax?: string
 }
 
-const ListboxComponent = React.forwardRef<HTMLDivElement, ListboxComponentProps>((props, ref) => {
+const ListboxComponent = React.forwardRef<HTMLDivElement, ListComponentProps>((props, ref) => {
   const { children, endOption, endOptionHref, autoHeightMax, ...other } = props
   const scrollbarsRef = useRef<Scrollbars>(null)
   const xs = useMediaQuery('(max-width:600px)')
   useKeyboardScroll(scrollbarsRef, { padding: 12 })
   const router = useRouter()
-  console.log('rendering')
+
   return (
-    <div
-      style={{
+    <Box
+      sx={{
         display: 'flex',
         flexDirection: 'column',
         maxHeight: 'none',
       }}
     >
-      <div ref={ref} {...other} style={{ padding: '0px' }}>
+      <Box ref={ref} {...other} style={{ padding: '0px' }}>
         <Scrollbars
+          className={props.className}
           ref={scrollbarsRef}
           renderThumbVertical={(scrollbarProps) => (
             <div
@@ -50,7 +50,7 @@ const ListboxComponent = React.forwardRef<HTMLDivElement, ListboxComponentProps>
                 maxHeight: autoHeightMax ?? (xs ? '175px' : '291px'),
                 inset: '0px',
                 overflow: 'auto',
-                paddingBottom: '18px',
+                paddingBottom: '7px',
                 minHeight: '100%',
               }}
             />
@@ -61,13 +61,16 @@ const ListboxComponent = React.forwardRef<HTMLDivElement, ListboxComponentProps>
           autoHideTimeout={500}
           autoHideDuration={500}
           hideTracksWhenNotNeeded
-          universal
         >
           {props.children}
         </Scrollbars>
-      </div>
-      {endOption && <Box onMouseDown={() => endOptionHref && router.push(endOptionHref)}>{endOption}</Box>}
-    </div>
+      </Box>
+      {endOption && (
+        <Box ref={ref} onMouseDown={() => endOptionHref && router.push(endOptionHref)}>
+          {endOption}
+        </Box>
+      )}
+    </Box>
   )
 })
 

--- a/src/components/inputs/ListBoxComponent.tsx
+++ b/src/components/inputs/ListBoxComponent.tsx
@@ -1,0 +1,76 @@
+import { useKeyboardScroll } from '@/hooks/useKeyboardScroll'
+import { Box, useMediaQuery } from '@mui/material'
+import { useRouter } from 'next/navigation'
+import React, { useRef } from 'react'
+import Scrollbars from 'react-custom-scrollbars'
+
+export type ListboxComponentProps = React.HTMLAttributes<HTMLElement> & {
+  children: React.ReactNode
+  role: string
+  endOption?: React.ReactNode
+  endOptionHref?: string
+  autoHeightMax?: string
+}
+
+const ListboxComponent = React.forwardRef<HTMLDivElement, ListboxComponentProps>((props, ref) => {
+  const { children, endOption, endOptionHref, autoHeightMax, ...other } = props
+  const scrollbarsRef = useRef<Scrollbars>(null)
+  const xs = useMediaQuery('(max-width:600px)')
+  useKeyboardScroll(scrollbarsRef, { padding: 12 })
+  const router = useRouter()
+  console.log('rendering')
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        maxHeight: 'none',
+      }}
+    >
+      <div ref={ref} {...other} style={{ padding: '0px' }}>
+        <Scrollbars
+          ref={scrollbarsRef}
+          renderThumbVertical={(scrollbarProps) => (
+            <div
+              {...scrollbarProps}
+              className="thumb"
+              style={{
+                borderRadius: '6px',
+                backgroundColor: 'rgba(0, 0, 0, 0.5)',
+              }}
+            />
+          )}
+          renderView={(viewProps) => (
+            <div
+              {...viewProps}
+              style={{
+                ...viewProps.style,
+                borderRadius: '0',
+                position: 'relative',
+                maxHeight: autoHeightMax ?? (xs ? '175px' : '291px'),
+                inset: '0px',
+                overflow: 'auto',
+                paddingBottom: '18px',
+                minHeight: '100%',
+              }}
+            />
+          )}
+          autoHide
+          autoHeight
+          autoHeightMax={autoHeightMax ?? (xs ? '172px' : '291px')}
+          autoHideTimeout={500}
+          autoHideDuration={500}
+          hideTracksWhenNotNeeded
+          universal
+        >
+          {props.children}
+        </Scrollbars>
+      </div>
+      {endOption && <Box onMouseDown={() => endOptionHref && router.push(endOptionHref)}>{endOption}</Box>}
+    </div>
+  )
+})
+
+ListboxComponent.displayName = 'ListboxComponent'
+
+export default ListboxComponent

--- a/src/components/inputs/Selector.tsx
+++ b/src/components/inputs/Selector.tsx
@@ -1,20 +1,19 @@
-import { Box, Button, Popper, Stack, Typography } from '@mui/material'
-import { StyledAutocomplete } from '@/components/inputs/Autocomplete'
-import { statusIcons } from '@/utils/iconMatcher'
-import { useFocusableInput } from '@/hooks/useFocusableInput'
-import { HTMLAttributes, ReactNode, useEffect, useMemo, useState } from 'react'
-import { StyledTextField } from './TextField'
-import { WorkflowStateResponse } from '@/types/dto/workflowStates.dto'
-import { IAssigneeCombined, Sizes, IExtraOption, ITemplate, UserTypesName } from '@/types/interfaces'
-import { TruncateMaxNumber } from '@/types/constants'
-import { truncateText } from '@/utils/truncateText'
 import { CopilotAvatar } from '@/components/atoms/CopilotAvatar'
-import { getAssigneeName } from '@/utils/assignee'
 import { StyledHelperText } from '@/components/error/FormHelperText'
-import React from 'react'
-import { ListComponent } from '@/components/inputs/ListComponent'
+import { StyledAutocomplete } from '@/components/inputs/Autocomplete'
+import { useFocusableInput } from '@/hooks/useFocusableInput'
+import { TruncateMaxNumber } from '@/types/constants'
+import { WorkflowStateResponse } from '@/types/dto/workflowStates.dto'
+import { IAssigneeCombined, IExtraOption, ITemplate, Sizes, UserTypesName } from '@/types/interfaces'
+import { getAssigneeName } from '@/utils/assignee'
+import { statusIcons } from '@/utils/iconMatcher'
+import { truncateText } from '@/utils/truncateText'
+import { Box, Button, Popper, Stack, Typography } from '@mui/material'
 import { ModifierArguments } from '@popperjs/core'
 import { Property } from 'csstype'
+import React, { HTMLAttributes, ReactNode, useEffect, useMemo, useState } from 'react'
+import ListboxComponent, { type ListboxComponentProps } from './ListBoxComponent'
+import { StyledTextField } from './TextField'
 
 export enum SelectorType {
   ASSIGNEE_SELECTOR = 'assigneeSelector',
@@ -167,7 +166,15 @@ export default function Selector<T extends keyof SelectorOptionsType>({
   }
 
   const ListWithEndOption = (props: JSX.IntrinsicElements['div']) => (
-    <ListComponent {...props} endOption={endOption} endOptionHref={endOptionHref} autoHeightMax={listAutoHeightMax} />
+    <ListboxComponent
+      {...props}
+      role="listbox"
+      autoHeightMax={listAutoHeightMax}
+      endOption={endOption}
+      endOptionHref={endOptionHref}
+    >
+      {props.children}
+    </ListboxComponent>
   )
 
   return (
@@ -240,7 +247,14 @@ export default function Selector<T extends keyof SelectorOptionsType>({
           blurOnSelect={true}
           openOnFocus
           onKeyDown={handleKeyDown}
-          ListboxProps={{ sx: { maxHeight: { xs: '175px', sm: '291px' }, padding: '0px 0px 8px 0px' } }}
+          ListboxProps={
+            {
+              sx: { maxHeight: { xs: '175px', sm: '291px' }, padding: '0px 0px 8px 0px' },
+              endOption: endOption,
+              endOptionHref: endOptionHref,
+              autoHeightMax: listAutoHeightMax,
+            } as unknown as ListboxComponentProps
+          }
           options={extraOption ? [extraOption, ...processedOptions] : processedOptions}
           value={value}
           onChange={(_, newValue: unknown) => {
@@ -250,7 +264,15 @@ export default function Selector<T extends keyof SelectorOptionsType>({
               setInputStatusValue('')
             }
           }}
-          ListboxComponent={ListWithEndOption}
+          ListboxComponent={
+            ListboxComponent as React.ComponentType<
+              React.HTMLAttributes<HTMLElement> & {
+                endOption?: React.ReactNode
+                endOptionHref?: string
+                autoHeightMax?: string
+              }
+            >
+          }
           getOptionLabel={(option: unknown) => detectSelectorType(option)}
           groupBy={(option: unknown) => {
             if (standaloneOptionIds.has((option as SelectorOptionsType[typeof selectorType]).id)) {

--- a/src/hooks/useKeyboardScroll.ts
+++ b/src/hooks/useKeyboardScroll.ts
@@ -1,0 +1,43 @@
+import { RefObject, useEffect } from 'react'
+import Scrollbars from 'react-custom-scrollbars'
+
+interface UseKeyboardScrollOptions {
+  padding?: number
+}
+// useKeyboardScroll is a hook made to add functionality of keyboard scrolling to the custom scrollbar - 'react-custom-scrollbars' used in our application.
+export const useKeyboardScroll = (scrollbarsRef: RefObject<Scrollbars>, options: UseKeyboardScrollOptions = {}) => {
+  const { padding = 8 } = options
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return
+
+      setTimeout(() => {
+        const input = document.querySelector('[role="combobox"]') as HTMLElement
+        if (!input) return
+
+        const activeId = input.getAttribute('aria-activedescendant')
+        if (!activeId) return
+
+        const activeElement = document.getElementById(activeId)
+        if (!activeElement || !scrollbarsRef.current) return
+
+        const container = scrollbarsRef.current.getValues()
+        const activeRect = activeElement.getBoundingClientRect()
+        const containerRect = (scrollbarsRef.current as any).container.getBoundingClientRect()
+
+        const elementTop = activeRect.top - containerRect.top
+        const elementBottom = activeRect.bottom - containerRect.top
+
+        if (elementTop < 0) {
+          scrollbarsRef.current.scrollTop(container.scrollTop + elementTop - padding)
+        } else if (elementBottom > containerRect.height) {
+          scrollbarsRef.current.scrollTop(container.scrollTop + (elementBottom - containerRect.height) + padding)
+        }
+      }, 0)
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [scrollbarsRef, padding])
+}


### PR DESCRIPTION
## Changes

- [x] created a new component for ListBoxComponent to support keyboard navigation. 
- [x] changed the flow of the original ListBoxComponent with endOptions which resulted in a lot of change in the code base.  

## Testing Criteria

- [LOOM](https://www.loom.com/share/defefb179a604eb288f78a00c20c0281)

## Notes

- This is a temporary patch/reference PR. Lets wait to implement new custom scrollbar because the existing custom scrollbar caused some issues and changes in this PR and the package is very old. PR achieves the fix with a hacky javascript DOM manipulation. 