### PR TITLE
OUT-1515 | OUT-1516: Improvements to Notification copy

### DIFF
--- a/src/jobs/notifications/send-reply-create-notifications.ts
+++ b/src/jobs/notifications/send-reply-create-notifications.ts
@@ -96,14 +96,14 @@ async function getNotificationDetails(copilot: CopilotAPI, user: User, comment: 
   const ctaParams = { taskId: task.id, commentId: comment.parentId, replyId: comment.id }
   const deliveryTargets = {
     inProduct: {
-      title: 'Someone replied to your comment',
+      title: 'Reply was added',
       body: `${senderName} replied to your comment on the task ‘${task.title}’.`,
       ctaParams,
     },
     email: {
       subject: 'A reply was added',
       header: `A reply was added by ${senderName}`,
-      title: 'View task',
+      title: 'View reply',
       body: `${senderName} replied to a thread on the task '${task.title}'. To view the reply, open the task below.`,
       ctaParams,
     },


### PR DESCRIPTION
## Changes

- [x] Change in-product title for IU notifications
- [x] Change email CTA text for client notifications 

## Testing Criteria

- [x] Screenshots

<img width="866" alt="image" src="https://github.com/user-attachments/assets/3e33b209-336a-4328-a043-6b5ce956cd24" />

<img width="993" alt="image" src="https://github.com/user-attachments/assets/f4430622-bc2c-4ddb-8767-a4dbe47f4628" />



## Impact & Surface Area of Change

- `send-reply-create-notifications` -> IU header text and Client email CTA button text
