### PR TITLE
OUT-1420 | Add tooltips to image preview buttons on hover

### DIFF
--- a/src/app/detail/ui/ImagePreviewModal/ImagePreviewHeader.tsx
+++ b/src/app/detail/ui/ImagePreviewModal/ImagePreviewHeader.tsx
@@ -2,10 +2,11 @@ import { IHeaderOverride } from '@cyntler/react-doc-viewer'
 import { Box } from '@mui/material'
 
 import { StyledImageTopBar } from '@/app/detail/ui/styledComponent'
+import { Tooltip } from '@/components/atoms/Tooltip'
 import { useDownloadFile } from '@/hooks/useDownload'
+import { useWindowWidth } from '@/hooks/useWindowWidth'
 import { DownloadIconBlack, ImagePreviewIconPNG, ImagePreviewModalCloseIcon } from '@/icons'
 import { getFileNameFromSignedUrl } from '@/utils/signUrl'
-import { useWindowWidth } from '@/hooks/useWindowWidth'
 import { truncateText } from '@/utils/truncateText'
 
 type DocViewerHeader = (
@@ -31,16 +32,20 @@ export const ImagePreviewHeader: DocViewerHeader = (state, { handleClose }) => {
 
   return (
     <StyledImageTopBar>
-      <Box className="close-icon-container" onClick={handleClose}>
-        <ImagePreviewModalCloseIcon />
-      </Box>
+      <Tooltip title="Close">
+        <Box className="close-icon-container" onClick={handleClose}>
+          <ImagePreviewModalCloseIcon />
+        </Box>
+      </Tooltip>
       <Box className="title-container">
         <ImagePreviewIconPNG />
         {width < 600 ? truncateText(fileName, 24) : fileName}
       </Box>
-      <Box className="download-btn" onClick={downloadImage}>
-        <DownloadIconBlack />
-      </Box>
+      <Tooltip title="Download">
+        <Box className="download-btn" onClick={downloadImage}>
+          <DownloadIconBlack />
+        </Box>
+      </Tooltip>
     </StyledImageTopBar>
   )
 }

--- a/src/app/detail/ui/ImagePreviewModal/ImageRenderer.tsx
+++ b/src/app/detail/ui/ImagePreviewModal/ImageRenderer.tsx
@@ -7,19 +7,26 @@ import { TransformComponent, TransformWrapper } from 'react-zoom-pan-pinch'
 
 import { StyledImageRenderer, StyledZoomControls } from '@/app/detail/ui/styledComponent'
 import { ZoomIcon, ZoomInIcon, ZoomOutIcon } from '@/icons'
+import { Tooltip } from '@/components/atoms/Tooltip'
 
 const Controls = ({ zoomIn, zoomOut, resetTransform }: any) => {
   return (
     <StyledZoomControls>
-      <Box className="control-btn" onClick={() => zoomOut()}>
-        <ZoomOutIcon />
-      </Box>
-      <Box className="control-btn" onClick={() => resetTransform()}>
-        <ZoomIcon />
-      </Box>
-      <Box className="control-btn" onClick={() => zoomIn()}>
-        <ZoomInIcon />
-      </Box>
+      <Tooltip title="Zoom out">
+        <Box className="control-btn" onClick={() => zoomOut()}>
+          <ZoomOutIcon />
+        </Box>
+      </Tooltip>
+      <Tooltip title="Reset zoom">
+        <Box className="control-btn" onClick={() => resetTransform()}>
+          <ZoomIcon />
+        </Box>
+      </Tooltip>
+      <Tooltip title="Zoom in">
+        <Box className="control-btn" onClick={() => zoomIn()}>
+          <ZoomInIcon />
+        </Box>
+      </Tooltip>
     </StyledZoomControls>
   )
 }

--- a/src/components/atoms/Tooltip.tsx
+++ b/src/components/atoms/Tooltip.tsx
@@ -1,0 +1,29 @@
+import { Tooltip } from '@mui/material'
+import { ReactElement } from 'react'
+
+interface TooltipProps {
+  title: string
+  children: ReactElement
+}
+
+const TooltipComponent = ({ title, children }: TooltipProps) => {
+  return (
+    <Tooltip
+      title={title}
+      slotProps={{
+        tooltip: {
+          sx: {
+            fontWeight: 500,
+            fontSize: '12px',
+            color: 'rgb(107, 111, 118)',
+            backgroundColor: 'white',
+          },
+        },
+      }}
+    >
+      {children}
+    </Tooltip>
+  )
+}
+
+export { TooltipComponent as Tooltip }


### PR DESCRIPTION
## Changes

- [x] Add tooltip component on header / zoom controls

## Testing Criteria

- [x] Screenshots

![image](https://github.com/user-attachments/assets/54105cd7-df27-4641-a4bb-87a6d4f337f6)

Same for rest