### PR TITLE
OUT-1533, OUT-1532 | Contents of reply submission box are not vertically centered

### DIFF
--- a/src/app/detail/ui/ImagePreviewModal/index.tsx
+++ b/src/app/detail/ui/ImagePreviewModal/index.tsx
@@ -29,6 +29,7 @@ export const ImagePreviewModal = () => {
       onClose={handleClose}
       aria-labelledby={'preview-image-modal'}
       aria-describedby="preview-image-modal-popup"
+      disableRestoreFocus
     >
       <StyledImagePreviewWrapper onClick={handleBackdropClick}>
         <DocViewer

--- a/src/components/inputs/ReplyInput.tsx
+++ b/src/components/inputs/ReplyInput.tsx
@@ -120,6 +120,7 @@ export const ReplyInput = ({
         direction="row"
         columnGap={'8px'}
         width="100%"
+        alignItems="flex-start"
         sx={{
           padding: '8px 0px 0px 0px',
         }}
@@ -131,6 +132,7 @@ export const ReplyInput = ({
           currentAssignee={currentUserDetails}
           sx={{
             border: (theme) => `1.1px solid ${theme.color.gray[200]}`,
+            marginTop: '6px',
           }}
         />
         <Box onBlur={() => setFocusReplyInput(false)} onFocus={() => setFocusReplyInput(true)} width={'100%'}>
@@ -157,9 +159,9 @@ export const ReplyInput = ({
               overflow: 'hidden',
               wordBreak: 'break-word',
               whiteSpace: 'pre-wrap',
-              justifyContent: 'center',
+
               alignItems: isMultiline ? 'flex-start' : 'center',
-              marginTop: isMultiline ? '0px' : '-5px',
+              marginTop: isMultiline ? '5px' : '0px',
               flexGrow: 1,
             }}
             addAttachmentButton


### PR DESCRIPTION
## Changes

- [x] Content in reply input centered vertically.
- [x] Focus restoration disabled for Image preview modal.

## Testing Criteria

![image](https://github.com/user-attachments/assets/01fae861-a02a-4b43-8038-a91abd2bd6ec)
![image](https://github.com/user-attachments/assets/ba99dcda-eabc-4bf7-83d3-0c1f2678945e)

- [LOOM, OUT-1532](https://www.loom.com/share/10ad02641d1c44bba243dfa36dd65df6)
