### PR TITLE
OUT-1648 | Filter limited access IU from assignee dropdown in subtasks

### DIFF
--- a/src/app/_fetchers/AssigneeFetcher.tsx
+++ b/src/app/_fetchers/AssigneeFetcher.tsx
@@ -54,10 +54,12 @@ export const AssigneeFetcher = async ({
   task,
   clientCompanyId,
 }: AssigneeFetcherProps) => {
-  const assignableUsersWithType = addTypeToAssignee(await fetchAssignee(token, userType, isPreview))
-  const assignableUsersWithTypeForLimitedTask = clientCompanyId
-    ? addTypeToAssignee(await fetchAssignee(token, userType, isPreview, clientCompanyId))
-    : []
+  const [assignableUsersWithType, assignableUsersWithTypeForLimitedTask] = await Promise.all([
+    fetchAssignee(token, userType, isPreview).then(addTypeToAssignee),
+    clientCompanyId
+      ? fetchAssignee(token, userType, isPreview, clientCompanyId).then(addTypeToAssignee)
+      : Promise.resolve([]),
+  ])
   return (
     <ClientSideStateUpdate
       assignee={assignableUsersWithType}

--- a/src/app/_fetchers/AssigneeFetcher.tsx
+++ b/src/app/_fetchers/AssigneeFetcher.tsx
@@ -54,7 +54,7 @@ export const AssigneeFetcher = async ({
   task,
   clientCompanyId,
 }: AssigneeFetcherProps) => {
-  const [assignableUsersWithType, assignableUsersWithTypeForLimitedTask] = await Promise.all([
+  const [assignableUsersWithType, activeTaskAssignees] = await Promise.all([
     fetchAssignee(token, userType, isPreview).then(addTypeToAssignee),
     clientCompanyId
       ? fetchAssignee(token, userType, isPreview, clientCompanyId).then(addTypeToAssignee)
@@ -65,7 +65,7 @@ export const AssigneeFetcher = async ({
       assignee={assignableUsersWithType}
       viewSettings={viewSettings}
       task={task}
-      assigneeListForLimitedTasks={assignableUsersWithTypeForLimitedTask}
+      activeTaskAssignees={activeTaskAssignees}
     >
       {null}
     </ClientSideStateUpdate>

--- a/src/app/api/users/users.controller.ts
+++ b/src/app/api/users/users.controller.ts
@@ -12,10 +12,12 @@ export const getUsers = async (req: NextRequest) => {
   const userType = req.nextUrl.searchParams.get('userType') || undefined
   const limit = rawLimit ? +rawLimit : undefined
   const nextToken = req.nextUrl.searchParams.get('nextToken') || undefined
+  const clientCompanyId = req.nextUrl.searchParams.get('clientCompanyId') || undefined
+  //Added a clientCompanyId param here to incorporate filtering of limited access IU for subtask creation if the parent task is assigned to client out of scope.
   // "search" param condition has been separated so we can unplug it in the future after CopilotAPI implements keyword match natively
   const users = await (keyword
-    ? usersService.getFilteredUsersStartingWith(keyword, userType, limit, nextToken)
-    : usersService.getGroupedUsers(limit))
+    ? usersService.getFilteredUsersStartingWith(keyword, userType, limit, nextToken, clientCompanyId)
+    : usersService.getGroupedUsers(limit, undefined, clientCompanyId))
 
   return NextResponse.json({ users })
 }

--- a/src/app/api/users/users.service.ts
+++ b/src/app/api/users/users.service.ts
@@ -80,11 +80,7 @@ class UsersService extends BaseService {
     let filteredIUs = internalUsers
     if (companyId) {
       filteredIUs = filteredIUs.filter((iu) => {
-        if (iu.isClientAccessLimited) {
-          return iu.companyAccessList?.includes(companyId)
-        } else {
-          return true
-        }
+        !iu.isClientAccessLimited || iu.companyAccessList?.includes(companyId)
       })
     }
 

--- a/src/app/detail/[task_id]/[user_type]/page.tsx
+++ b/src/app/detail/[task_id]/[user_type]/page.tsx
@@ -197,6 +197,7 @@ export default async function TaskDetailPage({
                   userType={params.user_type}
                   isPreview={!!getPreviewMode(tokenPayload)}
                   task={task}
+                  clientCompanyId={task.assigneeType !== 'internalUser' ? task.assigneeId : undefined}
                 />
                 <Sidebar
                   task_id={task_id}

--- a/src/app/detail/ui/NewTaskCard.tsx
+++ b/src/app/detail/ui/NewTaskCard.tsx
@@ -26,6 +26,7 @@ import { NoAssigneeExtraOptions } from '@/utils/noAssignee'
 import { trimAllTags } from '@/utils/trimTags'
 import { setDebouncedFilteredAssignees } from '@/utils/users'
 import { Box, Stack, Typography } from '@mui/material'
+import { AssigneeType as AssigneeTypeEnum } from '@prisma/client'
 import dayjs from 'dayjs'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useSelector } from 'react-redux'
@@ -54,7 +55,7 @@ export const NewTaskCard = ({
   handleSubTaskCreation: (payload: CreateTaskRequest) => void
 }) => {
   const { workflowStates, assignee, token, filterOptions, previewMode, activeTask } = useSelector(selectTaskBoard)
-  const { assigneeListForLimitedTasks } = useSelector(selectTaskDetails)
+  const { activeTaskAssignees } = useSelector(selectTaskDetails)
 
   const { templates } = useSelector(selectCreateTemplate)
   const [activeDebounceTimeoutId, setActiveDebounceTimeoutId] = useState<NodeJS.Timeout | null>(null)
@@ -75,9 +76,7 @@ export const NewTaskCard = ({
     assigneeType: null,
   })
 
-  const [filteredAssignees, setFilteredAssignees] = useState(
-    assigneeListForLimitedTasks.length ? assigneeListForLimitedTasks : assignee,
-  )
+  const [filteredAssignees, setFilteredAssignees] = useState(activeTaskAssignees.length ? activeTaskAssignees : assignee)
 
   const inputRef = useRef<HTMLInputElement>(null)
 
@@ -143,7 +142,8 @@ export const NewTaskCard = ({
     setIsUploading(uploading)
   }
 
-  const clientCompanyId = activeTask && activeTask.assigneeType !== 'internalUser' ? activeTask.assigneeId : undefined
+  const clientCompanyId =
+    activeTask && activeTask.assigneeType !== AssigneeTypeEnum.internalUser ? activeTask.assigneeId : undefined
 
   const applyTemplate = useCallback(
     (id: string, templateTitle: string) => {
@@ -377,7 +377,7 @@ export const NewTaskCard = ({
                 clearTimeout(activeDebounceTimeoutId)
               }
               setLoading(true)
-              setFilteredAssignees(assigneeListForLimitedTasks.length ? assigneeListForLimitedTasks : assignee)
+              setFilteredAssignees(activeTaskAssignees.length ? activeTaskAssignees : assignee)
               setLoading(false)
             }}
             options={loading ? [] : filteredAssignees}
@@ -389,7 +389,7 @@ export const NewTaskCard = ({
             selectorType={SelectorType.ASSIGNEE_SELECTOR}
             handleInputChange={async (newInputValue: string) => {
               if (!newInputValue) {
-                setFilteredAssignees(assigneeListForLimitedTasks.length ? assigneeListForLimitedTasks : assignee)
+                setFilteredAssignees(activeTaskAssignees.length ? activeTaskAssignees : assignee)
                 return
               }
               setDebouncedFilteredAssignees(

--- a/src/app/detail/ui/TaskCardList.tsx
+++ b/src/app/detail/ui/TaskCardList.tsx
@@ -34,6 +34,7 @@ import { NoAssignee, NoAssigneeExtraOptions, NoDataFoundOption } from '@/utils/n
 import { ShouldConfirmBeforeReassignment } from '@/utils/shouldConfirmBeforeReassign'
 import { setDebouncedFilteredAssignees } from '@/utils/users'
 import { Box, Skeleton, Stack, Typography } from '@mui/material'
+import { AssigneeType } from '@prisma/client'
 import { useEffect, useState } from 'react'
 import { useSelector } from 'react-redux'
 import { ScopedMutator } from 'swr/_internal'
@@ -51,7 +52,7 @@ interface TaskCardListProps {
 export const TaskCardList = ({ task, variant, workflowState, mode, handleUpdate }: TaskCardListProps) => {
   const { assignee, workflowStates, previewMode, token, confirmAssignModalId, assigneeCache, activeTask } =
     useSelector(selectTaskBoard)
-  const { assigneeListForLimitedTasks } = useSelector(selectTaskDetails)
+  const { activeTaskAssignees } = useSelector(selectTaskDetails)
 
   const [currentAssignee, setCurrentAssignee] = useState<IAssigneeCombined | undefined>(() => {
     return assigneeCache[task.id]
@@ -60,9 +61,7 @@ export const TaskCardList = ({ task, variant, workflowState, mode, handleUpdate 
   const [inputStatusValue, setInputStatusValue] = useState('')
   const [selectedAssignee, setSelectedAssignee] = useState<IAssigneeCombined | undefined>(undefined)
   const [loading, setLoading] = useState(false)
-  const [filteredAssignees, setFilteredAssignees] = useState(
-    assigneeListForLimitedTasks.length ? assigneeListForLimitedTasks : assignee,
-  )
+  const [filteredAssignees, setFilteredAssignees] = useState(activeTaskAssignees.length ? activeTaskAssignees : assignee)
   const [activeDebounceTimeoutId, setActiveDebounceTimeoutId] = useState<NodeJS.Timeout | null>(null)
 
   useEffect(() => {
@@ -108,7 +107,7 @@ export const TaskCardList = ({ task, variant, workflowState, mode, handleUpdate 
 
   const getClientCompanyId = () => {
     if (variant == 'subtask' && activeTask) {
-      return activeTask.assigneeType !== 'internalUser' ? activeTask.assigneeId : undefined
+      return activeTask.assigneeType !== AssigneeType.internalUser ? activeTask.assigneeId : undefined
     }
     return undefined
   }
@@ -295,7 +294,7 @@ export const TaskCardList = ({ task, variant, workflowState, mode, handleUpdate 
             }
             handleInputChange={async (newInputValue: string) => {
               if (!newInputValue || isAssigneeTextMatching(newInputValue, assigneeValue)) {
-                setFilteredAssignees(assigneeListForLimitedTasks.length ? assigneeListForLimitedTasks : assignee)
+                setFilteredAssignees(activeTaskAssignees.length ? activeTaskAssignees : assignee)
                 return
               }
 

--- a/src/hoc/ClientSideStateUpdate.tsx
+++ b/src/hoc/ClientSideStateUpdate.tsx
@@ -14,7 +14,7 @@ import {
   setViewSettings,
   setWorkflowStates,
 } from '@/redux/features/taskBoardSlice'
-import { setAssigneeListForLimitedTask, setAssigneeSuggestion, setExpandedComments } from '@/redux/features/taskDetailsSlice'
+import { setActiveTaskAssignees, setAssigneeSuggestion, setExpandedComments } from '@/redux/features/taskDetailsSlice'
 import { setTemplates } from '@/redux/features/templateSlice'
 import store from '@/redux/store'
 import { Token } from '@/types/common'
@@ -125,11 +125,11 @@ export const ClientSideStateUpdate = ({
       store.dispatch(setAccessibleTasks(accessibleTasks))
     }
     if (assigneeListForLimitedTasks) {
-      store.dispatch(setAssigneeListForLimitedTask(assigneeListForLimitedTasks))
+      store.dispatch(setActiveTaskAssignees(assigneeListForLimitedTasks))
     }
     return () => {
       store.dispatch(setActiveTask(undefined))
-      store.dispatch(setAssigneeListForLimitedTask([]))
+      store.dispatch(setActiveTaskAssignees([]))
     } //when component is unmounted, we need to clear the active task.
   }, [
     workflowStates,

--- a/src/hoc/ClientSideStateUpdate.tsx
+++ b/src/hoc/ClientSideStateUpdate.tsx
@@ -14,7 +14,7 @@ import {
   setViewSettings,
   setWorkflowStates,
 } from '@/redux/features/taskBoardSlice'
-import { setAssigneeSuggestion, setExpandedComments } from '@/redux/features/taskDetailsSlice'
+import { setAssigneeListForLimitedTask, setAssigneeSuggestion, setExpandedComments } from '@/redux/features/taskDetailsSlice'
 import { setTemplates } from '@/redux/features/templateSlice'
 import store from '@/redux/store'
 import { Token } from '@/types/common'
@@ -46,6 +46,7 @@ export const ClientSideStateUpdate = ({
   clearExpandedComments,
   accesibleTaskIds,
   accessibleTasks,
+  assigneeListForLimitedTasks,
 }: {
   children: ReactNode
   workflowStates?: WorkflowStateResponse[]
@@ -60,6 +61,7 @@ export const ClientSideStateUpdate = ({
   clearExpandedComments?: boolean
   accesibleTaskIds?: string[]
   accessibleTasks?: TaskResponse[]
+  assigneeListForLimitedTasks?: IAssigneeCombined[]
 }) => {
   const { tasks: tasksInStore, viewSettingsTemp } = useSelector(selectTaskBoard)
   useEffect(() => {
@@ -122,8 +124,12 @@ export const ClientSideStateUpdate = ({
     if (accessibleTasks) {
       store.dispatch(setAccessibleTasks(accessibleTasks))
     }
+    if (assigneeListForLimitedTasks) {
+      store.dispatch(setAssigneeListForLimitedTask(assigneeListForLimitedTasks))
+    }
     return () => {
       store.dispatch(setActiveTask(undefined))
+      store.dispatch(setAssigneeListForLimitedTask([]))
     } //when component is unmounted, we need to clear the active task.
   }, [
     workflowStates,

--- a/src/hoc/ClientSideStateUpdate.tsx
+++ b/src/hoc/ClientSideStateUpdate.tsx
@@ -46,7 +46,7 @@ export const ClientSideStateUpdate = ({
   clearExpandedComments,
   accesibleTaskIds,
   accessibleTasks,
-  assigneeListForLimitedTasks,
+  activeTaskAssignees,
 }: {
   children: ReactNode
   workflowStates?: WorkflowStateResponse[]
@@ -61,7 +61,7 @@ export const ClientSideStateUpdate = ({
   clearExpandedComments?: boolean
   accesibleTaskIds?: string[]
   accessibleTasks?: TaskResponse[]
-  assigneeListForLimitedTasks?: IAssigneeCombined[]
+  activeTaskAssignees?: IAssigneeCombined[]
 }) => {
   const { tasks: tasksInStore, viewSettingsTemp } = useSelector(selectTaskBoard)
   useEffect(() => {
@@ -124,8 +124,8 @@ export const ClientSideStateUpdate = ({
     if (accessibleTasks) {
       store.dispatch(setAccessibleTasks(accessibleTasks))
     }
-    if (assigneeListForLimitedTasks) {
-      store.dispatch(setActiveTaskAssignees(assigneeListForLimitedTasks))
+    if (activeTaskAssignees) {
+      store.dispatch(setActiveTaskAssignees(activeTaskAssignees))
     }
     return () => {
       store.dispatch(setActiveTask(undefined))
@@ -143,6 +143,7 @@ export const ClientSideStateUpdate = ({
     task,
     accesibleTaskIds,
     accessibleTasks,
+    activeTaskAssignees,
   ])
 
   return children

--- a/src/redux/features/taskDetailsSlice.ts
+++ b/src/redux/features/taskDetailsSlice.ts
@@ -12,7 +12,7 @@ interface IInitialState {
   // URL of an image opened in preview modal for task description / comments
   openImage: string | null
   expandedComments: string[]
-  assigneeListForLimitedTasks: IAssigneeCombined[]
+  activeTaskAssignees: IAssigneeCombined[]
 }
 
 const initialState: IInitialState = {
@@ -23,7 +23,7 @@ const initialState: IInitialState = {
   showConfirmAssignModal: false,
   openImage: null,
   expandedComments: [],
-  assigneeListForLimitedTasks: [],
+  activeTaskAssignees: [],
 }
 
 const taskDetailsSlice = createSlice({
@@ -51,8 +51,8 @@ const taskDetailsSlice = createSlice({
     setExpandedComments: (state, action: { payload: string[] }) => {
       state.expandedComments = action.payload
     },
-    setAssigneeListForLimitedTask: (state, action: { payload: IAssigneeCombined[] }) => {
-      state.assigneeListForLimitedTasks = action.payload
+    setActiveTaskAssignees: (state, action: { payload: IAssigneeCombined[] }) => {
+      state.activeTaskAssignees = action.payload
     },
   },
 })
@@ -67,7 +67,7 @@ export const {
   toggleShowConfirmAssignModal,
   setOpenImage,
   setExpandedComments,
-  setAssigneeListForLimitedTask,
+  setActiveTaskAssignees,
 } = taskDetailsSlice.actions
 
 export default taskDetailsSlice.reducer

--- a/src/redux/features/taskDetailsSlice.ts
+++ b/src/redux/features/taskDetailsSlice.ts
@@ -1,6 +1,6 @@
 import { createSlice } from '@reduxjs/toolkit'
 import { RootState } from '../store'
-import { IAssigneeSuggestions } from '@/types/interfaces'
+import { IAssigneeCombined, IAssigneeSuggestions } from '@/types/interfaces'
 import { TaskResponse } from '@/types/dto/tasks.dto'
 
 interface IInitialState {
@@ -12,6 +12,7 @@ interface IInitialState {
   // URL of an image opened in preview modal for task description / comments
   openImage: string | null
   expandedComments: string[]
+  assigneeListForLimitedTasks: IAssigneeCombined[]
 }
 
 const initialState: IInitialState = {
@@ -22,6 +23,7 @@ const initialState: IInitialState = {
   showConfirmAssignModal: false,
   openImage: null,
   expandedComments: [],
+  assigneeListForLimitedTasks: [],
 }
 
 const taskDetailsSlice = createSlice({
@@ -49,6 +51,9 @@ const taskDetailsSlice = createSlice({
     setExpandedComments: (state, action: { payload: string[] }) => {
       state.expandedComments = action.payload
     },
+    setAssigneeListForLimitedTask: (state, action: { payload: IAssigneeCombined[] }) => {
+      state.assigneeListForLimitedTasks = action.payload
+    },
   },
 })
 
@@ -62,6 +67,7 @@ export const {
   toggleShowConfirmAssignModal,
   setOpenImage,
   setExpandedComments,
+  setAssigneeListForLimitedTask,
 } = taskDetailsSlice.actions
 
 export default taskDetailsSlice.reducer

--- a/src/services/users.ts
+++ b/src/services/users.ts
@@ -13,13 +13,16 @@ export async function getAssigneeList(
   limit?: number,
   nextToken?: string,
   filterOptions?: string,
+  clientCompanyId?: string,
 ): Promise<IAssignee> {
   const reqUrl =
     `/api/users?token=${token}` +
     buildOptionalSearchParam('search', keyword) +
     buildOptionalSearchParam('limit', limit) +
     buildOptionalSearchParam('nextToken', nextToken) +
-    buildOptionalSearchParam('userType', filterOptions)
+    buildOptionalSearchParam('userType', filterOptions) +
+    buildOptionalSearchParam('clientCompanyId', clientCompanyId)
+
   const res = await fetch(reqUrl, {
     next: { tags: ['getAssigneeList'] },
   })

--- a/src/utils/users.ts
+++ b/src/utils/users.ts
@@ -51,14 +51,21 @@ export const setDebouncedFilteredAssignees = (
   token: string,
   newInputValue: string,
   filterOptions?: string,
+  clientCompanyId?: string,
 ): void => {
   if (activeDebounceTimeoutId) {
     clearTimeout(activeDebounceTimeoutId)
   }
   const newTimeoutId = setTimeout(async () => {
     setLoading(true)
-
-    const newAssignees = await getAssigneeList(z.string().parse(token), newInputValue, 10000, '0', filterOptions)
+    const newAssignees = await getAssigneeList(
+      z.string().parse(token),
+      newInputValue,
+      10000,
+      '0',
+      filterOptions,
+      clientCompanyId,
+    )
 
     setAssigneeState(addTypeToAssignee(newAssignees))
     setLoading(false)

--- a/src/utils/users.ts
+++ b/src/utils/users.ts
@@ -5,6 +5,7 @@ import { z } from 'zod'
 import { addTypeToAssignee } from '@/utils/addTypeToAssignee'
 import { IAssigneeCombined } from '@/types/interfaces'
 import { containsCaseInsensitiveSubstring, startsWithCaseInsensitiveSubstring } from '@/utils/string'
+import { MAX_FETCH_ASSIGNEE_COUNT } from '@/constants/users'
 
 /**
  * Filters an array of Copilot IU / Client / Company to find keyword matching its name fields
@@ -61,7 +62,7 @@ export const setDebouncedFilteredAssignees = (
     const newAssignees = await getAssigneeList(
       z.string().parse(token),
       newInputValue,
-      10000,
+      MAX_FETCH_ASSIGNEE_COUNT,
       '0',
       filterOptions,
       clientCompanyId,


### PR DESCRIPTION
## Changes

- [x] added a separate optional param in users api called clientCompanyId. The param is passed from details page if the current task is assigned to a client or company.
- [x] filtered out limited access internal uses from assignee dropdown list in subtask creation and subtask list if the parent task is assigned to client/company out of scope for the iu.
- [x] created a separate redux state to store the filtered out assignee list array for a task detail page.

## Testing Criteria

- [LOOM](https://www.loom.com/share/278e41a440d741bda123559bff69078f)

## Notes

- User can still reassign the parent task to a client out of scope for an iu. And if the subtasks of the parent task is assigned to limited access IU, then there is no way for the IU to access the sub task once the parent is reassigned to a client.
