### PR TITLE
OUT-1463 | Support deleted parent comment when comment has replies

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "dev": "next dev",
     "dev:embedded": "tsx ./src/cmd/serve-embedded",
+    "dev:debug": "nodemon --exec \"node --inspect-brk node_modules/.bin/next dev\"",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
@@ -91,6 +92,7 @@
     "eslint-config-next": "14.0.4",
     "husky": "^8.0.0",
     "jest": "^29.7.0",
+    "nodemon": "^3.1.9",
     "open": "^10.1.0",
     "prettier": "^3.1.1",
     "tailwindcss": "^3.3.0",

--- a/prisma/migrations/20250306131831_add_deleted_at_to_activity_logs/migration.sql
+++ b/prisma/migrations/20250306131831_add_deleted_at_to_activity_logs/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "ActivityLogs" ADD COLUMN     "deletedAt" TIMESTAMP(3);

--- a/prisma/schema/activityLog.prisma
+++ b/prisma/schema/activityLog.prisma
@@ -19,6 +19,7 @@ model ActivityLog {
   userRole    AssigneeType
   createdAt   DateTime     @default(now()) @db.Timestamptz()
   updatedAt   DateTime     @updatedAt @ignore @db.Timestamptz()
+  deletedAt   DateTime?
 
   @@index([createdAt])
   @@index([taskId], name: "IX_ActivityLogs_taskId")

--- a/src/app/api/activity-logs/services/activity-log.service.ts
+++ b/src/app/api/activity-logs/services/activity-log.service.ts
@@ -13,7 +13,7 @@ import { CommentService } from '@api/comment/comment.service'
 import APIError from '@api/core/exceptions/api'
 import User from '@api/core/models/User.model'
 import { BaseService } from '@api/core/services/base.service'
-import { ActivityType, AssigneeType, Comment } from '@prisma/client'
+import { ActivityType, AssigneeType, Comment, CommentInitiator } from '@prisma/client'
 import httpStatus from 'http-status'
 import { z } from 'zod'
 
@@ -160,10 +160,10 @@ export class ActivityLogService extends BaseService {
 
         const copilotUsers = replies
           .map((reply) => {
-            if (userRole === AssigneeType.internalUser) {
+            if (reply.initiatorType === CommentInitiator.internalUser) {
               return internalUsers.data.find((iu) => iu.id === reply.initiatorId)
             }
-            if (userRole === AssigneeType.client) {
+            if (reply.initiatorType === CommentInitiator.client) {
               return clientUsers.data?.find((client) => client.id === reply.initiatorId)
             }
           })

--- a/src/app/api/activity-logs/services/activity-log.service.ts
+++ b/src/app/api/activity-logs/services/activity-log.service.ts
@@ -178,7 +178,7 @@ export class ActivityLogService extends BaseService {
 
         return {
           ...payload,
-          content: comment.content,
+          content: comment.deletedAt ? '' : comment.content,
           replies,
           replyCount: replyCounts[comment.id] || 0,
           firstInitiators: initiators?.[comment.id]?.slice(0, 3),

--- a/src/app/api/comment/comment.service.ts
+++ b/src/app/api/comment/comment.service.ts
@@ -96,7 +96,7 @@ export class CommentService extends BaseService {
     const policyGate = new PoliciesService(this.user)
     policyGate.authorize(UserAction.Update, Resource.Comment)
 
-    const filters = { id, workspaceId: this.user.workspaceId, initiatorId: this.user.internalUserId }
+    const filters = { id, workspaceId: this.user.workspaceId, initiatorId: this.user.internalUserId, deletedAt: undefined }
     const prevComment = await this.db.comment.findFirst({
       where: filters,
     })

--- a/src/app/api/comment/comment.service.ts
+++ b/src/app/api/comment/comment.service.ts
@@ -114,10 +114,8 @@ export class CommentService extends BaseService {
   async getCommentsByIds(commentIds: string[]) {
     return await this.db.comment.findMany({
       where: {
-        id: {
-          in: commentIds,
-        },
-        deletedAt: undefined,
+        id: { in: commentIds },
+        deletedAt: undefined, // Also get deleted comments (to show if comment parent was deleted)
       },
     })
   }
@@ -128,10 +126,14 @@ export class CommentService extends BaseService {
         parentId,
         workspaceId: this.user.workspaceId,
       },
-      orderBy: { createdAt: 'desc' },
+      orderBy: { createdAt: 'asc' },
     })
   }
 
+  /**
+   * Returns an object with parentId as key and array of reply comments containing that comment as parentId
+   * as value
+   */
   async getReplyCounts(commentIds: string[]): Promise<Record<string, number>> {
     if (!commentIds) return {}
 
@@ -195,7 +197,6 @@ export class CommentService extends BaseService {
       const expandedReplies = await commentRepo.getAllRepliesForParents(expandComments)
       replies = [...replies, ...expandedReplies]
     }
-
     const limitedReplies = await commentRepo.getLimitedRepliesForParents(commentIds)
     replies = [...replies, ...limitedReplies]
 

--- a/src/types/dto/comment.dto.ts
+++ b/src/types/dto/comment.dto.ts
@@ -10,10 +10,16 @@ export const CreateCommentSchema = z.object({
 
 export type CreateComment = z.infer<typeof CreateCommentSchema>
 
-export const UpdateCommentSchema = z.object({
-  content: z.string(),
-  mentions: z.string().array().optional(),
-})
+export const UpdateCommentSchema = z
+  .object({
+    content: z.string().optional(),
+    mentions: z.string().array().optional(),
+    deletedAt: z.null().optional(),
+  })
+  .refine(({ content, deletedAt }) => deletedAt !== undefined || content !== undefined, {
+    message: 'Content must be present to update comment',
+    path: ['content'],
+  })
 
 export type UpdateComment = z.infer<typeof UpdateCommentSchema>
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4041,7 +4041,7 @@ char-regex@^1.0.2:
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
   integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
 
-chokidar@^3.5.3:
+chokidar@^3.5.2, chokidar@^3.5.3:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.6.0.tgz#197c6cc669ef2a8dc5e7b4d97ee4e092c3eb0d5b"
   integrity sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==
@@ -4389,6 +4389,13 @@ debug@^3.2.7:
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
+
+debug@^4:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.0.tgz#2b3f2aea2ffeb776477460267377dc8710faba8a"
+  integrity sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==
+  dependencies:
+    ms "^2.1.3"
 
 decimal.js@^10.4.3:
   version "10.4.3"
@@ -5578,6 +5585,11 @@ ieee754@^1.1.13:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
+
+ignore-by-default@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/ignore-by-default/-/ignore-by-default-1.0.1.tgz#48ca6d72f6c6a3af00a9ad4ae6876be3889e2b09"
+  integrity sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==
 
 ignore@^5.2.0:
   version "5.3.2"
@@ -6909,6 +6921,22 @@ node-releases@^2.0.18:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.18.tgz#f010e8d35e2fe8d6b2944f03f70213ecedc4ca3f"
   integrity sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==
 
+nodemon@^3.1.9:
+  version "3.1.9"
+  resolved "https://registry.yarnpkg.com/nodemon/-/nodemon-3.1.9.tgz#df502cdc3b120e1c3c0c6e4152349019efa7387b"
+  integrity sha512-hdr1oIb2p6ZSxu3PB2JWWYS7ZQ0qvaZsc3hK8DR8f02kRzc8rjYmxAIvdz+aYC+8F2IjNaB7HMcSDg8nQpJxyg==
+  dependencies:
+    chokidar "^3.5.2"
+    debug "^4"
+    ignore-by-default "^1.0.1"
+    minimatch "^3.1.2"
+    pstree.remy "^1.1.8"
+    semver "^7.5.3"
+    simple-update-notifier "^2.0.0"
+    supports-color "^5.5.0"
+    touch "^3.1.0"
+    undefsafe "^2.0.5"
+
 normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
@@ -7503,6 +7531,11 @@ proxy-from-env@^1.1.0:
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
   integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
+pstree.remy@^1.1.8:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/pstree.remy/-/pstree.remy-1.1.8.tgz#c242224f4a67c21f686839bbdb4ac282b8373d3a"
+  integrity sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==
+
 pump@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.2.tgz#836f3edd6bc2ee599256c924ffe0d88573ddcbf8"
@@ -8010,6 +8043,13 @@ simple-get@^4.0.0:
     once "^1.3.1"
     simple-concat "^1.0.0"
 
+simple-update-notifier@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz#d70b92bdab7d6d90dfd73931195a30b6e3d7cebb"
+  integrity sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==
+  dependencies:
+    semver "^7.5.3"
+
 sisteransi@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
@@ -8316,7 +8356,7 @@ superjson@^2.2.1:
   dependencies:
     copy-anything "^3.0.2"
 
-supports-color@^5.3.0:
+supports-color@^5.3.0, supports-color@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
@@ -8535,6 +8575,11 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
+touch@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/touch/-/touch-3.1.1.tgz#097a23d7b161476435e5c1344a95c0f75b4a5694"
+  integrity sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==
+
 tough-cookie@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-5.0.0.tgz#6b6518e2b5c070cf742d872ee0f4f92d69eac1af"
@@ -8716,6 +8761,11 @@ unbox-primitive@^1.0.2:
     has-bigints "^1.0.2"
     has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
+
+undefsafe@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/undefsafe/-/undefsafe-2.0.5.tgz#38733b9327bdcd226db889fb723a6efd162e6e2c"
+  integrity sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==
 
 undici-types@~6.19.2:
   version "6.19.8"


### PR DESCRIPTION
## Changes

- [x] Add feature to soft-delete ActivityLogs table by adding `deletedAt`
- [x] Delete comments from activity-logs if it has no replies, else mark as soft-deleted in Comments table using `deletedAt`  
- [x] Implement content scrubbing for deleted thread parent comments 
- [x] Implement undo feature for comment deletion (following design) 

## Testing Criteria

- [x] Screencast

https://github.com/user-attachments/assets/bc5f16a5-9c88-4f5f-b7e5-d0a9f6b14002




## Notes

- Added `nodemon` package to run next server in debug mode with hot reloading

## Impact & Surface Area of Change

- GET `/api/activity-logs` -> Activity logs can now house deleted comments
