### PR TITLE
OUT-1349 | Replace Tiptap Read-only mode with markup content

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "bottleneck": "^2.19.5",
     "copilot-node-sdk": "^3.5.0",
     "dayjs": "^1.11.10",
+    "dompurify": "^3.2.4",
     "http-status": "^1.7.4",
     "immutability-helper": "^3.1.1",
     "jsdom": "^25.0.1",

--- a/src/components/SafeHTMLViewer/index.tsx
+++ b/src/components/SafeHTMLViewer/index.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import DOMPurify from 'dompurify'
+import 'tapwrite/dist/assets/Tapwrite.css'
+
+const SafeHTMLViewer = ({ content, className }: { content: string; className?: string }) => {
+  const clean = DOMPurify.sanitize(content, {
+    ALLOWED_TAGS: [
+      'p',
+      'br',
+      'strong',
+      'em',
+      'u',
+      'strike',
+      'h1',
+      'h2',
+      'h3',
+      'ul',
+      'ol',
+      'li',
+      'blockquote',
+      'code',
+      'pre',
+      'a',
+    ],
+    ALLOWED_ATTR: ['href', 'target', 'rel'],
+  })
+  return <div className={`${className} tiptap`} dangerouslySetInnerHTML={{ __html: clean }} />
+}
+
+export default SafeHTMLViewer

--- a/src/components/cards/CommentCard.tsx
+++ b/src/components/cards/CommentCard.tsx
@@ -6,6 +6,7 @@ import { ListBtn } from '@/components/buttons/ListBtn'
 import { PrimaryBtn } from '@/components/buttons/PrimaryBtn'
 import { MenuBox } from '@/components/inputs/MenuBox'
 import { ConfirmDeleteUI } from '@/components/layouts/ConfirmDeleteUI'
+import SafeHTMLViewer from '@/components/SafeHTMLViewer'
 import { useWindowWidth } from '@/hooks/useWindowWidth'
 import { TrashIcon } from '@/icons'
 import { selectAuthDetails } from '@/redux/features/authDetailsSlice'
@@ -122,12 +123,7 @@ export const CommentCard = ({
           )}
         </Stack>
 
-        <Tapwrite
-          content={(comment.details as { content: string }).content}
-          getContent={() => {}}
-          readonly
-          editorClass="tapwrite-comment"
-        />
+        <SafeHTMLViewer content={(comment.details as { content: string }).content} className="tapwrite-comment" />
 
         {Array.isArray((comment as LogResponse).details?.replies) &&
           ((comment as LogResponse).details.replies as LogResponse[]).map((item: LogResponse) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2948,6 +2948,11 @@
   resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.5.tgz#cb6e2a691b70cb177c6e3ae9c1d2e8b2ea8cd304"
   integrity sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==
 
+"@types/trusted-types@^2.0.7":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.7.tgz#baccb07a970b91707df3a3e8ba6896c57ead2d11"
+  integrity sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==
+
 "@types/use-sync-external-store@^0.0.3":
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz#b6725d5f4af24ace33b36fafd295136e75509f43"
@@ -4028,6 +4033,13 @@ domhandler@^5.0.2, domhandler@^5.0.3:
   integrity sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==
   dependencies:
     domelementtype "^2.3.0"
+
+dompurify@^3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.2.4.tgz#af5a5a11407524431456cf18836c55d13441cd8e"
+  integrity sha512-ysFSFEDVduQpyhzAob/kkuJjf5zWkZD8/A9ywSp1byueyuCfHamrCBa14/Oc2iiB0e51B+NpxSl5gmzn+Ms/mg==
+  optionalDependencies:
+    "@types/trusted-types" "^2.0.7"
 
 domutils@^3.0.1:
   version "3.1.0"


### PR DESCRIPTION
## Changes

- [x] Replaced readonly comments with markup instead of rendering another tapwrite instance. 

## Remaining 

- [x] tapwrite version upgrade. 
- [x] Markup that supports Attachment, Image and mention extensions from tapwrite.

