### PR TITLE
OUT-1452 | Match fade in/out transition for kebab menu

### DIFF
--- a/src/components/cards/TemplateCard.tsx
+++ b/src/components/cards/TemplateCard.tsx
@@ -1,12 +1,11 @@
 'use client'
 
-import { Box, Stack, Typography } from '@mui/material'
-import { ListBtn } from '../buttons/ListBtn'
-import { EditIcon, EllipsisIcon, TemplateIcon, TrashIcon } from '@/icons'
-import { MenuBox } from '../inputs/MenuBox'
-import { useState } from 'react'
 import { StyledMenuBox } from '@/app/detail/ui/styledComponent'
+import { EditIcon, EllipsisIcon, TemplateIcon, TrashIcon } from '@/icons'
 import { truncateText } from '@/utils/truncateText'
+import { Box, Stack, Typography } from '@mui/material'
+import { useState } from 'react'
+import { ListBtn } from '../buttons/ListBtn'
 
 interface TemplateCardProps {
   title: string

--- a/src/components/cards/TemplateCard.tsx
+++ b/src/components/cards/TemplateCard.tsx
@@ -1,11 +1,12 @@
 'use client'
 
+import { useState } from 'react'
+
 import { StyledMenuBox } from '@/app/detail/ui/styledComponent'
+import { ListBtn } from '@/components/buttons/ListBtn'
 import { EditIcon, EllipsisIcon, TemplateIcon, TrashIcon } from '@/icons'
 import { truncateText } from '@/utils/truncateText'
 import { Box, Stack, Typography } from '@mui/material'
-import { useState } from 'react'
-import { ListBtn } from '../buttons/ListBtn'
 
 interface TemplateCardProps {
   title: string

--- a/src/components/inputs/MenuBox.tsx
+++ b/src/components/inputs/MenuBox.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { MoreBtn } from '@/components/buttons/MoreBtn'
-import { Box, ClickAwayListener, Popper } from '@mui/material'
+import { Box, ClickAwayListener, Grow, Popper } from '@mui/material'
 import { Dispatch, ReactNode, SetStateAction, useEffect, useState } from 'react'
 
 export const MenuBox = ({
@@ -33,7 +33,7 @@ export const MenuBox = ({
 
   const handleClick = (event: React.MouseEvent<HTMLElement>) => {
     setAnchorEl(anchorEl ? null : event.currentTarget)
-    setIsMenuOpen && setIsMenuOpen(Boolean(anchorEl ? null : event.currentTarget))
+    setIsMenuOpen?.(Boolean(anchorEl ? null : event.currentTarget))
   }
 
   const open = Boolean(anchorEl)
@@ -41,16 +41,14 @@ export const MenuBox = ({
   const id = open ? 'menu-box-popper' : undefined
 
   useEffect(() => {
-    if (getMenuOpen) {
-      getMenuOpen(open)
-    }
-  }, [open])
+    getMenuOpen?.(open)
+  }, [open, getMenuOpen])
 
   return (
     <ClickAwayListener
       onClickAway={() => {
         setAnchorEl(null)
-        setIsMenuOpen && setIsMenuOpen(false)
+        setIsMenuOpen?.(false)
       }}
     >
       <Box className="menubox">
@@ -71,6 +69,7 @@ export const MenuBox = ({
           open={open}
           anchorEl={anchorEl}
           placement="bottom-end"
+          transition
           modifiers={[
             {
               name: 'offset',
@@ -79,18 +78,22 @@ export const MenuBox = ({
               },
             },
           ]}
-          sx={(theme) => ({ border: `1px solid ${theme.color.gray[150]}`, borderRadius: '4px', backgroundColor: 'white' })}
         >
-          <Box
-            sx={{
-              boxShadow: '0px 6px 20px 0px rgba(0, 0, 0, 0.12)',
-              borderRadius: '4px',
-              backgroundColor: 'transparent',
-            }}
-            p="2px 0px"
-          >
-            {menuContent}
-          </Box>
+          {({ TransitionProps }) => (
+            <Grow {...TransitionProps} style={{ transformOrigin: 'top right' }}>
+              <Box
+                sx={(theme) => ({
+                  border: `1px solid ${theme.color.gray[150]}`,
+                  borderRadius: '4px',
+                  backgroundColor: 'white',
+                  boxShadow: '0px 6px 20px 0px rgba(0, 0, 0, 0.12)',
+                })}
+                p="2px 0px"
+              >
+                {menuContent}
+              </Box>
+            </Grow>
+          )}
         </Popper>
       </Box>
     </ClickAwayListener>

--- a/src/components/inputs/MenuBox.tsx
+++ b/src/components/inputs/MenuBox.tsx
@@ -1,8 +1,9 @@
 'use client'
 
+import { Dispatch, ReactNode, SetStateAction, useEffect, useState } from 'react'
+
 import { MoreBtn } from '@/components/buttons/MoreBtn'
 import { Box, ClickAwayListener, Grow, Popper } from '@mui/material'
-import { Dispatch, ReactNode, SetStateAction, useEffect, useState } from 'react'
 
 export const MenuBox = ({
   menuContent,


### PR DESCRIPTION
## Changes

- [x] Implement fade in / out exactly like Copilot core apps for Menubox globally (affects comments, preview mode header & template card)
- [x] Minor refactoring (Remove unused Menubox import, clean function call usages) 

## Testing Criteria

- [x] Screencast

[Screencast from 2025-02-24 18-30-12.webm](https://github.com/user-attachments/assets/f04d8e23-abde-40ba-8431-e14947c41207)
