### PR TITLE
OUT-1581 | Optimistically update UI for sub task creation

### DIFF
--- a/src/app/detail/ui/Subtasks.tsx
+++ b/src/app/detail/ui/Subtasks.tsx
@@ -1,25 +1,39 @@
 'use client'
 
-import { useOptimistic, useState } from 'react'
+import { useState } from 'react'
 import { Box, Stack, Typography } from '@mui/material'
-
 import { NewTaskCard } from '@/app/detail/ui/NewTaskCard'
 import { GhostBtn } from '@/components/buttons/GhostBtn'
-import { AddLargeIcon, GrayAddIcon, GrayAddMediumIcon } from '@/icons'
+import { GrayAddMediumIcon } from '@/icons'
 import { TaskCardList } from '@/app/detail/ui/TaskCardList'
 import { useSelector } from 'react-redux'
 import { selectTaskBoard } from '@/redux/features/taskBoardSlice'
-import useSWR from 'swr'
+import useSWR, { useSWRConfig } from 'swr'
 import { fetcher } from '@/utils/fetcher'
-import { TaskResponse } from '@/types/dto/tasks.dto'
-import { IconBtn } from '@/components/buttons/IconBtn'
+import { CreateTaskRequest, TaskResponse } from '@/types/dto/tasks.dto'
 import { AddBtn } from '@/components/buttons/AddBtn'
 import { CustomLink } from '@/hoc/CustomLink'
 import { getCardHref } from '@/utils/getCardHref'
 import { UserRole } from '@/app/api/core/types/user'
