### PR TITLE
OUT-1597 | Show all ancestor task titles in App Bridge header

### DIFF
--- a/src/app/api/tasks/[id]/path/route.ts
+++ b/src/app/api/tasks/[id]/path/route.ts
@@ -1,0 +1,4 @@
+import { withErrorHandler } from '@api/core/utils/withErrorHandler'
+import { getTaskPath } from '@api/tasks/tasks.controller'
+
+export const GET = withErrorHandler(getTaskPath)

--- a/src/app/api/tasks/subtasks.service.ts
+++ b/src/app/api/tasks/subtasks.service.ts
@@ -1,11 +1,11 @@
+import { CopilotAPI } from '@/utils/CopilotAPI'
 import { buildLtreeNodeString } from '@/utils/ltree'
 import APIError from '@api/core/exceptions/api'
 import { BaseService } from '@api/core/services/base.service'
+import { UserRole } from '@api/core/types/user'
+import { AssigneeType } from '@prisma/client'
 import httpStatus from 'http-status'
 import { z } from 'zod'
-import { UserRole } from '../core/types/user'
-import { CopilotAPI } from '@/utils/CopilotAPI'
-import { AssigneeType } from '@prisma/client'
 
 interface Assignable {
   assigneeId: string
@@ -84,7 +84,7 @@ export class SubtaskService extends BaseService {
     )
   }
 
