### PR TITLE
OUT-1522 | Add droppable area indicator when user drags file to a reply

### DIFF
--- a/src/app/detail/ui/styledComponent.tsx
+++ b/src/app/detail/ui/styledComponent.tsx
@@ -89,7 +89,6 @@ export const CommentCardContainer = styled(Stack)(({ theme }) => ({
   border: `1px solid ${theme.color.gray[150]}`,
   borderRadius: theme.spacing(theme.shape.radius100),
   background: theme.color.base.white,
-  padding: '8px',
   width: '100%',
 }))
 

--- a/src/components/cards/CollapsibleReplyCard.tsx
+++ b/src/components/cards/CollapsibleReplyCard.tsx
@@ -19,7 +19,7 @@ export const CollapsibleReplyCard = ({
     <>
       <Stack
         sx={{
-          padding: '8px 0px',
+          padding: '8px',
           alignSelf: 'stretch',
           alignItems: 'center',
           display: 'flex',

--- a/src/components/cards/CommentCard.tsx
+++ b/src/components/cards/CommentCard.tsx
@@ -203,7 +203,7 @@ export const CommentCard = ({
           <Stack
             direction="column"
             rowGap={'2px'}
-            sx={{ paddingBottom: '4px' }}
+            sx={{ padding: '8px' }}
             onMouseEnter={() => setIsHovered(true)}
             onMouseLeave={() => setIsHovered(false)}
           >
@@ -312,7 +312,7 @@ export const CommentCard = ({
 
         {((Array.isArray((comment as LogResponse).details?.replies) &&
           ((comment as LogResponse).details.replies as ReplyResponse[]).length > 0) ||
-          showReply) && <CustomDivider sx={{ marginTop: '4px' }} />}
+          showReply) && <CustomDivider />}
         {replyCount > 3 && !expandedComments.includes(z.string().parse(comment.details.id)) && (
           <CollapsibleReplyCard
             lastAssignees={comment.details.firstInitiators as IAssigneeCombined[]}

--- a/src/components/cards/DeletedCommentCard.tsx
+++ b/src/components/cards/DeletedCommentCard.tsx
@@ -2,7 +2,7 @@ import { Stack, Typography } from '@mui/material'
 
 export const DeletedCommentCard = () => {
   return (
-    <Stack sx={{ paddingBottom: '4px' }}>
+    <Stack sx={{ padding: '8px' }}>
       <Typography
         variant="bodyMd"
         sx={{

--- a/src/components/cards/ReplyCard.tsx
+++ b/src/components/cards/ReplyCard.tsx
@@ -119,7 +119,7 @@ export const ReplyCard = ({
         columnGap={2}
         alignItems="flex-start"
         sx={{
-          padding: '8px 0px 0px 0px',
+          padding: '8px',
         }}
         onMouseEnter={() => setIsHovered(true)}
         onMouseLeave={() => setIsHovered(false)}
@@ -140,6 +140,7 @@ export const ReplyCard = ({
           rowGap={'2px'}
           width={'100%'}
           sx={{
+            marginBottom: '-8px',
             paddingBottom: '8px',
             borderBottom: (theme) => `1px solid ${theme.color.gray[150]}`,
             marginRight: '-10px',

--- a/src/components/inputs/CommentInput.tsx
+++ b/src/components/inputs/CommentInput.tsx
@@ -142,6 +142,7 @@ export const CommentInput = ({ createComment, task_id }: Prop) => {
         sx={{
           backgroundColor: (theme) => (isDragging ? theme.color.background.bgCommentDrag : theme.color.base.white),
           wordBreak: 'break-word',
+          padding: '8px',
         }}
         onDragOver={handleDragOver}
         onDragEnter={handleDragEnter}

--- a/src/components/inputs/ReplyInput.tsx
+++ b/src/components/inputs/ReplyInput.tsx
@@ -114,6 +114,36 @@ export const ReplyInput = ({
     }
   }, [focusReplyInput, editorRef.current])
 
+  const [isDragging, setIsDragging] = useState(false)
+  const dragCounter = useRef(0)
+
+  const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault()
+    if (!isDragging) {
+      setIsDragging(true)
+    }
+  }
+
+  const handleDragEnter = () => {
+    dragCounter.current += 1
+    if (!isDragging) {
+      setIsDragging(true)
+    }
+  }
+
+  const handleDragLeave = () => {
+    dragCounter.current -= 1
+    if (dragCounter.current === 0) {
+      setIsDragging(false)
+    }
+  }
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault()
+    setIsDragging(false)
+    dragCounter.current = 0
+  }
+
   return (
     <>
       <Stack
@@ -122,8 +152,15 @@ export const ReplyInput = ({
         width="100%"
         alignItems="flex-start"
         sx={{
-          padding: '8px 0px 0px 0px',
+          padding: '8px',
+          backgroundColor: (theme) => (isDragging ? theme.color.background.bgCommentDrag : theme.color.gray[100]),
+          wordBreak: 'break-word',
+          paddingInline: '8px',
         }}
+        onDragOver={handleDragOver}
+        onDragEnter={handleDragEnter}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
       >
         <CopilotAvatar
           width="20px"
@@ -135,7 +172,7 @@ export const ReplyInput = ({
             marginTop: '6px',
           }}
         />
-        <Box onBlur={() => setFocusReplyInput(false)} onFocus={() => setFocusReplyInput(true)} width={'100%'}>
+        <Box sx={{}} onBlur={() => setFocusReplyInput(false)} onFocus={() => setFocusReplyInput(true)} width={'100%'}>
           <Tapwrite
             editorRef={editorRef}
             content={detail}
@@ -159,8 +196,7 @@ export const ReplyInput = ({
               overflow: 'hidden',
               wordBreak: 'break-word',
               whiteSpace: 'pre-wrap',
-
-              alignItems: isMultiline ? 'flex-start' : 'center',
+              alignItems: isMultiline ? 'normal' : 'center',
               marginTop: isMultiline ? '5px' : '0px',
               flexGrow: 1,
             }}


### PR DESCRIPTION
## Changes

- [x] added a droppable indicator which attachments/images are being dragged/dropped in reply input. 
- [x] design changes for comment cards and replies. 

## Testing Criteria

[Screencast from 03-17-2025 03:17:28 PM.webm](https://github.com/user-attachments/assets/9e77e162-e723-44b8-ad32-27af2c6c42ad)

## Impact & Surface Area of Change

- Comment reply designs in a comment card.
