### PR TITLE
OUT-1523, OUT-1529, OUT-1512 | Comment edits do not display in real time

### DIFF
--- a/src/components/cards/CommentCard.tsx
+++ b/src/components/cards/CommentCard.tsx
@@ -346,6 +346,7 @@ export const CommentCard = ({
             createComment={createComment}
             uploadFn={uploadFn}
             focusReplyInput={focusReplyInput}
+            setFocusReplyInput={setFocusedReplyInput}
           />
         ) : null}
       </Stack>

--- a/src/components/cards/CommentCard.tsx
+++ b/src/components/cards/CommentCard.tsx
@@ -62,6 +62,7 @@ export const CommentCard = ({
   const [timeAgo, setTimeAgo] = useState(getTimeDifference(comment.createdAt))
   const [isReadOnly, setIsReadOnly] = useState<boolean>(true)
   const editRef = useRef<HTMLDivElement>(null)
+  const [focusReplyInput, setFocusedReplyInput] = useState(false)
 
   const [showConfirmDeleteModal, setShowConfirmDeleteModal] = useState(false)
   const { tokenPayload } = useSelector(selectAuthDetails)
@@ -224,7 +225,12 @@ export const CommentCard = ({
 
                 {(isHovered || isMobile() || isMenuOpen) && (
                   <Stack direction="row" columnGap={2} sx={{ height: '10px' }} alignItems="center">
-                    <ReplyButton handleClick={() => setShowReply((prev) => !prev)} />
+                    <ReplyButton
+                      handleClick={() => {
+                        setShowReply((prev) => !prev)
+                        setFocusedReplyInput(true)
+                      }}
+                    />
                     {canEdit && (
                       <MenuBox
                         getMenuOpen={(open) => {
@@ -334,7 +340,13 @@ export const CommentCard = ({
         {(Array.isArray((comment as LogResponse).details?.replies) &&
           ((comment as LogResponse).details.replies as LogResponse[]).length > 0) ||
         showReply ? (
-          <ReplyInput comment={comment} task_id={task_id} createComment={createComment} uploadFn={uploadFn} />
+          <ReplyInput
+            comment={comment}
+            task_id={task_id}
+            createComment={createComment}
+            uploadFn={uploadFn}
+            focusReplyInput={focusReplyInput}
+          />
         ) : null}
       </Stack>
       <StyledModal

--- a/src/components/cards/ReplyCard.tsx
+++ b/src/components/cards/ReplyCard.tsx
@@ -61,6 +61,10 @@ export const ReplyCard = ({
     return /Mobi|Android|iPhone|iPad|iPod/i.test(navigator.userAgent) || windowWidth < 600
   }
 
+  useEffect(() => {
+    setEditedContent(content)
+  }, [content])
+
   const cancelEdit = () => {
     setIsReadOnly(true)
     setEditedContent(content)

--- a/src/components/inputs/ReplyInput.tsx
+++ b/src/components/inputs/ReplyInput.tsx
@@ -157,8 +157,9 @@ export const ReplyInput = ({
               overflow: 'hidden',
               wordBreak: 'break-word',
               whiteSpace: 'pre-wrap',
-              paddingTop: '5px',
-              marginTop: '-5px',
+              justifyContent: 'center',
+              alignItems: isMultiline ? 'flex-start' : 'center',
+              marginTop: isMultiline ? '0px' : '-5px',
               flexGrow: 1,
             }}
             addAttachmentButton

--- a/src/components/inputs/ReplyInput.tsx
+++ b/src/components/inputs/ReplyInput.tsx
@@ -13,7 +13,7 @@ import { getMentionsList } from '@/utils/getMentionList'
 import { deleteEditorAttachmentsHandler } from '@/utils/inlineImage'
 import { isTapwriteContentEmpty } from '@/utils/isTapwriteContentEmpty'
 import { Avatar, Box, InputAdornment, Stack } from '@mui/material'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { Dispatch, SetStateAction, useCallback, useEffect, useRef, useState } from 'react'
 import { useSelector } from 'react-redux'
 import { Tapwrite } from 'tapwrite'
 
@@ -23,11 +23,18 @@ interface ReplyInputProps {
   createComment: (postCommentPayload: CreateComment) => void
   uploadFn: ((file: File) => Promise<string | undefined>) | undefined
   focusReplyInput: boolean
+  setFocusReplyInput: Dispatch<SetStateAction<boolean>>
 }
 
-export const ReplyInput = ({ task_id, comment, createComment, uploadFn, focusReplyInput }: ReplyInputProps) => {
+export const ReplyInput = ({
+  task_id,
+  comment,
+  createComment,
+  uploadFn,
+  focusReplyInput,
+  setFocusReplyInput,
+}: ReplyInputProps) => {
   const [detail, setDetail] = useState('')
-  const [isFocused, setIsFocused] = useState(false)
   const { token, assignee } = useSelector(selectTaskBoard)
   const windowWidth = useWindowWidth()
   const isMobile = () => {
@@ -67,7 +74,7 @@ export const ReplyInput = ({ task_id, comment, createComment, uploadFn, focusRep
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (!isFocused || isMobile()) {
+      if (!focusReplyInput || isMobile()) {
         return
       }
       if (event.key === 'Enter' && !event.shiftKey && !isListOrMenuActive) {
@@ -85,7 +92,7 @@ export const ReplyInput = ({ task_id, comment, createComment, uploadFn, focusRep
     return () => {
       window.removeEventListener('keydown', handleKeyDown)
     }
-  }, [detail, isListOrMenuActive, isFocused, isMobile])
+  }, [detail, isListOrMenuActive, focusReplyInput, isMobile])
 
   const handleUploadStatusChange = (uploading: boolean) => {
     setIsUploading(uploading)
@@ -102,10 +109,10 @@ export const ReplyInput = ({ task_id, comment, createComment, uploadFn, focusRep
   }, [detail, editorRef.current])
 
   useEffect(() => {
-    if (editorRef.current) {
+    if (editorRef.current && focusReplyInput) {
       editorRef.current.focus()
     }
-  }, [focusReplyInput])
+  }, [focusReplyInput, editorRef.current])
 
   return (
     <>
@@ -126,7 +133,7 @@ export const ReplyInput = ({ task_id, comment, createComment, uploadFn, focusRep
             border: (theme) => `1.1px solid ${theme.color.gray[200]}`,
           }}
         />
-        <Box onBlur={() => setIsFocused(false)} onFocus={() => setIsFocused(true)} width={'100%'}>
+        <Box onBlur={() => setFocusReplyInput(false)} onFocus={() => setFocusReplyInput(true)} width={'100%'}>
           <Tapwrite
             editorRef={editorRef}
             content={detail}


### PR DESCRIPTION
## Changes

- [x] added an effect to sync up content of replies on real time update.
- [x] if reply input is multiline, the end buttons on reply input box are directed to column from row.
- [x] reply icon click focuses the reply input box.

## Testing Criteria

- [LOOM](https://www.loom.com/share/01458341a7f541c7b926b8b4a0aa6219)- OUT-1523
- [LOOM](https://www.loom.com/share/23b50bd4af3d48939a3e43356a9fdbac) - OUT-1529
- [LOOM](https://www.loom.com/share/bac6907b54df444c808724cef37f7c55) - OUT-1512