### PR TITLE
OUT-1352 | Implement task queue for notifications on task update

### DIFF
--- a/src/app/api/notification/notification.service.ts
+++ b/src/app/api/notification/notification.service.ts
@@ -35,6 +35,7 @@ export class NotificationService extends BaseService {
         // If any of the given action is not present in details obj, that type of notification is not sent
         deliveryTargets: { inProduct, email },
       }
+      console.info('NotificationService#create | Creating single notification:', notificationDetails)
 
       const notification = await copilot.createNotification(notificationDetails)
       // NOTE: There are cases where task.assigneeType does not account for IU notification!
@@ -94,6 +95,8 @@ export class NotificationService extends BaseService {
             recipientId,
             deliveryTargets: { inProduct, email },
           }
+          console.info('NotificationService#bulkCreate | Creating single notification:', notificationDetails)
+
           notifications.push(await copilot.createNotification(notificationDetails))
         } catch (err: unknown) {
           console.error(`Failed to send notifications to ${recipientId}:`, err)

--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -1,5 +1,5 @@
 import { MAX_FETCH_ASSIGNEE_COUNT } from '@/constants/users'
-import { sendTaskCreateNotifications } from '@/jobs/notifications'
+import { sendTaskCreateNotifications, sendTaskUpdateNotifications } from '@/jobs/notifications'
 import { ClientResponse, CompanyResponse, InternalUsers } from '@/types/common'
 import { CreateTaskRequest, UpdateTaskRequest } from '@/types/dto/tasks.dto'
 import { CopilotAPI } from '@/utils/CopilotAPI'
@@ -271,8 +271,7 @@ export class TasksService extends BaseService {
       await activityLogger.logTaskUpdated(prevTask)
     }
 
-    const taskNotificationsSevice = new TaskNotificationsService(this.user)
-    await taskNotificationsSevice.sendTaskUpdateNotifications(prevTask, updatedTask)
+    await sendTaskUpdateNotifications.trigger({ prevTask, updatedTask, user: this.user })
 
     return updatedTask
   }

--- a/src/jobs/notifications/index.ts
+++ b/src/jobs/notifications/index.ts
@@ -1,1 +1,2 @@
 export { sendTaskCreateNotifications } from './send-task-create-notifications'
+export { sendTaskUpdateNotifications } from './send-task-update-notifications'

--- a/src/jobs/notifications/send-task-create-notifications.ts
+++ b/src/jobs/notifications/send-task-create-notifications.ts
@@ -20,7 +20,7 @@ export const sendTaskCreateNotifications = task({
     await taskNotificationsSevice.sendTaskCreateNotifications(task)
 
     return {
-      message: `Sent notifications for taskId ${task.id} successfully`,
+      message: `Sent create notifications for taskId ${task.id} successfully`,
     }
   },
 })

--- a/src/jobs/notifications/send-task-update-notifications.ts
+++ b/src/jobs/notifications/send-task-update-notifications.ts
@@ -10,7 +10,7 @@ type UpdateTaskNotificationPayload = {
 }
 
 export const sendTaskUpdateNotifications = task({
-  id: 'send-task-create-notifications',
+  id: 'send-task-update-notifications',
   machine: { preset: 'medium-1x' },
 
   run: async (payload: UpdateTaskNotificationPayload, { ctx }) => {

--- a/src/jobs/notifications/send-task-update-notifications.ts
+++ b/src/jobs/notifications/send-task-update-notifications.ts
@@ -1,0 +1,27 @@
+import { TaskNotificationsService } from '@/app/api/tasks/task-notifications.service'
+import { TaskWithWorkflowState } from '@/types/db'
+import User from '@api/core/models/User.model'
+import { logger, task } from '@trigger.dev/sdk/v3'
+
+type UpdateTaskNotificationPayload = {
+  user: User
+  prevTask: TaskWithWorkflowState
+  updatedTask: TaskWithWorkflowState
+}
+
+export const sendTaskUpdateNotifications = task({
+  id: 'send-task-create-notifications',
+  machine: { preset: 'medium-1x' },
+
+  run: async (payload: UpdateTaskNotificationPayload, { ctx }) => {
+    logger.log('Sending task update notifications for:', { payload, ctx })
+
+    const { prevTask, updatedTask, user } = payload
+    const taskNotificationsSevice = new TaskNotificationsService(user)
+    await taskNotificationsSevice.sendTaskUpdateNotifications(prevTask, updatedTask)
+
+    return {
+      message: `Sent update notifications for taskId ${updatedTask.id} successfully`,
+    }
+  },
+})


### PR DESCRIPTION
## Changes

- [x] Offload notifications on task update to trigger on a `medium-1x` machine
- [x] Update copy for task create message  

## Testing Criteria

- [x] Workflow state update

![image](https://github.com/user-attachments/assets/5f767ef8-b859-41d8-8686-9cce085ae5a8)

- [x] Reassignment

![image](https://github.com/user-attachments/assets/76ba6570-115a-41b4-8071-a18e75483b68)


