### PR TITLE
OUT-1530 | TypeError: crypto.randomUUID is not a function

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "supabase": "^2.1.1",
     "swr": "^2.2.5",
     "tapwrite": "1.1.91",
+    "uuid": "^11.1.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/src/utils/generateRandomString.ts
+++ b/src/utils/generateRandomString.ts
@@ -1,7 +1,7 @@
-import * as crypto from 'crypto'
+import { v4 as uuidv4 } from 'uuid'
 
 export function generateRandomString(name: string) {
-  const result = crypto.randomUUID()
+  const result = uuidv4()
   const safeName = name.replace(/[^a-zA-Z0-9\/\-_\.]/g, '_') //regex made to replace characters which are not alphanumeric, slash, dash, underscore, period with and underscore
 
   return result + '_' + safeName

--- a/src/utils/signedTemplateUrlReplacer.ts
+++ b/src/utils/signedTemplateUrlReplacer.ts
@@ -1,7 +1,7 @@
 import { supabaseBucket } from '@/config'
 import { SupabaseActions } from '@/utils/SupabaseActions'
-import * as crypto from 'crypto'
 import { JSDOM } from 'jsdom'
+import { v4 as uuidv4 } from 'uuid'
 
 /**
  * Extracts the template path from a given url string
@@ -48,7 +48,7 @@ export const copyTemplateMediaToTask = async (workspaceId: string, body: string)
   for (let src of srcArray) {
     const srcSegments = src.split('/')
     const filename = srcSegments[srcSegments.length - 1]
-    const newUniqueFilename = crypto.randomUUID() + filename.slice(36)
+    const newUniqueFilename = uuidv4() + filename.slice(36)
     copyPromises.push(supabase.copyAttachment(src, `${workspaceId}/${newUniqueFilename}`))
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8849,6 +8849,11 @@ util-deprecate@^1.0.1, util-deprecate@^1.0.2:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
+uuid@^11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.0.tgz#9549028be1753bb934fc96e2bca09bb4105ae912"
+  integrity sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==
+
 uuid@^9.0.0:
   version "9.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"


### PR DESCRIPTION
## Changes

- [x] Use `uuid` package since `crypto` module is unstable to be run on client code unless using `window.crypto.*`. (however using `window` would make this util non-reusable for backend code, so swapped to use the main package instead)

## Testing Criteria

- [x] Screencast

https://github.com/user-attachments/assets/46d246cd-2d50-4150-9641-737ff3730a7d


