### PR TITLE
OUT-1377 | Task description dissapearing when opening tasks.

### DIFF
--- a/src/app/detail/ui/TaskEditor.tsx
+++ b/src/app/detail/ui/TaskEditor.tsx
@@ -169,7 +169,11 @@ export const TaskEditor = ({
       <Box mt="12px" sx={{ height: '100%', width: '100%' }}>
         <Tapwrite
           content={updateDetail}
-          getContent={handleDetailChange}
+          getContent={(content: string) => {
+            if (updateDetail !== '') {
+              handleDetailChange(content)
+            }
+          }}
           readonly={!isEditable}
           editorClass=""
           placeholder="Add description..."


### PR DESCRIPTION
## Changes

- [x] added a check for updating task description to prevent it from updating to empty on first load.


