### PR TITLE
OUT-1626 | Realtime issue on navigation from parent to child task.

### DIFF
--- a/src/app/detail/[task_id]/[user_type]/actions.ts
+++ b/src/app/detail/[task_id]/[user_type]/actions.ts
@@ -122,3 +122,7 @@ export const postScrapMedia = async (token: string, payload: ScrapMediaRequest) 
     body: JSON.stringify(payload),
   })
 }
+
+export const revalidateGetOneTask = async () => {
+  revalidateTag('getOneTask')
+}

--- a/src/app/detail/ui/TaskEditor.tsx
+++ b/src/app/detail/ui/TaskEditor.tsx
@@ -72,7 +72,7 @@ export const TaskEditor = ({
   // }
 
   useEffect(() => {
-    revalidateGetOneTask()
+    revalidateGetOneTask() //cache invalidation on realtime updates
   }, [])
 
   useEffect(() => {

--- a/src/app/detail/ui/TaskEditor.tsx
+++ b/src/app/detail/ui/TaskEditor.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { revalidateGetOneTask } from '@/app/detail/[task_id]/[user_type]/actions'
 import { ImagePreviewModal } from '@/app/detail/ui/ImagePreviewModal'
 import { StyledModal } from '@/app/detail/ui/styledComponent'
 import AttachmentLayout from '@/components/AttachmentLayout'
@@ -69,6 +70,10 @@ export const TaskEditor = ({
   //     }
   //   }
   // }
+
+  useEffect(() => {
+    revalidateGetOneTask()
+  }, [])
 
   useEffect(() => {
     if (!isUserTyping && activeUploads === 0) {


### PR DESCRIPTION
## Changes

- [x] Added a revalidation for `getOneTask` on each details client component mount. A bit questionable but gets the job done. Also, this is better than running `router.restart()` on client navigations. 

## Testing Criteria

- [LOOM](https://www.loom.com/share/6b979f4bf40044c5b2f8598c5be78871)


