### PR TITLE
OUT-1429 | Split first and last name in activity feed to avoid new lines

### DIFF
--- a/src/app/detail/ui/ActivityLog.tsx
+++ b/src/app/detail/ui/ActivityLog.tsx
@@ -148,8 +148,8 @@ export const ActivityLog = ({ log }: Prop) => {
             <Typography variant="md" sx={{ fontStyle: 'italic' }}>
               Deleted User
             </Typography>
-          )}
-          {activityDescription[log.type as ActivityType](...logEntities)}
+          )}{' '}
+          {activityDescription[log.type as ActivityType](...logEntities)}{' '}
           <StyledTypography> {getTimeDifference(log.createdAt)}</StyledTypography>
         </TypographyContainer>
       </Stack>

--- a/src/app/detail/ui/styledComponent.tsx
+++ b/src/app/detail/ui/styledComponent.tsx
@@ -1,12 +1,9 @@
 'use client'
 
-import { ListBtn } from '@/components/buttons/ListBtn'
 import { MenuBox } from '@/components/inputs/MenuBox'
-import { EmojiIcon, ReplyIcon, TemplateIcon } from '@/icons'
+import { EmojiIcon, ReplyIcon } from '@/icons'
 import { KeyboardArrowRight } from '@mui/icons-material'
 import { Box, Modal, Stack, Typography, styled } from '@mui/material'
-import Link from 'next/link'
-import { Tapwrite } from 'tapwrite'
 
 export const StyledTypography = styled(Typography)(({ theme }) => ({
   color: theme.color.gray[500],
@@ -15,6 +12,7 @@ export const StyledTypography = styled(Typography)(({ theme }) => ({
 }))
 
 export const BoldTypography = styled(Typography)(({ theme }) => ({
+  display: 'inline',
   color: theme.color.gray[600],
   fontSize: theme.typography.md.fontSize,
   lineHeight: '22px',
@@ -26,9 +24,10 @@ export const AvatarTypography = styled(Typography)(({ theme }) => ({
 }))
 
 export const TypographyContainer = styled(Stack)(({ theme }) => ({
-  display: 'flex',
-  flexWrap: 'wrap',
-  alignItems: 'center',
+  display: 'block',
+  p: {
+    display: 'inline',
+  },
 }))
 
 export const StyledKeyboardIcon = styled(KeyboardArrowRight)(({ theme }) => ({


### PR DESCRIPTION
## Changes

- [x] Make activity log `display: block` and corresponding elements `inline` instead of using flexbox

## Testing Criteria

- [x] Screenshot

![image](https://github.com/user-attachments/assets/af66de33-3612-4629-a97f-0f25a28f84b3)
