### PR TITLE
OUT-1424 | Remove console log for 'Comment cannot be empty'

### DIFF
--- a/src/components/inputs/CommentInput.tsx
+++ b/src/components/inputs/CommentInput.tsx
@@ -31,6 +31,8 @@ export const CommentInput = ({ createComment, task_id }: Prop) => {
   const currentUserId = tokenPayload?.internalUserId ?? tokenPayload?.clientId
   const currentUserDetails = assignee.find((el) => el.id === currentUserId)
 
+  const [isFocused, setIsFocused] = useState(false)
+
   const handleSubmit = () => {
     let content = detail
     const END_P = '<p></p>'
@@ -47,13 +49,15 @@ export const CommentInput = ({ createComment, task_id }: Prop) => {
       }
       createComment(commentPayload)
       setDetail('') // Clear the input after creating comment
-    } else {
-      console.info('Comment cannot be empty.')
     }
   }
   // useEffect to handle keydown event for Enter key
+
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
+      if (!isFocused) {
+        return
+      }
       if (event.key === 'Enter' && !event.shiftKey && !isListOrMenuActive) {
         event.preventDefault() // Prevent new line in the editor
         handleSubmit()
@@ -73,7 +77,7 @@ export const CommentInput = ({ createComment, task_id }: Prop) => {
     return () => {
       window.removeEventListener('keydown', handleKeyDown)
     }
-  }, [detail, isListOrMenuActive]) // Depend on detail to ensure the latest state is captured
+  }, [detail, isListOrMenuActive, isFocused]) // Depend on detail to ensure the latest state is captured
 
   const uploadFn = token
     ? async (file: File) => {
@@ -133,6 +137,8 @@ export const CommentInput = ({ createComment, task_id }: Prop) => {
         onDragEnter={handleDragEnter}
         onDragLeave={handleDragLeave}
         onDrop={handleDrop}
+        onBlur={() => setIsFocused(false)}
+        onFocus={() => setIsFocused(true)}
       >
         <Tapwrite
           content={detail}


### PR DESCRIPTION
## Changes

- [x] handled enter key events on comment input only when the comment input is focused. Previously, even if we were editing description then they enter key event was triggered for comment input. 
- [x] removed the log.


