### PR TITLE
OUT-1620 | Bug: Tasks with inaccessible subtasks appear in card should not show '0' as subtask count

### DIFF
--- a/src/components/atoms/TaskMetaItems.tsx
+++ b/src/components/atoms/TaskMetaItems.tsx
@@ -27,7 +27,7 @@ export const TaskMetaItems = ({ task, lineHeight }: { task: TaskResponse; lineHe
           </Typography>
         </Stack>
       )}
-      {task.subtaskCount > 0 && (
+      {subtaskCount > 0 && (
         <Stack direction="row" alignItems={'center'} columnGap={'4px'}>
           <Typography
             variant="bodySm"

--- a/src/components/atoms/TaskMetaItems.tsx
+++ b/src/components/atoms/TaskMetaItems.tsx
@@ -2,10 +2,15 @@ import { ArchiveBoxIcon, SubtaskIcon } from '@/icons'
 import { selectTaskBoard } from '@/redux/features/taskBoardSlice'
 import { TaskResponse } from '@/types/dto/tasks.dto'
 import { Box, Stack, Typography } from '@mui/material'
+import { useMemo } from 'react'
 import { useSelector } from 'react-redux'
 
 export const TaskMetaItems = ({ task, lineHeight }: { task: TaskResponse; lineHeight: string }) => {
   const { accessibleTasks } = useSelector(selectTaskBoard)
+  const subtaskCount = useMemo(() => {
+    return accessibleTasks.filter((t) => t.parentId === task.id).length
+  }, [accessibleTasks, task.id])
+
   return (
     <>
       {task.isArchived && (
@@ -32,7 +37,7 @@ export const TaskMetaItems = ({ task, lineHeight }: { task: TaskResponse; lineHe
               lineHeight: lineHeight ?? '21px',
             }}
           >
-            {accessibleTasks.filter((t) => t.parentId === task.id).length}
+            {subtaskCount}
           </Typography>
           <SubtaskIcon />
         </Stack>


### PR DESCRIPTION
## Changes

- [x] Fix subtaskCount meta item rendering logic to not show count when count is 0, even for tasks without inaccessible children

## Testing Criteria

- [x] Screenshot

<img width="430" alt="image" src="https://github.com/user-attachments/assets/43521671-91b4-49ef-84e1-670d730f7778" />

Previously this used to falsely show "0"

