### PR TITLE
OUT-1467 | Tasks reposition on hover in board view

### DIFF
--- a/src/utils/sortTask.ts
+++ b/src/utils/sortTask.ts
@@ -1,6 +1,7 @@
 interface Sortable {
   dueDate?: string
   createdAt: Date
+  id: string
 }
 
 const getTimestamp = (date: string | Date) => new Date(date).getTime()
@@ -18,11 +19,21 @@ export const sortTaskByDescendingOrder = <T extends Sortable>(tasks: T[]): T[] =
         return getTimestamp(a.dueDate) - getTimestamp(b.dueDate)
       } else {
         // If due dates are the same use descending createdAt order
-        return getTimestamp(b.createdAt) - getTimestamp(a.createdAt)
+        if (getTimestamp(a.createdAt) !== getTimestamp(b.createdAt)) {
+          return getTimestamp(b.createdAt) - getTimestamp(a.createdAt)
+        } else {
+          // If createdAt times are also equal, sort by id alphabetically
+          return a.id.localeCompare(b.id)
+        }
       }
     } else {
       // Sort by createdAt in desc order
-      return getTimestamp(b.createdAt) - getTimestamp(a.createdAt)
+      if (getTimestamp(a.createdAt) !== getTimestamp(b.createdAt)) {
+        return getTimestamp(b.createdAt) - getTimestamp(a.createdAt)
+      } else {
+        // If createdAt times are equal, sort by id alphabetically
+        return a.id.localeCompare(b.id)
+      }
     }
   })
 }

--- a/src/utils/sortTask.ts
+++ b/src/utils/sortTask.ts
@@ -17,23 +17,9 @@ export const sortTaskByDescendingOrder = <T extends Sortable>(tasks: T[]): T[] =
       // Sort by duedate in asc order.
       if (a.dueDate !== b.dueDate) {
         return getTimestamp(a.dueDate) - getTimestamp(b.dueDate)
-      } else {
-        // If due dates are the same use descending createdAt order
-        if (getTimestamp(a.createdAt) !== getTimestamp(b.createdAt)) {
-          return getTimestamp(b.createdAt) - getTimestamp(a.createdAt)
-        } else {
-          // If createdAt times are also equal, sort by id alphabetically
-          return a.id.localeCompare(b.id)
-        }
-      }
-    } else {
-      // Sort by createdAt in desc order
-      if (getTimestamp(a.createdAt) !== getTimestamp(b.createdAt)) {
-        return getTimestamp(b.createdAt) - getTimestamp(a.createdAt)
-      } else {
-        // If createdAt times are equal, sort by id alphabetically
-        return a.id.localeCompare(b.id)
       }
     }
+    const createdAtDiff = getTimestamp(b.createdAt) - getTimestamp(a.createdAt)
+    return createdAtDiff !== 0 ? createdAtDiff : a.id.localeCompare(b.id)
   })
 }


### PR DESCRIPTION
## Changes

- [x] the main reason for this issue was our sorting method for tasks while rendering them in a board. Tasks are sorted according to due dates, if due dates are not there, then they are sorted by createdAt timestamp. The issue was arising because of createdAt timestamp becoming equal for certain tasks.
- [x] So added another condition for two task having same value of createdAt, sorted them by id alphabetically.

## Testing Criteria

- [LOOM](https://www.loom.com/share/50bb5072308940eba8a7282e275f0800?focus_title=1&muted=1&from_recorder=1)


