### PR TITLE
OUT-1635, OUT-1634, OUT-1582 | Change copy for empty due date property

### DIFF
--- a/src/app/detail/ui/NewTaskCard.tsx
+++ b/src/app/detail/ui/NewTaskCard.tsx
@@ -403,7 +403,7 @@ export const NewTaskCard = ({
                 <Typography
                   variant="bodySm"
                   sx={{
-                    color: (theme) => (assigneeValue ? theme.color.gray[600] : theme.color.gray[550]),
+                    color: (theme) => (assigneeValue ? theme.color.gray[600] : theme.color.text.textDisabled),
                     textOverflow: 'ellipsis',
                     whiteSpace: 'nowrap',
                     lineHeight: '22px',

--- a/src/app/ui/NewTaskForm.tsx
+++ b/src/app/ui/NewTaskForm.tsx
@@ -206,7 +206,7 @@ export const NewTaskForm = ({ handleCreate, handleClose }: NewTaskFormProps) => 
                 <Typography
                   variant="bodySm"
                   sx={{
-                    color: (theme) => (tempAssignee ? theme.color.gray[600] : theme.color.gray[550]),
+                    color: (theme) => (tempAssignee ? theme.color.gray[600] : theme.color.text.textDisabled),
                     textOverflow: 'ellipsis',
                     whiteSpace: 'nowrap',
 

--- a/src/components/AttachmentLayout.tsx
+++ b/src/components/AttachmentLayout.tsx
@@ -70,6 +70,7 @@ const AttachmentLayout: React.FC<AttachmentLayoutProps> = ({
         border: (theme) => `1px solid ${theme.color.gray[selected ? 600 : 300]}`,
         '& .download-btn': {
           opacity: 1,
+          cursor: 'pointer',
         },
       },
     },

--- a/src/components/inputs/DatePickerComponent.tsx
+++ b/src/components/inputs/DatePickerComponent.tsx
@@ -63,7 +63,7 @@ export const DatePickerComponent = ({
         onClick={handleClick}
         aria-describedby={id}
         sx={{
-          cursor: disabled ? 'auto' : 'default',
+          cursor: disabled ? 'auto' : 'pointer',
           padding: variant == 'button' || variant == 'icon' ? '0px' : '4px 8px',
           borderRadius: '4px',
         }}
@@ -73,25 +73,38 @@ export const DatePickerComponent = ({
             height={height}
             padding={padding}
             buttonContent={
-              <Stack direction="row" alignItems={'center'} columnGap={gap ?? '8px'}>
-                {size == Sizes.SMALL ? <CalenderIconSmall /> : <CalenderIcon />}
-                {size == Sizes.SMALL ? (
+              <Stack direction="row" alignItems="center" columnGap={gap ?? '8px'}>
+                {size === Sizes.SMALL ? <CalenderIconSmall /> : <CalenderIcon />}
+
+                {value ? (
+                  size === Sizes.SMALL ? (
+                    <Typography
+                      variant="bodySm"
+                      sx={{
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                        fontSize: '12px',
+                        overflow: 'hidden',
+                        maxWidth: { xs: '100px', sm: 'none' },
+                        color: (theme) => theme.color.gray[600],
+                      }}
+                    >
+                      {formatDate(value)}
+                    </Typography>
+                  ) : (
+                    <Typography variant="md" lineHeight="22px">
+                      {formatDate(value)}
+                    </Typography>
+                  )
+                ) : (
                   <Typography
-                    variant="bodySm"
+                    variant={size === Sizes.SMALL ? 'bodySm' : 'md'}
                     sx={{
-                      textOverflow: 'ellipsis',
-                      whiteSpace: 'nowrap',
-                      fontSize: '12px',
-                      overflow: 'hidden',
-                      maxWidth: { xs: '100px', sm: 'none' },
-                      color: (theme) => (value ? theme.color.gray[600] : theme.color.gray[550]),
+                      fontSize: size === Sizes.SMALL ? '12px' : undefined,
+                      color: (theme) => theme.color.text.textDisabled,
                     }}
                   >
-                    {value ? formatDate(value) : 'Due date'}
-                  </Typography>
-                ) : (
-                  <Typography variant="md" lineHeight="22px">
-                    {value ? formatDate(value) : 'Due date'}
+                    Due date
                   </Typography>
                 )}
               </Stack>
@@ -114,7 +127,7 @@ export const DatePickerComponent = ({
                 userSelect: 'none',
               }}
             >
-              {value ? formatDate(value) : 'No due date'}
+              {value ? formatDate(value) : 'None'}
             </Typography>
           </>
         ) : (

--- a/src/components/inputs/Selector-WorkflowState.tsx
+++ b/src/components/inputs/Selector-WorkflowState.tsx
@@ -70,7 +70,7 @@ export const WorkflowStateSelector = ({
               sx={{
                 padding: '4px 8px',
                 justifyContent: { xs: 'end', sm: 'flex-start' },
-                cursor: disabled ? 'auto' : 'default',
+                cursor: disabled ? 'auto' : 'pointer',
               }}
             >
               <Box>{statusIcons[Sizes.MEDIUM][value?.type]}</Box>

--- a/src/components/inputs/Selector.tsx
+++ b/src/components/inputs/Selector.tsx
@@ -230,6 +230,7 @@ export default function Selector<T extends keyof SelectorOptionsType>({
               padding: padding ? padding : '8px 8px',
               ':hover': {
                 backgroundColor: disabled ? 'none' : (theme) => theme.color.gray[100],
+                cursor: disabled ? 'auto' : 'pointer',
               },
             }}
           >


### PR DESCRIPTION
## Changes

- [x] used the correct placeholder color for selectors, workflowstate, assignee, due date on sub task card, and new task form.
- [x] changed copy of empty due date on the sidebar.
- [x] used pointer cursors on hover on different selectors, if not disabled.

## Testing Criteria

- [LOOM](https://www.loom.com/share/a0975beea1834ddf806d9f32a746c4b7)
