### PR TITLE
OUT-1465 | SecurityError: LockManager.request: request() is not allowed in this context

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
   },
   "overrides": {
     "@supabase/supabase-js": {
-      "@supabase/gotrue-js": "2.61.0"
+      "@supabase/auth-js": "2.61.0"
     }
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"

--- a/package.json
+++ b/package.json
@@ -106,5 +106,10 @@
       "yarn prettier:fix"
     ]
   },
+  "overrides": {
+    "@supabase/supabase-js": {
+      "@supabase/gotrue-js": "2.61.0"
+    }
+  },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
Ref: https://github.com/supabase/supabase-js/issues/936#issuecomment-2691252604

## Changes

- [x] Override `@supabase/auth-js` to last stable version `2.61.0` to prevent this issue

## Testing Criteria

- [x] Screencast


https://github.com/user-attachments/assets/6f40cb0b-220a-4970-80d9-e99f5a3d138a


## Impact & Surface Area of Change

- Realtime behavior
