### PR TITLE
OUT-1441 | Add border radius to toggle menu

### DIFF
--- a/src/components/inputs/MenuBox.tsx
+++ b/src/components/inputs/MenuBox.tsx
@@ -79,11 +79,13 @@ export const MenuBox = ({
               },
             },
           ]}
+          sx={(theme) => ({ border: `1px solid ${theme.color.gray[150]}`, borderRadius: '4px', backgroundColor: 'white' })}
         >
           <Box
             sx={{
               boxShadow: '0px 6px 20px 0px rgba(0, 0, 0, 0.12)',
               borderRadius: '4px',
+              backgroundColor: 'transparent',
             }}
             p="2px 0px"
           >


### PR DESCRIPTION
## Changes

- [x] Fix background color issue that has been haunting us for ages (background of popper & option is different)
- [x] Add proper 4px border radius 

## Testing Criteria

- [x] Screenshot

![image](https://github.com/user-attachments/assets/92de6e17-98fb-4b92-beee-974ffa73c1ca)
