### PR TITLE
OUT-1618 | Board view flickers with loading skeletons when switching from list view

### DIFF
--- a/src/app/detail/ui/TaskCardList.tsx
+++ b/src/app/detail/ui/TaskCardList.tsx
@@ -46,8 +46,10 @@ interface TaskCardListProps {
 }
 
 export const TaskCardList = ({ task, variant, workflowState, mode }: TaskCardListProps) => {
-  const { assignee, workflowStates, previewMode, token, confirmAssignModalId, tasks } = useSelector(selectTaskBoard)
-  const [currentAssignee, setCurrentAssignee] = useState<IAssigneeCombined | undefined>(undefined)
+  const { assignee, workflowStates, previewMode, token, confirmAssignModalId, assigneeCache } = useSelector(selectTaskBoard)
+  const [currentAssignee, setCurrentAssignee] = useState<IAssigneeCombined | undefined>(() => {
+    return assigneeCache[task.id]
+  })
 
   const [inputStatusValue, setInputStatusValue] = useState('')
   const [selectedAssignee, setSelectedAssignee] = useState<IAssigneeCombined | undefined>(undefined)
@@ -58,10 +60,13 @@ export const TaskCardList = ({ task, variant, workflowState, mode }: TaskCardLis
   useEffect(() => {
     if (assignee.length > 0) {
       const currentAssignee = assignee.find((el) => el.id === task.assigneeId)
+      const finalAssignee = currentAssignee ?? NoAssignee
       //@ts-expect-error  "type" property has mismatching types in between NoAssignee and IAssigneeCombined
-      setCurrentAssignee(currentAssignee ?? NoAssignee)
+      store.dispatch(setAssigneeCache({ key: task.id, value: finalAssignee }))
+      //@ts-expect-error  "type" property has mismatching types in between NoAssignee and IAssigneeCombined
+      setCurrentAssignee(finalAssignee)
     }
-  }, [assignee, task])
+  }, [assignee, task.id, task.assigneeId])
 
   const { renderingItem: _statusValue, updateRenderingItem: updateStatusValue } = useHandleSelectorComponent({
     // item: selectedWorkflowState,

--- a/src/app/detail/ui/TaskCardList.tsx
+++ b/src/app/detail/ui/TaskCardList.tsx
@@ -15,6 +15,7 @@ import { CustomLink } from '@/hoc/CustomLink'
 import { useHandleSelectorComponent } from '@/hooks/useHandleSelectorComponent'
 import {
   selectTaskBoard,
+  setAssigneeCache,
   setConfirmAssigneeModalId,
   setTasks,
   updateWorkflowStateIdByTaskId,
@@ -61,7 +62,7 @@ export const TaskCardList = ({ task, variant, workflowState, mode }: TaskCardLis
     if (assignee.length > 0) {
       const currentAssignee = assignee.find((el) => el.id === task.assigneeId)
       const finalAssignee = currentAssignee ?? NoAssignee
-      //@ts-expect-error  "type" property has mismatching types in between NoAssignee and IAssigneeCombined
+      // @ts-expect-error  "type" property has mismatching types in between NoAssignee and IAssigneeCombined
       store.dispatch(setAssigneeCache({ key: task.id, value: finalAssignee }))
       //@ts-expect-error  "type" property has mismatching types in between NoAssignee and IAssigneeCombined
       setCurrentAssignee(finalAssignee)

--- a/src/redux/features/taskBoardSlice.tsx
+++ b/src/redux/features/taskBoardSlice.tsx
@@ -25,6 +25,7 @@ interface IInitialState {
   accesibleTaskIds: string[]
   accessibleTasks: AccessibleTasksResponse[]
   confirmAssignModalId: string | undefined
+  assigneeCache: Record<string, IAssigneeCombined>
 }
 
 const initialState: IInitialState = {
@@ -50,6 +51,7 @@ const initialState: IInitialState = {
   accesibleTaskIds: [],
   accessibleTasks: [],
   confirmAssignModalId: '',
+  assigneeCache: {},
 }
 
 const taskBoardSlice = createSlice({
@@ -150,6 +152,9 @@ const taskBoardSlice = createSlice({
     setConfirmAssigneeModalId: (state, action: { payload: string | undefined }) => {
       state.confirmAssignModalId = action.payload
     },
+    setAssigneeCache: (state, action: { payload: { key: string; value: IAssigneeCombined } }) => {
+      state.assigneeCache[action.payload.key] = action.payload.value
+    }, //used in memory cache rather than useMemo for cross-view(board and list) caching. The alternate idea would be to include assignee object in the response of getTasks api for each task but that would be a bit expensive.
   },
 })
 
@@ -173,6 +178,7 @@ export const {
   setAccesibleTaskIds,
   setAccessibleTasks,
   setConfirmAssigneeModalId,
+  setAssigneeCache,
 } = taskBoardSlice.actions
 
 export default taskBoardSlice.reducer


### PR DESCRIPTION
## Changes

- [x] added a global cache for assignee to task id record.
- [x] used the data available in cache for rendering the assignee in board/list card.
- [x] used in memory cache rather than `useMemo` for cross-view(board and list) caching. The alternate idea would be to include assignee object in the response of `getTasks` api for each task but that would be a bit expensive. 

## Testing Criteria

- [LOOM](https://www.loom.com/share/dcf51e4080e340f0ae62cb68b3ac44d5)