+import { generateRandomString } from '@/utils/generateRandomString'
+import { selectAuthDetails } from '@/redux/features/authDetailsSlice'
+import { handleCreate } from '@/app/actions'
+import { checkOptimisticStableId } from '@/utils/optimisticCommentUtils'
+import { sortTaskByDescendingOrder } from '@/utils/sortTask'
+import { ClientResponseSchema, CompanyResponseSchema, InternalUsersSchema } from '@/types/common'
+import { z } from 'zod'
+
+interface OptimisticUpdate {
+  tempId: string
+  serverId?: string
+  timestamp: number
+}
 
 export const Subtasks = ({ task_id, token, userType }: { task_id: string; token: string; userType: UserRole }) => {
   const [openTaskForm, setOpenTaskForm] = useState(false)
+  const { workflowStates, assignee, activeTask } = useSelector(selectTaskBoard)
+  const { tokenPayload } = useSelector(selectAuthDetails)
+  const [optimisticUpdates, setOptimisticUpdates] = useState<OptimisticUpdate[]>([]) //might need this server-temp id maps in the future.
 
   const handleFormCancel = () => {
     setOpenTaskForm(false)
@@ -31,13 +45,63 @@ export const Subtasks = ({ task_id, token, userType }: { task_id: string; token:
   const cacheKey = `/api/tasks/?token=${token}&showArchived=1&showUnarchived=1&parentId=${task_id}`
   const { data: subTasks, mutate: mutateList } = useSWR(cacheKey, fetcher, { refreshInterval: 0 })
 
-  const mutateSubTasks = () => {
-    mutateList()
+  const { mutate } = useSWRConfig()
+
+  const handleSubTaskCreation = (payload: CreateTaskRequest) => {
+    const tempId = generateRandomString('temp-task')
+    setOptimisticUpdates((prev) => [
+      ...prev,
+      {
+        tempId,
+        timestamp: Date.now(),
+      },
+    ])
+    const tempSubtask: TaskResponse = {
+      id: tempId,
+      label: 'temp-label',
+      workspaceId: tokenPayload?.workspaceId || '',
+      assigneeId: payload.assigneeId ?? '',
+      assigneeType: payload.assigneeType,
+      title: payload.title,
+      body: payload.body,
+      workflowStateId: payload.workflowStateId,
+      workflowState: workflowStates.find((ws) => ws.id === payload.workflowStateId)!,
+      createdById: tokenPayload?.internalUserId ?? tokenPayload?.clientId ?? '',
+      assignee: z
+        .union([ClientResponseSchema, InternalUsersSchema, CompanyResponseSchema])
+        .parse(assignee.find((a) => a.id === payload.assigneeId)),
+      createdAt: new Date(),
+      lastArchivedDate: new Date().toISOString(),
+      isArchived: false,
+      parentId: activeTask?.id,
+      dueDate: payload.dueDate ? new Date(payload.dueDate).toISOString() : undefined,
+    }
+    const optimisticData = subTasks?.tasks ? sortTaskByDescendingOrder([...subTasks.tasks, tempSubtask]) : [tempSubtask]
+    try {
+      mutate(
+        cacheKey,
+        async () => {
+          const subTask = await handleCreate(token, payload)
+          setOptimisticUpdates((prev) =>
+            prev.map((update) => (update.tempId === tempId ? { ...update, serverId: subTask.id } : update)),
+          )
+          return await fetcher(cacheKey)
+        },
+        {
+          optimisticData: { tasks: optimisticData },
+          rollbackOnError: true,
+          revalidate: true,
+        },
+      )
+    } catch (error) {
+      console.error('Failed to create subtask:', error)
+      setOptimisticUpdates((prev) => prev.filter((update) => update.tempId !== tempId))
+    }
   }
 
   return (
     <Stack direction="column" rowGap={'8px'} width="100%" sx={{ padding: '24px 0px 0px' }}>
-      {subTasks && subTasks?.tasks.length > 0 ? (
+      {subTasks && subTasks?.tasks?.length > 0 ? (
         <Stack
           direction="row"
           sx={{
@@ -56,13 +120,32 @@ export const Subtasks = ({ task_id, token, userType }: { task_id: string; token:
         <GhostBtn buttonText="Create subtask" handleClick={handleFormOpen} startIcon={<GrayAddMediumIcon />} />
       )}
 
-      {openTaskForm && <NewTaskCard handleClose={handleFormCancel} mutateSubTasks={mutateSubTasks} />}
+      {openTaskForm && <NewTaskCard handleClose={handleFormCancel} handleSubTaskCreation={handleSubTaskCreation} />}
       <Box>
-        {subTasks?.tasks?.map((item: TaskResponse, index: number) => (
-          <CustomLink key={item.id} href={{ pathname: getCardHref(item, userType), query: { token } }}>
-            <TaskCardList task={item} />
-          </CustomLink>
-        ))}
+        {subTasks?.tasks?.map((item: TaskResponse, index: number) => {
+          const isTempId = item.id.includes('temp')
+          if (isTempId) {
+            return (
+              <div
+                style={{
+                  cursor: 'pointer',
+                }}
+                key={checkOptimisticStableId(item, optimisticUpdates)}
+              >
+                <TaskCardList task={item} />
+              </div>
+            )
+          }
+
+          return (
+            <CustomLink
+              key={checkOptimisticStableId(item, optimisticUpdates)}
+              href={{ pathname: getCardHref(item, userType), query: { token } }}
+            >
+              <TaskCardList task={item} />
+            </CustomLink>
+          )
+        })}
       </Box>
     </Stack>
   )

--- a/src/utils/optimisticCommentUtils.ts
+++ b/src/utils/optimisticCommentUtils.ts
@@ -2,6 +2,7 @@ import { ReplyResponse } from '@/app/api/activity-logs/schemas/CommentAddedSchem
 import { LogResponse } from '@/app/api/activity-logs/schemas/LogResponseSchema'
 import { ClientResponseSchema, ClientsResponse, InternalUsers, InternalUsersSchema } from '@/types/common'
 import { CreateComment } from '@/types/dto/comment.dto'
+import { TaskResponse } from '@/types/dto/tasks.dto'
 import { IAssigneeCombined } from '@/types/interfaces'
 import { ActivityType } from '@prisma/client'
 import { z } from 'zod'
@@ -14,7 +15,10 @@ export interface OptimisticUpdate {
 
 //util to maintain same key for collapse animation on optimistic updates. The optimistic updates are data reflected on the ui which are yet to be uploaded on the server.
 //Once the optimistic data gets updated on the server, we need to replace the tempId with the actual id from server. But if key changes unexpectedly or frequently on the Collapse or other animation components, the animation may break or cause flicker. By maintaining consistent key through tempId or serverId, the component remains stable and ensures animations work correctly.
-export const checkOptimisticStableId = (log: LogResponse | ReplyResponse, optimisticUpdates: OptimisticUpdate[]) => {
+export const checkOptimisticStableId = (
+  log: LogResponse | ReplyResponse | TaskResponse,
+  optimisticUpdates: OptimisticUpdate[],
+) => {
   const referenceId = 'details' in log ? (log.details.id ?? log.id) : log.id
   const matchingUpdate = optimisticUpdates.find((update) => update.tempId === log.id || update.serverId === referenceId)
   return matchingUpdate?.tempId ?? log.id

--- a/src/utils/optimisticTaskUtils.ts
+++ b/src/utils/optimisticTaskUtils.ts
@@ -1,0 +1,36 @@
+import { ClientResponseSchema, CompanyResponseSchema, InternalUsersSchema } from '@/types/common'
+import { CreateTaskRequest } from '@/types/dto/tasks.dto'
+import { WorkflowStateResponse } from '@/types/dto/workflowStates.dto'
+import { IAssigneeCombined } from '@/types/interfaces'
+import { z } from 'zod'
+
+export const getTempTask = (
+  tempId: string,
+  payload: CreateTaskRequest,
+  workflowStates: WorkflowStateResponse[],
+  assignee: IAssigneeCombined[],
+  workspaceId: string,
+  userId: string,
+  parentId: string,
+) => {
+  return {
+    id: tempId,
+    label: 'temp-label',
+    workspaceId: workspaceId,
+    assigneeId: payload.assigneeId ?? '',
+    assigneeType: payload.assigneeType,
+    title: payload.title,
+    body: payload.body,
+    workflowStateId: payload.workflowStateId,
+    workflowState: workflowStates.find((ws) => ws.id === payload.workflowStateId)!,
+    createdById: userId,
+    assignee: z
+      .union([ClientResponseSchema, InternalUsersSchema, CompanyResponseSchema])
+      .parse(assignee.find((a) => a.id === payload.assigneeId)),
+    createdAt: new Date(),
+    lastArchivedDate: new Date().toISOString(),
+    isArchived: false,
+    parentId: parentId,
+    dueDate: payload.dueDate ? new Date(payload.dueDate).toISOString() : undefined,
+  }
+}


### PR DESCRIPTION
## Changes

- [x] optimistically updated sub task creation and applied a seamless revalidation from the server to replace the temp tasks on the ui.
- [x] managed a server-temp id map state for future reference.

## Testing Criteria

- [LOOM](https://www.loom.com/share/d89073c84a254c0287755ea939a11b5e)


## Impact & Surface Area of Change

- Sub tasks component. 
