### PR TITLE
OUT-1554 | Add `subtaskCounts` tracking column for Realtime support

### DIFF
--- a/prisma/migrations/20250327094204_add_subtask_count_to_tasks/migration.sql
+++ b/prisma/migrations/20250327094204_add_subtask_count_to_tasks/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Tasks" ADD COLUMN     "subtaskCount" INTEGER NOT NULL DEFAULT 0;

--- a/prisma/schema/task.prisma
+++ b/prisma/schema/task.prisma
@@ -29,9 +29,10 @@ model Task {
   ClientNotification       ClientNotification[]
   InternalUserNotification InternalUserNotification[]
 
-  parentId String? @db.Uuid
-  parent   Task?   @relation("TaskToSubtasks", fields: [parentId], references: [id], onDelete: Cascade)
-  subtasks Task[]  @relation("TaskToSubtasks")
+  parentId     String? @db.Uuid
+  parent       Task?   @relation("TaskToSubtasks", fields: [parentId], references: [id], onDelete: Cascade)
+  subtasks     Task[]  @relation("TaskToSubtasks")
+  subtaskCount Int     @default(0)
 
   path Unsupported("ltree")? // Prisma does not have native support for ltrees yet
 

--- a/src/app/api/core/services/base.service.ts
+++ b/src/app/api/core/services/base.service.ts
@@ -1,6 +1,6 @@
 import DBClient from '@/lib/db'
-import { PrismaClient } from '@prisma/client'
 import User from '@api/core/models/User.model'
+import { PrismaClient } from '@prisma/client'
 
 /**
  * Base Service with access to db and current user
@@ -13,5 +13,13 @@ export class BaseService {
   constructor(user: User, customCopilotApiKey?: string) {
     this.user = user
     this.customApiKey = customCopilotApiKey
+  }
+
+  setTransaction(tx: PrismaClient) {
+    this.db = tx
+  }
+
+  unsetTransaction() {
+    this.db = DBClient.getInstance()
   }
 }

--- a/src/app/api/tasks/subtasks.service.ts
+++ b/src/app/api/tasks/subtasks.service.ts
@@ -18,17 +18,17 @@ export class SubtaskService extends BaseService {
     return level
   }
 
-  async addSubtaskCount(id: string, increaseBy?: number) {
+  async addSubtaskCount(id: string, increment: number = 1) {
     await this.db.task.update({
       where: { id, workspaceId: this.user.workspaceId },
-      data: { subtaskCount: { increment: increaseBy || 1 } },
+      data: { subtaskCount: { increment } },
     })
   }
 
-  async decreaseSubtaskCount(id: string, decreaseBy?: number) {
+  async decreaseSubtaskCount(id: string, decrement: number = 1) {
     await this.db.task.update({
       where: { id, workspaceId: this.user.workspaceId },
-      data: { subtaskCount: { decrement: decreaseBy || 1 } },
+      data: { subtaskCount: { decrement } },
     })
   }
 }

--- a/src/app/api/tasks/subtasks.service.ts
+++ b/src/app/api/tasks/subtasks.service.ts
@@ -17,4 +17,18 @@ export class SubtaskService extends BaseService {
     }
     return level
   }
+
+  async addSubtaskCount(id: string, increaseBy?: number, txn?: any) {
+    await this.db.task.update({
+      where: { id, workspaceId: this.user.workspaceId },
+      data: { subtaskCount: { increment: increaseBy || 1 } },
+    })
+  }
+
+  async decreaseSubtaskCount(id: string, decreaseBy?: number) {
+    await this.db.task.update({
+      where: { id, workspaceId: this.user.workspaceId },
+      data: { subtaskCount: { decrement: decreaseBy || 1 } },
+    })
+  }
 }

--- a/src/app/api/tasks/subtasks.service.ts
+++ b/src/app/api/tasks/subtasks.service.ts
@@ -18,7 +18,7 @@ export class SubtaskService extends BaseService {
     return level
   }
 
-  async addSubtaskCount(id: string, increaseBy?: number, txn?: any) {
+  async addSubtaskCount(id: string, increaseBy?: number) {
     await this.db.task.update({
       where: { id, workspaceId: this.user.workspaceId },
       data: { subtaskCount: { increment: increaseBy || 1 } },

--- a/src/cmd/load-testing/load-testing.service.ts
+++ b/src/cmd/load-testing/load-testing.service.ts
@@ -91,7 +91,14 @@ class LoadTester {
     for (let user of users) {
       const data: Omit<
         Task,
-        'id' | 'completedAt' | 'deletedAt' | 'lastActivityLogUpdated' | 'isArchived' | 'lastArchivedDate' | 'parentId'
+        | 'id'
+        | 'completedAt'
+        | 'deletedAt'
+        | 'lastActivityLogUpdated'
+        | 'isArchived'
+        | 'lastArchivedDate'
+        | 'parentId'
+        | 'subtaskCount'
       >[] = []
       const currentUser = await authenticateWithToken(this.token, this.apiKey)
       const labelsService = new LabelMappingService(currentUser, this.apiKey)


### PR DESCRIPTION
## Changes

- [x] Add schema changes and migrations for "Tasks" table for new `subtaskCounts` column
- [x] Implement count increment on subtask creation
- [x] Implement count decrement on subtask deletion
- [x] Add `subtaskCount` key to `getOne` and `getAll` task endpoints
- [x] Add support for transactions in BaseService 

## Testing Criteria

- [x] Count increment


https://github.com/user-attachments/assets/495c3eca-e2a3-44ea-86a0-5977e554949e


- [x] Count decrement


https://github.com/user-attachments/assets/ce303aaa-d740-4771-a102-e2083e9f9bc9


## Impact & Surface Area of Change

- CRUD endpoints for `/api/tasks`
