### PR TITLE
OUT-1497 | API - Add initiator details to replies & Order replies by earliest first

### DIFF
--- a/src/app/api/activity-logs/services/activity-log.service.ts
+++ b/src/app/api/activity-logs/services/activity-log.service.ts
@@ -172,10 +172,12 @@ export class ActivityLogService extends BaseService {
           })
           .filter((user): user is NonNullable<typeof user> => user !== undefined)
 
-        replies = replies.map((comment) => ({
-          ...comment,
-          initiator: copilotUsers.find((iu) => iu.id === comment.initiatorId) || null,
-        }))
+        replies = replies
+          .map((comment) => ({
+            ...comment,
+            initiator: copilotUsers.find((iu) => iu.id === comment.initiatorId) || null,
+          }))
+          .reverse()
 
         return {
           ...payload,

--- a/src/app/api/comment/comment.controller.ts
+++ b/src/app/api/comment/comment.controller.ts
@@ -1,12 +1,11 @@
-import httpStatus from 'http-status'
-import { NextRequest, NextResponse } from 'next/server'
-import { z } from 'zod'
-
 import { CreateCommentSchema, UpdateCommentSchema } from '@/types/dto/comment.dto'
 import { getSearchParams } from '@/utils/request'
 import { CommentService } from '@api/comment/comment.service'
 import { IdParams } from '@api/core/types/api'
 import authenticate from '@api/core/utils/authenticate'
+import httpStatus from 'http-status'
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
 
 export const createComment = async (req: NextRequest) => {
   const user = await authenticate(req)
@@ -44,5 +43,7 @@ export const getFilteredComments = async (req: NextRequest) => {
   const parentId = z.string().uuid().parse(rawParentId)
   const commentService = new CommentService(user)
   const comments = await commentService.getComments({ parentId })
-  return NextResponse.json({ comments })
+  return NextResponse.json({
+    comments: await commentService.addInitiatorDetails(comments),
+  })
 }

--- a/src/app/api/comment/comment.service.ts
+++ b/src/app/api/comment/comment.service.ts
@@ -1,10 +1,7 @@
-import { ActivityType, Comment, CommentInitiator, Prisma } from '@prisma/client'
-import httpStatus from 'http-status'
-import { z } from 'zod'
-
 import { sendCommentCreateNotifications } from '@/jobs/notifications'
 import { CreateComment, UpdateComment } from '@/types/dto/comment.dto'
 import { getArrayDifference, getArrayIntersection } from '@/utils/array'
+import { CopilotAPI } from '@/utils/CopilotAPI'
 import { CommentAddedSchema } from '@api/activity-logs/schemas/CommentAddedSchema'
 import { ActivityLogger } from '@api/activity-logs/services/activity-logger.service'
 import APIError from '@api/core/exceptions/api'
@@ -13,6 +10,9 @@ import { PoliciesService } from '@api/core/services/policies.service'
 import { Resource } from '@api/core/types/api'
 import { UserAction } from '@api/core/types/user'
 import { TasksService } from '@api/tasks/tasks.service'
+import { ActivityType, Comment, CommentInitiator, Prisma } from '@prisma/client'
+import httpStatus from 'http-status'
+import { z } from 'zod'
 
 export class CommentService extends BaseService {
   async create(data: CreateComment) {
@@ -110,7 +110,7 @@ export class CommentService extends BaseService {
         parentId,
         workspaceId: this.user.workspaceId,
       },
-      orderBy: { createdAt: 'desc' },
+      orderBy: { createdAt: 'asc' },
     })
   }
 
@@ -166,5 +166,28 @@ export class CommentService extends BaseService {
     replies = [...replies, ...limitedReplies]
 
     return replies
+  }
+
+  async addInitiatorDetails(comments: Comment[]) {
+    if (!comments.length) {
+      return comments
+    }
+
+    const copilot = new CopilotAPI(this.user.token)
+    const internalUsers = await copilot.getInternalUsers()
+    const clients = await copilot.getClients()
+
+    return comments.map((comment) => {
+      let initiator
+      const getUser = (user: { id: string }) => user.id === comment.initiatorId
+      if (comment.initiatorType === CommentInitiator.internalUser) {
+        initiator = internalUsers.data.find(getUser)
+      } else if (comment.initiatorType === CommentInitiator.client) {
+        initiator = clients?.data?.find(getUser)
+      } else {
+        initiator = internalUsers.data.find(getUser) || clients?.data?.find(getUser)
+      }
+      return { ...comment, initiator }
+    })
   }
 }


### PR DESCRIPTION
## Changes

- [x] Add initiator details to replies from `/api/comments`
- [x] Reverse ordering in GET `/api/activity-logs` to show earliest comments first (both limited & expanded)
- [x] Reverse ordering in GET `/api/comments` with `parentId` to show earliest comments first 

## Testing Criteria

- [x] Screenshots

<img width="1470" alt="image" src="https://github.com/user-attachments/assets/326cf3f2-8331-4cae-8e53-fedd2e150e11" />

<img width="1470" alt="image" src="https://github.com/user-attachments/assets/83989517-79ee-41ab-8410-f5b0e37a834d" />


## Impact & Surface Area of Change

- `/api/activity-logs` GET endpoint - intentional and only in scope of this milestone
- `/api/comments` GET endpoint - intentional and only in scope of this milestone
