### PR TITLE
OUT-1661 | Hide create subtask form after subtask is created

### DIFF
--- a/src/app/detail/ui/NewTaskCard.tsx
+++ b/src/app/detail/ui/NewTaskCard.tsx
@@ -216,9 +216,7 @@ export const NewTaskCard = ({
       }
       handleSubTaskCreation(payload)
       clearSubTaskFields()
-      if (inputRef.current) {
-        inputRef.current.focus()
-      }
+      handleClose()
     }
   }
 


### PR DESCRIPTION
## Changes

- [x] Closed the subtask form when a subtask is created. 

## Testing Criteria

- [LOOM](https://www.loom.com/share/ca5c2e2c3d914205976914b2c23aaccc)

