### PR TITLE
OUT-1303 | Fix VERCEL_URL navigation logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "react-dnd-touch-backend": "^16.0.1",
     "react-dom": "^18",
     "react-redux": "^9.1.0",
+    "server-only": "^0.0.1",
     "supabase": "^2.1.1",
     "swr": "^2.2.5",
     "tapwrite": "1.1.82",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -95,6 +95,8 @@ export default async function Main({ searchParams }: { searchParams: { token: st
     getWorkspace(token),
   ])
 
+  console.log('yyy', token, tokenPayload, userRole, viewSettings, workflowStates, tasks.length, workspace)
+
   console.info(`app/page.tsx | Serving user ${token} with payload`, tokenPayload)
   return (
     <ClientSideStateUpdate

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -95,8 +95,6 @@ export default async function Main({ searchParams }: { searchParams: { token: st
     getWorkspace(token),
   ])
 
-  console.log('yyy', token, tokenPayload, userRole, viewSettings, workflowStates, tasks.length, workspace)
-
   console.info(`app/page.tsx | Serving user ${token} with payload`, tokenPayload)
   return (
     <ClientSideStateUpdate

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,5 +1,3 @@
-import { z } from 'zod'
-
 export const copilotAPIKey = process.env.COPILOT_API_KEY || ''
 export const tasksAppId = process.env.COPILOT_TASKS_APP_ID || ''
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -3,20 +3,12 @@ import { z } from 'zod'
 export const copilotAPIKey = process.env.COPILOT_API_KEY || ''
 export const tasksAppId = process.env.COPILOT_TASKS_APP_ID || ''
 
-console.log(
-  'qqqq',
-  process.env.VERCEL_ENV,
-  process.env.VERCEL_BRANCH_URL,
-  process.env.VERCEL_PROJECT_PRODUCTION_URL,
-  process.env.VERCEL_URL,
-)
-
 export const apiUrl =
   process.env.VERCEL_ENV === 'production'
-    ? `https://${z.string().parse(process.env.VERCEL_PROJECT_PRODUCTION_URL)}`
+    ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
     : process.env.VERCEL_ENV === 'preview'
-      ? `https://${z.string().parse(process.env.VERCEL_BRANCH_URL)}`
-      : `http://${z.string().parse(process.env.VERCEL_URL)}`
+      ? `https://${process.env.VERCEL_BRANCH_URL}`
+      : `http://${process.env.VERCEL_URL}`
 
 export const isProd = process.env.NEXT_PUBLIC_VERCEL_ENV === 'production'
 export const SentryConfig = {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -3,6 +3,14 @@ import { z } from 'zod'
 export const copilotAPIKey = process.env.COPILOT_API_KEY || ''
 export const tasksAppId = process.env.COPILOT_TASKS_APP_ID || ''
 
+console.log(
+  'qqqq',
+  process.env.VERCEL_ENV,
+  process.env.VERCEL_BRANCH_URL,
+  process.env.VERCEL_PROJECT_PRODUCTION_URL,
+  process.env.VERCEL_URL,
+)
+
 export const apiUrl =
   process.env.VERCEL_ENV === 'production'
     ? `https://${z.string().parse(process.env.VERCEL_PROJECT_PRODUCTION_URL)}`

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,7 +1,13 @@
 export const copilotAPIKey = process.env.COPILOT_API_KEY || ''
 export const tasksAppId = process.env.COPILOT_TASKS_APP_ID || ''
 
-export const apiUrl = `${process.env.VERCEL_ENV === 'development' ? 'http://' : 'https://'}${process.env.VERCEL_URL}`
+export const apiUrl =
+  process.env.VERCEL_ENV === 'production'
+    ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
+    : process.env.VERCEL_ENV === 'preview'
+      ? `https://${process.env.VERCEL_BRANCH_URL}`
+      : `http://${process.env.VERCEL_URL}`
+
 export const isProd = process.env.NEXT_PUBLIC_VERCEL_ENV === 'production'
 export const SentryConfig = {
   DSN: process.env.NEXT_PUBLIC_SENTRY_DSN || '',

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,12 +1,14 @@
+import { z } from 'zod'
+
 export const copilotAPIKey = process.env.COPILOT_API_KEY || ''
 export const tasksAppId = process.env.COPILOT_TASKS_APP_ID || ''
 
 export const apiUrl =
   process.env.VERCEL_ENV === 'production'
-    ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
+    ? `https://${z.string().parse(process.env.VERCEL_PROJECT_PRODUCTION_URL)}`
     : process.env.VERCEL_ENV === 'preview'
-      ? `https://${process.env.VERCEL_BRANCH_URL}`
-      : `http://${process.env.VERCEL_URL}`
+      ? `https://${z.string().parse(process.env.VERCEL_BRANCH_URL)}`
+      : `http://${z.string().parse(process.env.VERCEL_URL)}`
 
 export const isProd = process.env.NEXT_PUBLIC_VERCEL_ENV === 'production'
 export const SentryConfig = {

--- a/src/hoc/RealTime.tsx
+++ b/src/hoc/RealTime.tsx
@@ -179,7 +179,7 @@ export const RealTime = ({
         handleTaskRealTimeUpdates,
       )
       .subscribe()
-    console.info('Connected to realtime channel', channel)
+    // console.info('Connected to realtime channel', channel)
 
     return () => {
       supabase.removeChannel(channel)

--- a/src/utils/redirect.ts
+++ b/src/utils/redirect.ts
@@ -4,10 +4,6 @@ import { z } from 'zod'
 import { UserType } from '@/types/interfaces'
 
 export const redirectIfTaskCta = (searchParams: Record<string, string>, userType: UserType) => {
-  console.log('apiUrl', apiUrl)
-  console.log('VERCEL_PROJECT_PRODUCTION_URL', process.env.VERCEL_PROJECT_PRODUCTION_URL)
-  console.log('VERCEL_BRANCH_URL', process.env.VERCEL_BRANCH_URL)
-
   const taskId = z.string().safeParse(searchParams.taskId)
   const commentId = z.string().safeParse(searchParams.commentId)
 

--- a/src/utils/redirect.ts
+++ b/src/utils/redirect.ts
@@ -1,3 +1,5 @@
+import 'server-only'
+
 import { apiUrl } from '@/config'
 import { redirect } from 'next/navigation'
 import { z } from 'zod'

--- a/src/utils/redirect.ts
+++ b/src/utils/redirect.ts
@@ -6,7 +6,6 @@ import { z } from 'zod'
 import { UserType } from '@/types/interfaces'
 
 export const redirectIfTaskCta = (searchParams: Record<string, string>, userType: UserType) => {
-  console.log('qqq', apiUrl)
   const taskId = z.string().safeParse(searchParams.taskId)
   const commentId = z.string().safeParse(searchParams.commentId)
 

--- a/src/utils/redirect.ts
+++ b/src/utils/redirect.ts
@@ -4,6 +4,10 @@ import { z } from 'zod'
 import { UserType } from '@/types/interfaces'
 
 export const redirectIfTaskCta = (searchParams: Record<string, string>, userType: UserType) => {
+  console.log('apiUrl', apiUrl)
+  console.log('VERCEL_PROJECT_PRODUCTION_URL', process.env.VERCEL_PROJECT_PRODUCTION_URL)
+  console.log('VERCEL_BRANCH_URL', process.env.VERCEL_BRANCH_URL)
+
   const taskId = z.string().safeParse(searchParams.taskId)
   const commentId = z.string().safeParse(searchParams.commentId)
 

--- a/src/utils/redirect.ts
+++ b/src/utils/redirect.ts
@@ -4,6 +4,7 @@ import { z } from 'zod'
 import { UserType } from '@/types/interfaces'
 
 export const redirectIfTaskCta = (searchParams: Record<string, string>, userType: UserType) => {
+  console.log('qqq', apiUrl)
   const taskId = z.string().safeParse(searchParams.taskId)
   const commentId = z.string().safeParse(searchParams.commentId)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7050,6 +7050,11 @@ semver@^7.5.2, semver@^7.5.3, semver@^7.5.4, semver@^7.6.3:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.3.tgz#980f7b5550bc175fb4dc09403085627f9eb33143"
   integrity sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==
 
+server-only@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/server-only/-/server-only-0.0.1.tgz#0f366bb6afb618c37c9255a314535dc412cd1c9e"
+  integrity sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==
+
 set-function-length@^1.2.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/set-function-length/-/set-function-length-1.2.2.tgz#aac72314198eaed975cf77b2c3b6b880695e5449"


### PR DESCRIPTION
## Changes

- [x] Use `VERCEL_BRANCH_URL` and `VERCEL_PROJECT_PRODUCTION_URL` along with `VERCEL_URL` to always get the cannonical URL for any environment (prod domain for production, branch suffixed domain for preview and defaults for dev)
- [x] Fixed condition where `VERCEL_ENV` was hardcoded to production for both prod and preview environments (removed VERCEL_ENV since it is autoinserted as a system environment var on build & runtime [[Ref](https://vercel.com/docs/projects/environment-variables/system-environment-variables)]) 

## Testing Criteria

- [x] Checking taskId redirect in preview URL:


[Screencast from 2025-02-05 17-36-35.webm](https://github.com/user-attachments/assets/fa3ff985-3dd1-4cb2-97e3-e8dfc209d852)

- [x] Checking taskId redirect in preview URL:

[Screencast from 2025-02-05 17-38-06.webm](https://github.com/user-attachments/assets/13d395ce-632f-468d-bf3f-8aa7312573df)

