### PR TITLE
OUT-1487 | Add support for optimistic update and animations for replies while creating/deleting

### DIFF
--- a/src/app/detail/ui/ActivityWrapper.tsx
+++ b/src/app/detail/ui/ActivityWrapper.tsx
@@ -113,6 +113,7 @@ export const ActivityWrapper = ({
           details: {
             content: postCommentPayload.content,
             id: tempId,
+            replies: [],
           },
           taskId: task_id,
           userId: currentUserId as string,

--- a/src/app/detail/ui/Comments.tsx
+++ b/src/app/detail/ui/Comments.tsx
@@ -5,6 +5,7 @@ import { IAssigneeCombined } from '@/types/interfaces'
 import { LogResponse } from '@api/activity-logs/schemas/LogResponseSchema'
 import { Stack } from '@mui/material'
 import { VerticalLine } from './styledComponent'
+import { OptimisticUpdate } from '@/utils/checkOptimisticStableId'
 
 interface Prop {
   comment: LogResponse
@@ -12,9 +13,10 @@ interface Prop {
   deleteComment: (id: string) => void
   task_id: string
   stableId: string
+  optimisticUpdates: OptimisticUpdate[]
 }
 
-export const Comments = ({ comment, createComment, deleteComment, task_id, stableId }: Prop) => {
+export const Comments = ({ comment, createComment, deleteComment, task_id, stableId, optimisticUpdates }: Prop) => {
   return (
     <Stack id={stableId} direction="row" columnGap={2} position="relative">
       <VerticalLine />
@@ -31,7 +33,13 @@ export const Comments = ({ comment, createComment, deleteComment, task_id, stabl
           size="large"
         />
 
-        <CommentCard comment={comment} createComment={createComment} deleteComment={deleteComment} task_id={task_id} />
+        <CommentCard
+          comment={comment}
+          createComment={createComment}
+          deleteComment={deleteComment}
+          task_id={task_id}
+          optimisticUpdates={optimisticUpdates}
+        />
       </Stack>
     </Stack>
   )

--- a/src/app/detail/ui/Comments.tsx
+++ b/src/app/detail/ui/Comments.tsx
@@ -10,7 +10,7 @@ import { OptimisticUpdate } from '@/utils/checkOptimisticStableId'
 interface Prop {
   comment: LogResponse
   createComment: (postCommentPayload: CreateComment) => void
-  deleteComment: (id: string) => void
+  deleteComment: (id: string, replyId?: string) => void
   task_id: string
   stableId: string
   optimisticUpdates: OptimisticUpdate[]

--- a/src/components/cards/CommentCard.tsx
+++ b/src/components/cards/CommentCard.tsx
@@ -55,7 +55,7 @@ export const CommentCard = ({
 }: {
   comment: LogResponse
   createComment: (postCommentPayload: CreateComment) => void
-  deleteComment: (id: string) => void
+  deleteComment: (id: string, replyId?: string) => void
   task_id: string
   optimisticUpdates: OptimisticUpdate[]
 }) => {
@@ -164,14 +164,14 @@ export const CommentCard = ({
       const updatedComment = await mutate()
 
       setReplies(updatedComment?.comments || comment.details.replies || [])
-      store.dispatch(setExpandedComments([...expandedComments, z.string().parse(comment.details.id)]))
+      store.dispatch(setExpandedComments([...expandedComments, z.string().parse(comment.details.id ?? '')]))
     } catch (error) {
       console.error('Failed to fetch replies:', error)
     }
   }
 
   useEffect(() => {
-    const replies = comment.details.replies as ReplyResponse[]
+    const replies = (comment.details.replies as ReplyResponse[]) || []
     if (expandedComments.length && expandedComments.includes(z.string().parse(comment.details.id))) {
       const lastReply = replies[replies.length - 1]
       if (lastReply && lastReply.id.includes('temp-comment')) {
@@ -309,10 +309,10 @@ export const CommentCard = ({
                 <Collapse key={checkOptimisticStableId(item, optimisticUpdates)}>
                   <ReplyCard
                     item={item}
-                    key={item.id}
                     uploadFn={uploadFn}
                     task_id={task_id}
                     handleImagePreview={handleImagePreview}
+                    deleteReply={deleteComment}
                   />
                 </Collapse>
               )

--- a/src/components/cards/CommentCard.tsx
+++ b/src/components/cards/CommentCard.tsx
@@ -215,48 +215,51 @@ export const CommentCard = ({
                 </StyledTypography>
               </Stack>
 
-              {(isHovered || isMobile() || isMenuOpen) && canEdit && (
+              {(isHovered || isMobile() || isMenuOpen) && (
                 <Stack direction="row" columnGap={2} sx={{ height: '10px' }} alignItems="center">
                   <ReplyButton handleClick={() => setShowReply((prev) => !prev)} />
-                  <MenuBox
-                    getMenuOpen={(open) => {
-                      setIsMenuOpen(open)
-                    }}
-                    menuContent={
-                      <>
-                        <ListBtn
-                          content="Edit comment"
-                          handleClick={() => {
-                            setIsReadOnly(false)
-                            if (editRef.current) {
-                              editRef.current.focus()
-                            }
-                          }}
-                          icon={<PencilIcon />}
-                          contentColor={(theme) => theme.color.text.text}
-                          width="175px"
-                          height="33px"
-                        />
-                        {canDelete && (
+                  {canEdit && (
+                    <MenuBox
+                      getMenuOpen={(open) => {
+                        setIsMenuOpen(open)
+                      }}
+                      menuContent={
+                        <>
                           <ListBtn
-                            content="Delete comment"
+                            content="Edit comment"
                             handleClick={() => {
-                              setShowConfirmDeleteModal(true)
+                              setIsReadOnly(false)
+                              if (editRef.current) {
+                                editRef.current.focus()
+                              }
                             }}
-                            icon={<TrashIcon />}
-                            contentColor={(theme) => theme.color.error}
+                            icon={<PencilIcon />}
+                            contentColor={(theme) => theme.color.text.text}
                             width="175px"
                             height="33px"
                           />
-                        )}
-                      </>
-                    }
-                    isSecondary
-                    width={'22px'}
-                    height={'22px'}
-                    displayButtonBackground={false}
-                    noHover={false}
-                  />
+
+                          {canDelete && (
+                            <ListBtn
+                              content="Delete comment"
+                              handleClick={() => {
+                                setShowConfirmDeleteModal(true)
+                              }}
+                              icon={<TrashIcon />}
+                              contentColor={(theme) => theme.color.error}
+                              width="175px"
+                              height="33px"
+                            />
+                          )}
+                        </>
+                      }
+                      isSecondary
+                      width={'22px'}
+                      height={'22px'}
+                      displayButtonBackground={false}
+                      noHover={false}
+                    />
+                  )}
                 </Stack>
               )}
             </Stack>

--- a/src/components/cards/ReplyCard.tsx
+++ b/src/components/cards/ReplyCard.tsx
@@ -8,7 +8,6 @@ import { BoldTypography, CustomDivider, StyledModal, StyledTypography } from '@/
 import { CopilotAvatar } from '@/components/atoms/CopilotAvatar'
 import AttachmentLayout from '@/components/AttachmentLayout'
 import { ListBtn } from '@/components/buttons/ListBtn'
-import { PrimaryBtn } from '@/components/buttons/PrimaryBtn'
 import { EditCommentButtons } from '@/components/buttonsGroup/EditCommentButtons'
 import { MenuBox } from '@/components/inputs/MenuBox'
 import { ConfirmDeleteUI } from '@/components/layouts/ConfirmDeleteUI'
@@ -33,11 +32,13 @@ export const ReplyCard = ({
   uploadFn,
   task_id,
   handleImagePreview,
+  deleteReply,
 }: {
   item: ReplyResponse
   uploadFn: ((file: File) => Promise<string | undefined>) | undefined
   task_id: string
   handleImagePreview: (e: React.MouseEvent<unknown>) => void
+  deleteReply: (id: string, replyId: string) => void
 }) => {
   const [isReadOnly, setIsReadOnly] = useState<boolean>(true)
   const [isMenuOpen, setIsMenuOpen] = useState(false)
@@ -233,7 +234,7 @@ export const ReplyCard = ({
           <ConfirmDeleteUI
             handleCancel={() => setShowConfirmDeleteModal(false)}
             handleDelete={() => {
-              deleteComment(token ?? '', item.id as string)
+              deleteReply(item.id as string, item.id)
               setShowConfirmDeleteModal(false)
             }}
             bodyTag="comment"

--- a/src/components/cards/ReplyCard.tsx
+++ b/src/components/cards/ReplyCard.tsx
@@ -237,7 +237,8 @@ export const ReplyCard = ({
               deleteReply(item.id as string, item.id)
               setShowConfirmDeleteModal(false)
             }}
-            bodyTag="comment"
+            bodyTag="message"
+            description="Are you sure you want to delete this message?"
           />
         </StyledModal>
       </Stack>

--- a/src/components/inputs/ReplyInput.tsx
+++ b/src/components/inputs/ReplyInput.tsx
@@ -52,7 +52,7 @@ export const ReplyInput = ({ task_id, comment, createComment, uploadFn }: ReplyI
   }, [comment, detail, task_id])
 
   useEffect(() => {
-    if (pendingReplies.length > 0 && comment.details.id) {
+    if (pendingReplies.length > 0 && !comment.details.id.includes('temp-comment')) {
       const { content, taskId } = pendingReplies[0]
       createComment({
         content,

--- a/src/components/layouts/ConfirmDeleteUI.tsx
+++ b/src/components/layouts/ConfirmDeleteUI.tsx
@@ -9,7 +9,7 @@ import { PrimaryBtn } from '../buttons/PrimaryBtn'
 interface Prop {
   handleCancel: () => void
   handleDelete: () => void
-  bodyTag?: 'task' | 'comment' | 'template'
+  bodyTag?: 'task' | 'comment' | 'template' | 'message'
   customBody?: string
   description?: string
 }
@@ -24,6 +24,7 @@ export const ConfirmDeleteUI = ({
   const getHeaderMessage = () => {
     if (customBody) return customBody
     if (bodyTag === 'comment') return 'Delete comment?'
+    if (bodyTag === 'message') return 'Delete message'
     return `Are you sure you want to delete this ${bodyTag}?`
   }
 

--- a/src/utils/checkOptimisticStableId.ts
+++ b/src/utils/checkOptimisticStableId.ts
@@ -11,8 +11,6 @@ export interface OptimisticUpdate {
 //util to maintain same key for collapse animation on optimistic updates
 export const checkOptimisticStableId = (log: LogResponse | ReplyResponse, optimisticUpdates: OptimisticUpdate[]) => {
   const referenceId = 'details' in log ? (log.details.id ?? log.id) : log.id
-
   const matchingUpdate = optimisticUpdates.find((update) => update.tempId === log.id || update.serverId === referenceId)
-
   return matchingUpdate ? matchingUpdate.tempId : log.id
 }

--- a/src/utils/checkOptimisticStableId.ts
+++ b/src/utils/checkOptimisticStableId.ts
@@ -1,0 +1,18 @@
+import { ReplyResponse } from '@/app/api/activity-logs/schemas/CommentAddedSchema'
+import { LogResponse } from '@/app/api/activity-logs/schemas/LogResponseSchema'
+import { ActivityType } from '@prisma/client'
+
+export interface OptimisticUpdate {
+  tempId: string
+  serverId?: string
+  timestamp: number
+}
+
+//util to maintain same key for collapse animation on optimistic updates
+export const checkOptimisticStableId = (log: LogResponse | ReplyResponse, optimisticUpdates: OptimisticUpdate[]) => {
+  const referenceId = 'details' in log ? (log.details.id ?? log.id) : log.id
+
+  const matchingUpdate = optimisticUpdates.find((update) => update.tempId === log.id || update.serverId === referenceId)
+
+  return matchingUpdate ? matchingUpdate.tempId : log.id
+}


### PR DESCRIPTION
## Changes

- [x] added optimistic updates for replies on creation.
- [x] added collapse animations on replies. 
- [x] added optimistic updates for replies on deletion.
- [x] shared functions like `getStableId`, creation, deletion of comments to replies on collapsed mode. 

## Testing Criteria

- [LOOM](https://www.loom.com/share/b8695656c4284949a9fa379c7b0c2eaf?focus_title=1&muted=1&from_recorder=1)

## Impact & Surface Area of Change

- general comment/activity-log functionality because replies share all the endpoints and functions related to comment/activity-logs. 





