### PR TITLE
OUT-1647 | Task details page content shifts slightly left when fully loaded

### DIFF
--- a/src/app/detail/ui/Sidebar.tsx
+++ b/src/app/detail/ui/Sidebar.tsx
@@ -486,14 +486,14 @@ export const SidebarSkeleton = () => {
         sx={{ flexWrap: 'wrap', padding: '12px 18px' }}
       >
         <Box sx={{ height: '30px', alignItems: 'center', justifyContent: 'center', display: 'flex' }}>
-          <Skeleton variant="rectangular" width={120} height={15} />
+          <Skeleton variant="rectangular" width={140} height={15} />
         </Box>
         <Box sx={{ height: '30px', alignItems: 'center', justifyContent: 'center', display: 'flex' }}>
-          <Skeleton variant="rectangular" width={120} height={15} />
+          <Skeleton variant="rectangular" width={140} height={15} />
         </Box>
 
         <Box sx={{ height: '30px', alignItems: 'center', justifyContent: 'center', display: 'flex' }}>
-          <Skeleton variant="rectangular" width={120} height={15} />
+          <Skeleton variant="rectangular" width={140} height={15} />
         </Box>
       </Stack>
     )


### PR DESCRIPTION
## Changes

- [x] Increased the width of loading skeletons on `Sidebar` component. 

## Testing Criteria

- [LOOM](https://www.loom.com/share/b59ccd00bb46405eaa4b9f21d6f50c7d)

## Notes

- Was only able to reproduce this issue on smaller resolution. Please test accordingly. 


