### PR TITLE
OUT-1421 | Add Image option to / menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "server-only": "^0.0.1",
     "supabase": "^2.1.1",
     "swr": "^2.2.5",
-    "tapwrite": "1.1.88",
+    "tapwrite": "1.1.89",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8409,10 +8409,10 @@ tapable@^2.2.0:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"
   integrity sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==
 
-tapwrite@1.1.88:
-  version "1.1.88"
-  resolved "https://registry.yarnpkg.com/tapwrite/-/tapwrite-1.1.88.tgz#aa9599f177ec71c6238f98dd35feda68a9c13e51"
-  integrity sha512-JADEeS0wC8z8iCaEN0DKdIEaf4eEqHu75Ymjl6RA8DeIE4CTx/jcfdaCmhA6sgA3zsz4bdAFtXMqNl99o4MOpQ==
+tapwrite@1.1.89:
+  version "1.1.89"
+  resolved "https://registry.yarnpkg.com/tapwrite/-/tapwrite-1.1.89.tgz#63e994bf67cf46b5bf385dcdb504b68427b8b960"
+  integrity sha512-kkz/KN/qRkJgLNdKqDyFLziOw4sSWmt/J0RL51gVC9g8AU1T+VGAHEUluvpHdmbBVxmFuGVl5Qpsc+qtensQAw==
   dependencies:
     re-resizable "^6.10.0"
     tippy.js "^6.3.7"


### PR DESCRIPTION
## Changes

- [x] updated tapwrite version to 1.1.89.
- [x] new tapwrite version supports images in floating menu options to insert images into the editor.

## Testing Criteria

- [LOOM](https://www.loom.com/share/03aa1495eeef4ed29f376fc65c8d38a3)
