### PR TITLE
OUT-1390 | Fix Unique Constraint issue in InternalUserNotifications table while deleting notifications

### DIFF
--- a/src/app/api/notification/notification.service.ts
+++ b/src/app/api/notification/notification.service.ts
@@ -143,7 +143,7 @@ export class NotificationService extends BaseService {
     // Hard delete this since we are not marking these as read, but deleting them
     await this.db.$executeRaw`
       DELETE FROM "InternalUserNotifications"
-      WHERE "taskId" = ${taskId}
+      WHERE "taskId" = ${taskId}::uuid
     `
   }
 

--- a/src/app/api/notification/notification.service.ts
+++ b/src/app/api/notification/notification.service.ts
@@ -140,7 +140,11 @@ export class NotificationService extends BaseService {
     }
     console.info(`Deleting all notifications triggerd by task ${taskId}`)
     await Promise.all(markAsReadPromises)
-    await this.db.internalUserNotification.deleteMany({ where: { taskId } })
+    // Hard delete this since we are not marking these as read, but deleting them
+    await this.db.$executeRaw`
+      DELETE FROM "InternalUserNotifications"
+      WHERE "taskId" = ${taskId}
+    `
   }
 
   /**


### PR DESCRIPTION
## Changes

- [x] The cause of the unique constraint violation was that multiple tasks were being softdeleted at the same time. We have the unique constraint on taskId + userId + deletedAt.
- [x] Hard delete these notifications since we are deleting them from Copilot, not marking them as read. 

## Testing Criteria

- [x] Screencast (The notification dispatch times are very long because of a temporary infra issue on Trigger's end)

 
[Screencast from 2025-02-10 16-59-58.webm](https://github.com/user-attachments/assets/b09f3c2d-6ad9-4754-acf1-2f035be75191)

- [x] Successful job run

![image](https://github.com/user-attachments/assets/fb1210e1-e928-4c18-b168-530111d9ce48)