-  async getAccessiblePathTasks(tasks: Assignable[]) {
+  async getAccessiblePathTasks<T extends Assignable>(tasks: T[]): Promise<T[]> {
     //  find the last index of the task that is unaccessible to the user
     //  return all tasks starting from index + 1 -> last value of tasks
     let latestAccessibleTaskIndex: number

--- a/src/app/api/tasks/subtasks.service.ts
+++ b/src/app/api/tasks/subtasks.service.ts
@@ -92,10 +92,12 @@ export class SubtaskService extends BaseService {
     if (this.user.role === UserRole.IU) {
       const copilot = new CopilotAPI(this.user.token)
       const iu = await copilot.getInternalUser(z.string().parse(this.user.internalUserId))
+      console.log('iu', iu)
       if (!iu.isClientAccessLimited) {
         return tasks
       }
       const clients = await copilot.getClients({ limit: 1_000_000 })
+      console.log('tasks', tasks)
       latestAccessibleTaskIndex = tasks.findLastIndex((task) => {
         if (task.assigneeType === AssigneeType.internalUser) return false
         else if (task.assigneeType === AssigneeType.client) {
@@ -118,6 +120,7 @@ export class SubtaskService extends BaseService {
     } else {
       throw new APIError(httpStatus.BAD_REQUEST, 'Failed to parse user role from token')
     }
+    console.log('latestAccessibleTaskIndex', latestAccessibleTaskIndex)
 
     if (latestAccessibleTaskIndex < 0) {
       return tasks

--- a/src/app/api/tasks/subtasks.service.ts
+++ b/src/app/api/tasks/subtasks.service.ts
@@ -112,21 +112,12 @@ export class SubtaskService extends BaseService {
       })
     } else if (this.user.role === UserRole.Client) {
       // If user is a client, just check index of which task was last assigned to client
-      console.log('\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n')
-      console.log('tasks', tasks)
-      console.log('client', this.user.clientId)
-      console.log('\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n')
-
       latestAccessibleTaskIndex = tasks.findLastIndex(
         (task) => task.assigneeId !== this.user.clientId && task.assigneeId !== this.user.companyId,
       )
     } else {
       throw new APIError(httpStatus.BAD_REQUEST, 'Failed to parse user role from token')
     }
-    console.log('\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n')
-    console.log('latestAccessibleTaskIndex', latestAccessibleTaskIndex)
-    console.log('\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n')
-
     if (latestAccessibleTaskIndex < 0) {
       return tasks
     }

--- a/src/app/api/tasks/subtasks.service.ts
+++ b/src/app/api/tasks/subtasks.service.ts
@@ -92,12 +92,10 @@ export class SubtaskService extends BaseService {
     if (this.user.role === UserRole.IU) {
       const copilot = new CopilotAPI(this.user.token)
       const iu = await copilot.getInternalUser(z.string().parse(this.user.internalUserId))
-      console.log('iu', iu)
       if (!iu.isClientAccessLimited) {
         return tasks
       }
       const clients = await copilot.getClients({ limit: 1_000_000 })
-      console.log('tasks', tasks)
       latestAccessibleTaskIndex = tasks.findLastIndex((task) => {
         if (task.assigneeType === AssigneeType.internalUser) return false
         else if (task.assigneeType === AssigneeType.client) {
@@ -114,13 +112,20 @@ export class SubtaskService extends BaseService {
       })
     } else if (this.user.role === UserRole.Client) {
       // If user is a client, just check index of which task was last assigned to client
+      console.log('\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n')
+      console.log('tasks', tasks)
+      console.log('client', this.user.clientId)
+      console.log('\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n')
+
       latestAccessibleTaskIndex = tasks.findLastIndex(
-        (task) => task.assigneeId !== this.user.clientId || task.assigneeId !== this.user.companyId,
+        (task) => task.assigneeId !== this.user.clientId && task.assigneeId !== this.user.companyId,
       )
     } else {
       throw new APIError(httpStatus.BAD_REQUEST, 'Failed to parse user role from token')
     }
+    console.log('\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n')
     console.log('latestAccessibleTaskIndex', latestAccessibleTaskIndex)
+    console.log('\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n')
 
     if (latestAccessibleTaskIndex < 0) {
       return tasks

--- a/src/app/api/tasks/subtasks.service.ts
+++ b/src/app/api/tasks/subtasks.service.ts
@@ -118,9 +118,6 @@ export class SubtaskService extends BaseService {
     } else {
       throw new APIError(httpStatus.BAD_REQUEST, 'Failed to parse user role from token')
     }
-    if (latestAccessibleTaskIndex < 0) {
-      return tasks
-    }
     return tasks.slice(latestAccessibleTaskIndex + 1)
   }
 }

--- a/src/app/api/tasks/tasks.controller.ts
+++ b/src/app/api/tasks/tasks.controller.ts
@@ -86,6 +86,6 @@ export const clientUpdateTask = async (req: NextRequest, { params: { id } }: IdP
 export const getTaskPath = async (req: NextRequest, { params: { id } }: IdParams) => {
   const user = await authenticate(req)
   const tasksService = new TasksService(user)
-  const ancestors = await tasksService.getTraversalPath(id)
-  return NextResponse.json({ ancestors })
+  const path = await tasksService.getTraversalPath(id)
+  return NextResponse.json({ path })
 }

--- a/src/app/api/tasks/tasks.controller.ts
+++ b/src/app/api/tasks/tasks.controller.ts
@@ -82,3 +82,10 @@ export const clientUpdateTask = async (req: NextRequest, { params: { id } }: IdP
   const updatedTask = await tasksService.clientUpdateTask(id, workflowStateId)
   return NextResponse.json({ updatedTask })
 }
+
+export const getTaskPath = async (req: NextRequest, { params: { id } }: IdParams) => {
+  const user = await authenticate(req)
+  const tasksService = new TasksService(user)
+  const ancestors = await tasksService.getTraversalPath(id)
+  return NextResponse.json({ ancestors })
+}

--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -604,7 +604,7 @@ export class TasksService extends BaseService {
     const parentTasks = await Promise.all(
       parents.map((id) =>
         this.db.task.findFirstOrThrow({
-          where: { id, workspaceId: this.user.workspaceId, assigneeId: { not: null } },
+          where: { id, workspaceId: this.user.workspaceId },
           select: { title: true, label: true, assigneeId: true, assigneeType: true },
         }),
       ) as Promise<AncestorTaskResponse>[],

--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -605,7 +605,7 @@ export class TasksService extends BaseService {
       parents.map((id) =>
         this.db.task.findFirstOrThrow({
           where: { id, workspaceId: this.user.workspaceId },
-          select: { title: true, label: true, assigneeId: true, assigneeType: true },
+          select: { id: true, title: true, label: true, assigneeId: true, assigneeType: true },
         }),
       ) as Promise<AncestorTaskResponse>[],
     )

--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -2,8 +2,7 @@ import { MAX_FETCH_ASSIGNEE_COUNT } from '@/constants/users'
 import { deleteTaskNotifications, sendTaskCreateNotifications, sendTaskUpdateNotifications } from '@/jobs/notifications'
 import { sendClientUpdateTaskNotifications } from '@/jobs/notifications/send-client-task-update-notifications'
 import { ClientResponse, CompanyResponse, InternalUsers } from '@/types/common'
-import { AncestorTask } from '@/types/db'
-import { CreateTaskRequest, UpdateTaskRequest } from '@/types/dto/tasks.dto'
+import { AncestorTaskResponse, CreateTaskRequest, UpdateTaskRequest } from '@/types/dto/tasks.dto'
 import { CopilotAPI } from '@/utils/CopilotAPI'
 import { buildLtree, buildLtreeNodeString, getIdsFromLtreePath } from '@/utils/ltree'
 import { getFilePathFromUrl, replaceImageSrc } from '@/utils/signedUrlReplacer'
@@ -589,7 +588,7 @@ export class TasksService extends BaseService {
     return updatedTask
   }
 
-  async getTraversalPath(id: string): Promise<any> {
+  async getTraversalPath(id: string): Promise<AncestorTaskResponse[]> {
     const taskWithPath = (
       await this.db.$queryRaw<{ path: string }[]>`
       SELECT "path" from "Tasks"
@@ -608,7 +607,7 @@ export class TasksService extends BaseService {
           where: { id, workspaceId: this.user.workspaceId, assigneeId: { not: null } },
           select: { title: true, label: true, assigneeId: true, assigneeType: true },
         }),
-      ) as Promise<AncestorTask>[], // safe casting, trust me
+      ) as Promise<AncestorTaskResponse>[],
     )
 
     const subtaskService = new SubtaskService(this.user)

--- a/src/app/detail/[task_id]/[user_type]/page.tsx
+++ b/src/app/detail/[task_id]/[user_type]/page.tsx
@@ -66,6 +66,7 @@ async function getSubTasksStatus(token: string, taskId: string): Promise<SubTask
 async function getTaskPath(token: string, taskId: string): Promise<AncestorTaskResponse[]> {
   const res = await fetch(`${apiUrl}/api/tasks/${taskId}/path?token=${token}`)
   const { path } = await res.json()
+  console.log('path', path)
   return path
 }
 

--- a/src/app/detail/[task_id]/[user_type]/page.tsx
+++ b/src/app/detail/[task_id]/[user_type]/page.tsx
@@ -116,12 +116,7 @@ export default async function TaskDetailPage({
               <StyledBox>
                 <AppMargin size={SizeofAppMargin.HEADER} py="17.5px">
                   <Stack direction="row" justifyContent="space-between">
-                    <HeaderBreadcrumbs
-                      token={token}
-                      title={task?.label}
-                      items={breadcrumbItems}
-                      userType={params.user_type}
-                    />
+                    <HeaderBreadcrumbs token={token} items={breadcrumbItems} userType={params.user_type} />
                     <Stack direction="row" alignItems="center" columnGap="8px">
                       <MenuBoxContainer role={tokenPayload.internalUserId ? UserRole.IU : UserRole.Client} />
                       <Stack direction="row" alignItems="center" columnGap="8px">
@@ -135,7 +130,6 @@ export default async function TaskDetailPage({
               <>
                 <HeaderBreadcrumbs
                   token={token}
-                  title={task?.label}
                   items={breadcrumbItems}
                   userType={params.user_type}
                   portalUrl={workspace.portalUrl}

--- a/src/app/detail/[task_id]/[user_type]/page.tsx
+++ b/src/app/detail/[task_id]/[user_type]/page.tsx
@@ -32,6 +32,7 @@ import { signedUrlTtl } from '@/constants/attachments'
 import { AppMargin, SizeofAppMargin } from '@/hoc/AppMargin'
 import CustomScrollBar from '@/hoc/CustomScrollBar'
 import { RealTime } from '@/hoc/RealTime'
+import { Clickable } from '@/hooks/app-bridge/types'
 import { WorkspaceResponse } from '@/types/common'
 import { AncestorTaskResponse, SubTaskStatusResponse, TaskResponse } from '@/types/dto/tasks.dto'
 import { UserType } from '@/types/interfaces'
@@ -105,7 +106,10 @@ export default async function TaskDetailPage({
 
   const isPreviewMode = !!getPreviewMode(tokenPayload)
 
-  const breadcrumbItems = taskPath.map((task) => task.label)
+  const breadcrumbItems: { label: string; href: string }[] = taskPath.map(({ label, id }) => ({
+    label,
+    href: `/detail/${id}/${user_type}?token=${token}`,
+  }))
 
   return (
     <DetailStateUpdate isRedirect={!!searchParams.isRedirect} token={token} tokenPayload={tokenPayload} task={task}>

--- a/src/app/detail/[task_id]/[user_type]/page.tsx
+++ b/src/app/detail/[task_id]/[user_type]/page.tsx
@@ -33,7 +33,7 @@ import { AppMargin, SizeofAppMargin } from '@/hoc/AppMargin'
 import CustomScrollBar from '@/hoc/CustomScrollBar'
 import { RealTime } from '@/hoc/RealTime'
 import { WorkspaceResponse } from '@/types/common'
-import { SubTaskStatusResponse, TaskResponse } from '@/types/dto/tasks.dto'
+import { AncestorTaskResponse, SubTaskStatusResponse, TaskResponse } from '@/types/dto/tasks.dto'
 import { UserType } from '@/types/interfaces'
 import { CopilotAPI } from '@/utils/CopilotAPI'
 import EscapeHandler from '@/utils/escapeHandler'
@@ -63,6 +63,12 @@ async function getSubTasksStatus(token: string, taskId: string): Promise<SubTask
   return data
 }
 
+async function getTaskPath(token: string, taskId: string): Promise<AncestorTaskResponse[]> {
+  const res = await fetch(`${apiUrl}/api/tasks/${taskId}/path?token=${token}`)
+  const { path } = await res.json()
+  return path
+}
+
 export default async function TaskDetailPage({
   params,
   searchParams,
@@ -79,11 +85,12 @@ export default async function TaskDetailPage({
 
   const copilotClient = new CopilotAPI(token)
 
-  const [task, tokenPayload, workspace, subTaskStatus] = await Promise.all([
+  const [task, tokenPayload, workspace, subTaskStatus, taskPath] = await Promise.all([
     getOneTask(token, task_id),
     copilotClient.getTokenPayload(),
     getWorkspace(token),
     getSubTasksStatus(token, task_id),
+    getTaskPath(token, task_id),
   ])
 
   if (!tokenPayload) {
@@ -97,6 +104,8 @@ export default async function TaskDetailPage({
 
   const isPreviewMode = !!getPreviewMode(tokenPayload)
 
+  const breadcrumbItems = taskPath.map((task) => task.label)
+
   return (
     <DetailStateUpdate isRedirect={!!searchParams.isRedirect} token={token} tokenPayload={tokenPayload} task={task}>
       <RealTime tokenPayload={tokenPayload}>
@@ -107,7 +116,12 @@ export default async function TaskDetailPage({
               <StyledBox>
                 <AppMargin size={SizeofAppMargin.HEADER} py="17.5px">
                   <Stack direction="row" justifyContent="space-between">
-                    <HeaderBreadcrumbs token={token} title={task?.label} userType={params.user_type} />
+                    <HeaderBreadcrumbs
+                      token={token}
+                      title={task?.label}
+                      items={breadcrumbItems}
+                      userType={params.user_type}
+                    />
                     <Stack direction="row" alignItems="center" columnGap="8px">
                       <MenuBoxContainer role={tokenPayload.internalUserId ? UserRole.IU : UserRole.Client} />
                       <Stack direction="row" alignItems="center" columnGap="8px">
@@ -122,6 +136,7 @@ export default async function TaskDetailPage({
                 <HeaderBreadcrumbs
                   token={token}
                   title={task?.label}
+                  items={breadcrumbItems}
                   userType={params.user_type}
                   portalUrl={workspace.portalUrl}
                 />

--- a/src/app/detail/[task_id]/[user_type]/page.tsx
+++ b/src/app/detail/[task_id]/[user_type]/page.tsx
@@ -22,7 +22,6 @@ import { Sidebar, SidebarSkeleton } from '@/app/detail/ui/Sidebar'
 import { StyledBox, StyledTiptapDescriptionWrapper, TaskDetailsContainer } from '@/app/detail/ui/styledComponent'
 import { Subtasks } from '@/app/detail/ui/Subtasks'
 import { TaskEditor } from '@/app/detail/ui/TaskEditor'
-import { ToggleButtonContainer } from '@/app/detail/ui/ToggleButtonContainer'
 import { ToggleController } from '@/app/detail/ui/ToggleController'
 import { DeletedTaskRedirectPage } from '@/components/layouts/DeletedTaskRedirectPage'
 import { HeaderBreadcrumbs } from '@/components/layouts/HeaderBreadcrumbs'
@@ -32,7 +31,6 @@ import { signedUrlTtl } from '@/constants/attachments'
 import { AppMargin, SizeofAppMargin } from '@/hoc/AppMargin'
 import CustomScrollBar from '@/hoc/CustomScrollBar'
 import { RealTime } from '@/hoc/RealTime'
-import { Clickable } from '@/hooks/app-bridge/types'
 import { WorkspaceResponse } from '@/types/common'
 import { AncestorTaskResponse, SubTaskStatusResponse, TaskResponse } from '@/types/dto/tasks.dto'
 import { UserType } from '@/types/interfaces'
@@ -67,7 +65,6 @@ async function getSubTasksStatus(token: string, taskId: string): Promise<SubTask
 async function getTaskPath(token: string, taskId: string): Promise<AncestorTaskResponse[]> {
   const res = await fetch(`${apiUrl}/api/tasks/${taskId}/path?token=${token}`)
   const { path } = await res.json()
-  console.log('path', path)
   return path
 }
 

--- a/src/app/manage-templates/ui/Header.tsx
+++ b/src/app/manage-templates/ui/Header.tsx
@@ -21,7 +21,7 @@ export const ManageTemplateHeader = ({ token }: { token: string }) => {
       <AppMargin size={SizeofAppMargin.HEADER} py="14px">
         <Stack direction="row" justifyContent="space-between" alignItems="center">
           <HeaderBreadcrumbs
-            items={['Manage templates']}
+            items={[{ label: 'Manage templates' }]}
             token={token}
             // Treat user as IU since only they are allowed to manage templates for now
             userType={UserType.INTERNAL_USER}

--- a/src/app/manage-templates/ui/Header.tsx
+++ b/src/app/manage-templates/ui/Header.tsx
@@ -21,7 +21,7 @@ export const ManageTemplateHeader = ({ token }: { token: string }) => {
       <AppMargin size={SizeofAppMargin.HEADER} py="14px">
         <Stack direction="row" justifyContent="space-between" alignItems="center">
           <HeaderBreadcrumbs
-            title="Manage templates"
+            items={['Manage templates']}
             token={token}
             // Treat user as IU since only they are allowed to manage templates for now
             userType={UserType.INTERNAL_USER}

--- a/src/components/layouts/HeaderBreadcrumbs.tsx
+++ b/src/components/layouts/HeaderBreadcrumbs.tsx
@@ -24,6 +24,11 @@ export const HeaderBreadcrumbs = ({
   portalUrl?: string
 }) => {
   const { previewMode } = useSelector(selectTaskBoard)
+  console.log('items', items)
+  console.log(
+    'items breadcrumb',
+    items.map((label) => ({ label })),
+  )
 
   const getTasksLink = (userType: UserType): ValidTasksBoardLink => {
     if (previewMode) return '/client'

--- a/src/components/layouts/HeaderBreadcrumbs.tsx
+++ b/src/components/layouts/HeaderBreadcrumbs.tsx
@@ -3,7 +3,6 @@
 import { StyledKeyboardIcon, StyledTypography } from '@/app/detail/ui/styledComponent'
 import { SecondaryBtn } from '@/components/buttons/SecondaryBtn'
 import { CustomLink } from '@/hoc/CustomLink'
-import { Clickable } from '@/hooks/app-bridge/types'
 import { useBreadcrumbs } from '@/hooks/app-bridge/useBreadcrumbs'
 import { selectTaskBoard } from '@/redux/features/taskBoardSlice'
 import { UserType } from '@/types/interfaces'
@@ -27,11 +26,6 @@ export const HeaderBreadcrumbs = ({
 }) => {
   const { previewMode } = useSelector(selectTaskBoard)
   const router = useRouter()
-  console.log('items', items)
-  console.log(
-    'items breadcrumb',
-    items.map((label) => ({ label })),
-  )
 
   const getTasksLink = (userType: UserType): ValidTasksBoardLink => {
     if (previewMode) return '/client'

--- a/src/components/layouts/HeaderBreadcrumbs.tsx
+++ b/src/components/layouts/HeaderBreadcrumbs.tsx
@@ -3,10 +3,12 @@
 import { StyledKeyboardIcon, StyledTypography } from '@/app/detail/ui/styledComponent'
 import { SecondaryBtn } from '@/components/buttons/SecondaryBtn'
 import { CustomLink } from '@/hoc/CustomLink'
+import { Clickable } from '@/hooks/app-bridge/types'
 import { useBreadcrumbs } from '@/hooks/app-bridge/useBreadcrumbs'
 import { selectTaskBoard } from '@/redux/features/taskBoardSlice'
 import { UserType } from '@/types/interfaces'
 import { Stack, Typography } from '@mui/material'
+import { useRouter } from 'next/navigation'
 import { Fragment } from 'react'
 import { useSelector } from 'react-redux'
 
@@ -19,11 +21,12 @@ export const HeaderBreadcrumbs = ({
   portalUrl,
 }: {
   token: string | undefined
-  items: string[]
+  items: { label: string; href?: string }[]
   userType: UserType
   portalUrl?: string
 }) => {
   const { previewMode } = useSelector(selectTaskBoard)
+  const router = useRouter()
   console.log('items', items)
   console.log(
     'items breadcrumb',
@@ -40,7 +43,7 @@ export const HeaderBreadcrumbs = ({
     return tasksLinks[userType]
   }
   useBreadcrumbs(
-    items.map((label) => ({ label })),
+    items.map(({ label, href }) => ({ label, onClick: href ? () => router.push(href) : undefined })),
     { portalUrl },
   )
 
@@ -61,7 +64,7 @@ export const HeaderBreadcrumbs = ({
         />
       </CustomLink>
       {items.map((item) => (
-        <Fragment key={item}>
+        <Fragment key={item.label}>
           <StyledKeyboardIcon />
           <Typography
             variant="sm"
@@ -69,7 +72,7 @@ export const HeaderBreadcrumbs = ({
               fontSize: '13px',
             }}
           >
-            {item}
+            {item.label}
           </Typography>
         </Fragment>
       ))}

--- a/src/components/layouts/HeaderBreadcrumbs.tsx
+++ b/src/components/layouts/HeaderBreadcrumbs.tsx
@@ -7,19 +7,19 @@ import { useBreadcrumbs } from '@/hooks/app-bridge/useBreadcrumbs'
 import { selectTaskBoard } from '@/redux/features/taskBoardSlice'
 import { UserType } from '@/types/interfaces'
 import { Stack, Typography } from '@mui/material'
-import { useRouter } from 'next/navigation'
+import { Fragment } from 'react'
 import { useSelector } from 'react-redux'
 
 type ValidTasksBoardLink = '/' | '/client'
 
 export const HeaderBreadcrumbs = ({
   token,
-  title,
+  items,
   userType,
   portalUrl,
 }: {
   token: string | undefined
-  title: string
+  items: string[]
   userType: UserType
   portalUrl?: string
 }) => {
@@ -35,11 +35,7 @@ export const HeaderBreadcrumbs = ({
     return tasksLinks[userType]
   }
   useBreadcrumbs(
-    [
-      {
-        label: title,
-      },
-    ],
+    items.map((label) => ({ label })),
     { portalUrl },
   )
 
@@ -59,15 +55,19 @@ export const HeaderBreadcrumbs = ({
           variant="breadcrumb"
         />
       </CustomLink>
-      <StyledKeyboardIcon />
-      <Typography
-        variant="sm"
-        sx={{
-          fontSize: '13px',
-        }}
-      >
-        {title}
-      </Typography>
+      {items.map((item) => (
+        <Fragment key={item}>
+          <StyledKeyboardIcon />
+          <Typography
+            variant="sm"
+            sx={{
+              fontSize: '13px',
+            }}
+          >
+            {item}
+          </Typography>
+        </Fragment>
+      ))}
     </Stack>
   )
 }

--- a/src/types/db.ts
+++ b/src/types/db.ts
@@ -1,3 +1,5 @@
-import { Task, WorkflowState } from '@prisma/client'
+import { AssigneeType, Task, WorkflowState } from '@prisma/client'
 
 export type TaskWithWorkflowState = Task & { workflowState: WorkflowState }
+
+export type AncestorTask = Pick<Task, 'title' | 'label'> & { assigneeId: string; assigneeType: AssigneeType }

--- a/src/types/db.ts
+++ b/src/types/db.ts
@@ -1,5 +1,3 @@
-import { AssigneeType, Task, WorkflowState } from '@prisma/client'
+import { Task, WorkflowState } from '@prisma/client'
 
 export type TaskWithWorkflowState = Task & { workflowState: WorkflowState }
-
-export type AncestorTask = Pick<Task, 'title' | 'label'> & { assigneeId: string; assigneeType: AssigneeType }

--- a/src/types/dto/tasks.dto.ts
+++ b/src/types/dto/tasks.dto.ts
@@ -1,4 +1,4 @@
-import { AssigneeType as PrismaAssigneeType } from '@prisma/client'
+import { AssigneeType as PrismaAssigneeType, Task } from '@prisma/client'
 import { z } from 'zod'
 import { WorkflowStateResponseSchema } from './workflowStates.dto'
 import { DateStringSchema } from '@/types/date'
@@ -63,3 +63,8 @@ export type AccessibleTasksResponse = Pick<
   TaskResponse,
   'id' | 'assigneeId' | 'assigneeType' | 'title' | 'body' | 'parentId'
 >
+
+export type AncestorTaskResponse = Pick<Task, 'title' | 'label'> & {
+  assigneeId: string
+  assigneeType: NonNullable<AssigneeType>
+}

--- a/src/types/dto/tasks.dto.ts
+++ b/src/types/dto/tasks.dto.ts
@@ -64,7 +64,7 @@ export type AccessibleTasksResponse = Pick<
   'id' | 'assigneeId' | 'assigneeType' | 'title' | 'body' | 'parentId'
 >
 
-export type AncestorTaskResponse = Pick<Task, 'title' | 'label'> & {
+export type AncestorTaskResponse = Pick<Task, 'id' | 'title' | 'label'> & {
   assigneeId: string
   assigneeType: NonNullable<AssigneeType>
 }

--- a/src/utils/ltree.ts
+++ b/src/utils/ltree.ts
@@ -5,3 +5,5 @@ export const buildLtree = (...paths: string[]) => {
 export const buildLtreeNodeString = (str: string) => {
   return str.toLowerCase().replaceAll('-', '_')
 }
+
+export const getIdsFromLtreePath = (path: string): string[] => path.replaceAll('_', '-').split('.')


### PR DESCRIPTION
## Changes

- [x] API - Implement GET `/api/tasks/:id/path` to get the traversal path tasks (ancestors)
- [x] UI - Implement clickable task label chains in breadcrumbs 

## Testing Criteria

- [x] Screenshot - non limited IU

<img width="1227" alt="image" src="https://github.com/user-attachments/assets/ec77fcc6-3ca3-4f0c-ad17-27079d449f67" />

- [x] Screenshot - Limited IU (Tasks are Testing breadcrumbs -> breadcrumbs 1 -> breadcrumbs 2 -> breadcrumbs 3)

<img width="1221" alt="image" src="https://github.com/user-attachments/assets/682fd597-e8fd-4879-a32d-37edc99d4c70" />

- [x] Screenshot - Client (All parent tasks are accessible)

<img width="1225" alt="image" src="https://github.com/user-attachments/assets/a732d51b-1103-4109-865c-8eaa7e2a2f23" />

- [x] Screenshot - Client (Parent task is not accessible) (Tasks are Testing breadcrumbs -> breadcrumbs 1 -> breadcrumbs 2 -> breadcrumbs 3)

<img width="1011" alt="image" src="https://github.com/user-attachments/assets/713ae80a-2d2f-40f4-9ef9-351f63331d6f" />
