### PR TITLE
OUT-1426 | Comment box area has inconsistent width

### DIFF
--- a/src/components/buttonsGroup/EditCommentButtons.tsx
+++ b/src/components/buttonsGroup/EditCommentButtons.tsx
@@ -20,6 +20,8 @@ export const EditCommentButtons = ({
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
+          wordBreak: 'normal',
+          whiteSpace: 'normal',
         }}
       >
         <Divider orientation="vertical" sx={{ height: '28px' }} />
@@ -28,7 +30,12 @@ export const EditCommentButtons = ({
           outlined
           handleClick={cancelEdit}
           buttonContent={
-            <Typography variant="sm" sx={{ color: (theme) => theme.color.text.text }}>
+            <Typography
+              variant="sm"
+              sx={{
+                color: (theme) => theme.color.text.text,
+              }}
+            >
               Cancel
             </Typography>
           }

--- a/src/components/cards/CommentCard.tsx
+++ b/src/components/cards/CommentCard.tsx
@@ -124,6 +124,7 @@ export const CommentCard = ({
       onMouseLeave={() => setIsHovered(false)}
       sx={{
         backgroundColor: (theme) => (isReadOnly ? `${theme.color.gray[100]}` : `${theme.color.base.white}`),
+        overflow: 'hidden',
       }}
     >
       <Stack direction="column" rowGap={'2px'}>
@@ -199,10 +200,12 @@ export const CommentCard = ({
           hardbreak
           parentContainerStyle={{
             width: '100%',
-            height: '100%',
-            maxWidth: '600px',
+            maxWidth: '100%',
             display: 'flex',
             flexDirection: 'column',
+            overflow: 'hidden',
+            wordBreak: 'break-word',
+            whiteSpace: 'pre-wrap',
           }}
           endButtons={<EditCommentButtons cancelEdit={cancelEdit} handleEdit={handleEdit} isReadOnly={isReadOnly} />}
           handleImageClick={handleImagePreview}

--- a/src/components/inputs/CommentInput.tsx
+++ b/src/components/inputs/CommentInput.tsx
@@ -147,10 +147,13 @@ export const CommentInput = ({ createComment, task_id }: Prop) => {
           }}
           parentContainerStyle={{
             width: '100%',
+            maxWidth: '100%',
             height: '100%',
-            maxWidth: '566px',
             display: 'flex',
             flexDirection: 'column',
+            overflow: 'hidden',
+            wordBreak: 'break-word',
+            whiteSpace: 'pre-wrap',
           }}
           uploadFn={uploadFn}
           deleteEditorAttachments={(url) => deleteEditorAttachmentsHandler(url, token ?? '', task_id, null)}


### PR DESCRIPTION
## Changes

- [x] added relevant styles for parent container of tapwrite in comments to make width the same for all the components. 
- [x] Disregarded the idea of having fixed width for comment containers, instead the comment containers now have width responsively which looks much cleaner. 

## Testing Criteria

- [LOOM](https://www.loom.com/share/54cd0f74b5d0410eb99445d3caed0627)


