### PR TITLE
OUT-1499 | Add support for media & attachments in GET Replies API

### DIFF
--- a/src/app/api/comment/comment.controller.ts
+++ b/src/app/api/comment/comment.controller.ts
@@ -1,5 +1,7 @@
 import { CreateCommentSchema, UpdateCommentSchema } from '@/types/dto/comment.dto'
 import { getSearchParams } from '@/utils/request'
+import { replaceImageSrc, signMediaForComments } from '@/utils/signedUrlReplacer'
+import { getSignedUrl } from '@/utils/signUrl'
 import { CommentService } from '@api/comment/comment.service'
 import { IdParams } from '@api/core/types/api'
 import authenticate from '@api/core/utils/authenticate'
@@ -43,7 +45,9 @@ export const getFilteredComments = async (req: NextRequest) => {
   const parentId = z.string().uuid().parse(rawParentId)
   const commentService = new CommentService(user)
   const comments = await commentService.getComments({ parentId })
+  const signedComments = await signMediaForComments(comments)
+
   return NextResponse.json({
-    comments: await commentService.addInitiatorDetails(comments),
+    comments: await commentService.addInitiatorDetails(signedComments),
   })
 }

--- a/src/utils/signedUrlReplacer.ts
+++ b/src/utils/signedUrlReplacer.ts
@@ -1,5 +1,5 @@
-import { Prisma, PrismaClient, StateType, WorkflowState } from '@prisma/client'
-import { DefaultArgs } from '@prisma/client/runtime/library'
+import { getSignedUrl } from '@/utils/signUrl'
+import { Comment } from '@prisma/client'
 
 export async function replaceImageSrc(htmlString: string, getSignedUrl: (filePath: string) => Promise<string | undefined>) {
   const imgTagRegex = /<img\s+[^>]*src="([^"]+)"[^>]*>/g //expression used to match all img tags in provided HTML string.
@@ -56,3 +56,13 @@ export const replaceImgSrcs = (body: string, newSrcs: string[], oldSrcs: string[
   })
   return updatedBody
 }
+
+export const signMediaForComments = async (comments: Comment[]) =>
+  await Promise.all(
+    comments.map(async (comment) => {
+      return {
+        ...comment,
+        content: await replaceImageSrc(comment.content, getSignedUrl),
+      }
+    }),
+  )


### PR DESCRIPTION
## Changes

- [x] Sign all individual replies before passing on to response
- [x] Refactor sign comments implementation to use reusable util 

## Testing Criteria

- [x] cc @arpandhakal  to test in UI

## Impact & Surface Area of Change

- GET `/api/activity-logs/:id` -> comments + comment replies (Loading of signed media like images and attachments)
- GET `/api/comments` -> Loading of signed media like images and attachments for a `parentId`
