### PR TITLE
OUT-1621 | Disable clickability and hover state for the last task breadcrumb on the task details page

### DIFF
--- a/src/components/layouts/HeaderBreadcrumbs.tsx
+++ b/src/components/layouts/HeaderBreadcrumbs.tsx
@@ -37,7 +37,10 @@ export const HeaderBreadcrumbs = ({
     return tasksLinks[userType]
   }
   useBreadcrumbs(
-    items.map(({ label, href }) => ({ label, onClick: href ? () => router.push(href) : undefined })),
+    items.map(({ label, href }, index) => ({
+      label,
+      onClick: index === items.length - 1 ? undefined : href ? () => router.push(href) : undefined,
+    })),
     { portalUrl },
   )
 


### PR DESCRIPTION
## Changes

- [x] disabled `href` on last items on the `headerBreadcrumbs` rendered on the `AppBridge`. :bridge_at_night: 

