### PR TITLE
OUT-1662, OUT-1663 | Activity feed vertical line sticks out of top profile icon

### DIFF
--- a/src/app/detail/ui/ActivityWrapper.tsx
+++ b/src/app/detail/ui/ActivityWrapper.tsx
@@ -186,7 +186,7 @@ export const ActivityWrapper = ({
 
   return (
     <Box width="100%">
-      <Stack direction="column" alignItems="left" p="24px 0px" rowGap={4}>
+      <Stack direction="column" alignItems="left" p="24px 0px" rowGap={'12px'}>
         <Typography variant="lg">Activity</Typography>
         {isLoading ? (
           <Stack direction="column" rowGap={5}>

--- a/src/app/detail/ui/TaskCardList.tsx
+++ b/src/app/detail/ui/TaskCardList.tsx
@@ -107,7 +107,7 @@ export const TaskCardList = ({ task, variant, workflowState, mode, handleUpdate 
       sx={{
         height: variant == 'task' ? '44px' : '36px',
         display: 'flex',
-        padding: variant == 'task' ? '6px 20px 6px 20px' : '6px 6px 6px 4px',
+        padding: variant == 'task' ? '6px 20px 6px 20px' : '6px 0px 6px 0px',
         alignItems: 'center',
         alignSelf: 'stretch',
         gap: '20px',
@@ -266,7 +266,7 @@ export const TaskCardList = ({ task, variant, workflowState, mode, handleUpdate 
             buttonContent={
               <Box
                 sx={{
-                  padding: '2px 4px',
+                  padding: '2px 2px',
                   display: 'flex',
                   alignItems: 'center',
                   borderRadius: '4px',

--- a/src/app/detail/ui/styledComponent.tsx
+++ b/src/app/detail/ui/styledComponent.tsx
@@ -53,7 +53,7 @@ export const StyledTiptapDescriptionWrapper = styled(Box)(({ theme }) => ({
 export const VerticalLine = styled('div')(({ theme }) => ({
   position: 'absolute',
   left: '11px',
-  top: '11px',
+  top: '12px',
   bottom: 0,
   width: '1px',
   height: 'calc(100% + 20px)',


### PR DESCRIPTION
## Changes

- [x] fixed gap in activity log and its list.
- [x] fixed vertical line sticking out of avatar on the first activity log.
- [x] subtasks list padding fixed.

## Testing Criteria

![image](https://github.com/user-attachments/assets/8f1a0620-7063-43a0-9aac-975100fe9f6b)
![image](https://github.com/user-attachments/assets/119e0a53-2036-4dd1-bbc2-402fe8c7986f)

