### PR TITLE
OUT-1595 | Match subtask count to reflect the number of accessible tasks, not the total num of tasks

### DIFF
--- a/src/app/detail/[task_id]/[user_type]/DetailStateUpdate.tsx
+++ b/src/app/detail/[task_id]/[user_type]/DetailStateUpdate.tsx
@@ -1,5 +1,5 @@
 import { ClientSideStateUpdate } from '@/hoc/ClientSideStateUpdate'
-import { getAllTasks, getAllWorkflowStates, getViewSettings } from '@/app/page'
+import { getAccessibleTasks, getAllTasks, getAllWorkflowStates, getViewSettings } from '@/app/page'
 import { Token } from '@/types/common'
 import { TaskResponse } from '@/types/dto/tasks.dto'
 
@@ -22,9 +22,10 @@ export const DetailStateUpdate = async ({ isRedirect, token, tokenPayload, task,
 
   // If flow has been redirected from notifications CTA button directly,
   // we must first get context for tasks, workflowStates and viewSettings
+  const accessibleTasks = await getAccessibleTasks(token)
   const [workflowStates, tasks, viewSettings] = await Promise.all([
     getAllWorkflowStates(token),
-    getAllTasks(token),
+    getAllTasks(token, accessibleTasks),
     getViewSettings(token),
   ])
   return (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -81,7 +81,7 @@ export async function getViewSettings(token: string): Promise<CreateViewSettings
   return await res.json()
 }
 
-async function getAccessibleTaskIds(token: string) {
+export async function getAccessibleTasks(token: string) {
   const res = await fetch(`${apiUrl}/api/tasks/all?token=${token}`)
 
   const data = await res.json()
@@ -105,7 +105,7 @@ export default async function Main({ searchParams }: { searchParams: { token: st
   redirectIfTaskCta(searchParams, userRole)
 
   const viewSettings = await getViewSettings(token)
-  const accessibleTasks = await getAccessibleTaskIds(token)
+  const accessibleTasks = await getAccessibleTasks(token)
   const copilot = new CopilotAPI(token)
   const currentInternalUser = tokenPayload.internalUserId
     ? await copilot.getInternalUser(tokenPayload.internalUserId)

--- a/src/hoc/ClientSideStateUpdate.tsx
+++ b/src/hoc/ClientSideStateUpdate.tsx
@@ -3,7 +3,7 @@
 import { setTokenPayload } from '@/redux/features/authDetailsSlice'
 import {
   selectTaskBoard,
-  setAccesibleTaskIds,
+  setAccessibleTasks,
   setActiveTask,
   setAssigneeList,
   setFilteredAssgineeList,
@@ -23,6 +23,7 @@ import { WorkflowStateResponse } from '@/types/dto/workflowStates.dto'
 import { IAssigneeCombined, IAssigneeSuggestions, ITemplate } from '@/types/interfaces'
 import { filterOptionsMap } from '@/types/objectMaps'
 import { getPreviewMode, handlePreviewMode } from '@/utils/previewMode'
+import { Task } from '@prisma/client'
 import { ReactNode, useEffect } from 'react'
 import { useSelector } from 'react-redux'
 
@@ -43,7 +44,7 @@ export const ClientSideStateUpdate = ({
   assigneeSuggestions,
   task,
   clearExpandedComments,
-  accesibleTaskIds,
+  accessibleTasks,
 }: {
   children: ReactNode
   workflowStates?: WorkflowStateResponse[]
@@ -56,7 +57,7 @@ export const ClientSideStateUpdate = ({
   assigneeSuggestions?: IAssigneeSuggestions[]
   task?: TaskResponse
   clearExpandedComments?: boolean
-  accesibleTaskIds?: string[]
+  accessibleTasks?: Pick<Task, 'id' | 'parentId'>[]
 }) => {
   const { tasks: tasksInStore, viewSettingsTemp } = useSelector(selectTaskBoard)
   useEffect(() => {
@@ -112,8 +113,8 @@ export const ClientSideStateUpdate = ({
       store.dispatch(setActiveTask(undefined)) //when navigated elsewhere from details page, removing the previously set ActiveTask
     } //for updating a task in store with respect to task response from db in task details page
 
-    if (accesibleTaskIds) {
-      store.dispatch(setAccesibleTaskIds(accesibleTaskIds))
+    if (accessibleTasks) {
+      store.dispatch(setAccessibleTasks(accessibleTasks))
     }
   }, [
     workflowStates,
@@ -125,7 +126,7 @@ export const ClientSideStateUpdate = ({
     templates,
     assigneeSuggestions,
     task,
-    accesibleTaskIds,
+    accessibleTasks,
   ])
 
   return children

--- a/src/redux/features/taskBoardSlice.tsx
+++ b/src/redux/features/taskBoardSlice.tsx
@@ -3,7 +3,7 @@ import { RootState } from '../store'
 import { WorkflowStateResponse } from '@/types/dto/workflowStates.dto'
 import { TaskResponse } from '@/types/dto/tasks.dto'
 import { FilterByOptions, FilterOptions, IAssigneeCombined, IFilterOptions } from '@/types/interfaces'
-import { ViewMode } from '@prisma/client'
+import { Task, ViewMode } from '@prisma/client'
 import { CreateViewSettingsDTO, FilterOptionsType } from '@/types/dto/viewSettings.dto'
 import { PreviewMode } from '@/types/common'
 
@@ -22,7 +22,7 @@ interface IInitialState {
   isTasksLoading: boolean
   activeTask: TaskResponse | undefined
   previewMode: PreviewMode
-  accesibleTaskIds: string[]
+  accessibleTasks: Pick<Task, 'id' | 'parentId'>[]
 }
 
 const initialState: IInitialState = {
@@ -45,7 +45,7 @@ const initialState: IInitialState = {
   isTasksLoading: true,
   activeTask: undefined,
   previewMode: null,
-  accesibleTaskIds: [],
+  accessibleTasks: [],
 }
 
 const taskBoardSlice = createSlice({
@@ -134,8 +134,8 @@ const taskBoardSlice = createSlice({
     setPreviewMode: (state, action: { payload: PreviewMode }) => {
       state.previewMode = action.payload
     },
-    setAccesibleTaskIds: (state, action: { payload: string[] }) => {
-      state.accesibleTaskIds = action.payload
+    setAccessibleTasks: (state, action: { payload: Pick<Task, 'id' | 'parentId'>[] }) => {
+      state.accessibleTasks = action.payload
     },
   },
 })
@@ -157,7 +157,7 @@ export const {
   setIsTasksLoading,
   setActiveTask,
   setPreviewMode,
-  setAccesibleTaskIds,
+  setAccessibleTasks,
 } = taskBoardSlice.actions
 
 export default taskBoardSlice.reducer


### PR DESCRIPTION
## Changes

- [x] changed the state accessibleTaskIds from storing only ids of global accessible tasks to store parentId of each tasks too.
- [x] compared the parentId of subtasks while fetching tasks to calculate number of subtasks count for client users and internal users.

## Testing Criteria

- TBD

