### PR TITLE
OUT-1539 | Overlapping avatars containing deleted users is messed up

### DIFF
--- a/src/components/atoms/OverlappingAvatars.tsx
+++ b/src/components/atoms/OverlappingAvatars.tsx
@@ -20,7 +20,7 @@ export const OverlappingAvatars: React.FC<OverlappingAvatarsProps> = ({
   height = '20px',
   fontSize = '14px',
   sx,
-  size,
+  size = 'default',
 }) => {
   const avatarSx: SxProps<Theme> = {
     ...sx,
@@ -43,10 +43,20 @@ export const OverlappingAvatars: React.FC<OverlappingAvatarsProps> = ({
   const renderAvatar = (assignee: IAssigneeCombined | null, index: number) => {
     const avatarVariant: 'circular' | 'rounded' | 'square' = assignee?.type === 'companies' ? 'rounded' : 'circular'
 
-    if (!assignee || (assignee?.name || assignee?.givenName) === 'No assignee') {
-      if (size === 'small') return <NoAssigneeAvatarSmall key={index} />
-      if (size === 'large') return <NoAssigneeAvatarLarge key={index} />
-      return <NoAssigneeAvatar key={index} />
+    if (!assignee || assignee?.name || assignee?.givenName === 'No assignee') {
+      return (
+        <Avatar
+          key={index}
+          sx={{
+            ...avatarSx,
+            border: (theme) => `1.1px solid ${theme.color.gray[200]}`,
+            zIndex: assignees.length + index,
+          }}
+          variant={avatarVariant}
+        >
+          <NoAssigneeAvatar />
+        </Avatar>
+      )
     }
 
     if (assignee?.iconImageUrl || assignee?.avatarImageUrl) {

--- a/src/components/cards/CollapsibleReplyCard.tsx
+++ b/src/components/cards/CollapsibleReplyCard.tsx
@@ -27,7 +27,7 @@ export const CollapsibleReplyCard = ({
         direction="row"
         columnGap={'8px'}
       >
-        <OverlappingAvatars assignees={lastAssignees} width="20px" height="20px" fontSize="10px" size="large" />
+        <OverlappingAvatars assignees={lastAssignees} width="20px" height="20px" fontSize="10px" />
 
         <Stack direction={'row'} columnGap={'4px'} sx={{ marginTop: '0px' }}>
           <Typography variant="md" lineHeight="22px">


### PR DESCRIPTION
## Changes

- [x] Added appropriate styles and wrapped up `NoAssigneeAvatar` in `Avatar` component.

## Testing Criteria

![image](https://github.com/user-attachments/assets/4148f59e-7d24-4944-868f-5524db91f995)


