### PR TITLE
OUT-1381 | Enable attachments and images in comments

### DIFF
--- a/src/components/AttachmentLayout.tsx
+++ b/src/components/AttachmentLayout.tsx
@@ -30,7 +30,6 @@ const AttachmentLayout: React.FC<AttachmentLayoutProps> = ({ selected, src, file
     padding: { sm: '4px 8px', md: '4px 12px 4px 8px' },
     border: (theme) => `1px solid ${theme.color.gray[selected ? 600 : 150]}`,
     background: '#fff',
-    boxShadow: '0px 3px 4px 0px rgba(16, 17, 19, 0.06), 0px 4px 11px 0px rgba(20, 21, 24, 0.18)',
 
     '@media (max-width: 600px)': {
       '&:active': {

--- a/src/components/cards/CommentCard.tsx
+++ b/src/components/cards/CommentCard.tsx
@@ -2,6 +2,7 @@
 
 import { DotSeparator } from '@/app/detail/ui/DotSeparator'
 import { BoldTypography, CommentCardContainer, StyledModal, StyledTypography } from '@/app/detail/ui/styledComponent'
+import AttachmentLayout from '@/components/AttachmentLayout'
 import { ListBtn } from '@/components/buttons/ListBtn'
 import { PrimaryBtn } from '@/components/buttons/PrimaryBtn'
 import { MenuBox } from '@/components/inputs/MenuBox'
@@ -127,6 +128,7 @@ export const CommentCard = ({
           getContent={() => {}}
           readonly
           editorClass="tapwrite-comment"
+          attachmentLayout={AttachmentLayout}
         />
 
         {Array.isArray((comment as LogResponse).details?.replies) &&
@@ -150,6 +152,7 @@ export const CommentCard = ({
                   getContent={() => {}}
                   readonly
                   editorClass="tapwrite-comment"
+                  attachmentLayout={AttachmentLayout}
                 />
               </Stack>
             )
@@ -168,6 +171,7 @@ export const CommentCard = ({
                 placeholder="Leave a reply..."
                 suggestions={assigneeSuggestions}
                 editorClass="tapwrite-reply-input"
+                attachmentLayout={AttachmentLayout}
               />
               <InputAdornment
                 position="end"


### PR DESCRIPTION
## Changes

- [x] enabled attachments and images in comment card and comment input.
- [x] attachment layout provided for tapwrite instances on comment card and comment input.  

## Testing Criteria

![image](https://github.com/user-attachments/assets/27b20bc1-6456-4a6e-abc5-8b874417c873)

![image](https://github.com/user-attachments/assets/a94c233a-8beb-4fe1-b026-4212b4123c70)

