### PR TITLE
OUT-1600 | Text editor doesn't work for reply comment

### DIFF
--- a/src/components/inputs/ReplyInput.tsx
+++ b/src/components/inputs/ReplyInput.tsx
@@ -109,9 +109,11 @@ export const ReplyInput = ({
   }, [detail, editorRef.current])
 
   useEffect(() => {
-    if (editorRef.current && focusReplyInput) {
-      editorRef.current.focus()
-    }
+    setTimeout(() => {
+      if (editorRef.current && focusReplyInput) {
+        editorRef.current.focus()
+      }
+    }, 100)
   }, [focusReplyInput, editorRef.current])
 
   const [isDragging, setIsDragging] = useState(false)


### PR DESCRIPTION
## Changes

- [x] fixed bubble menu effects (bold, italics, numbers...) not working on reply input.
- [x] cause for this issue was focus state of reply input tapwrite instance being false while clicking outside the reply input. added a neglibile delay to the change in focus state.

## Testing Criteria

- [LOOM](https://www.loom.com/share/ba46fc675e48473f9c29ca7e1afeb619)
