### PR TITLE
OUT-1682 | Activity logs taking more time than usual to load in the UI.

### DIFF
--- a/src/app/detail/ui/ActivityWrapper.tsx
+++ b/src/app/detail/ui/ActivityWrapper.tsx
@@ -54,11 +54,11 @@ export const ActivityWrapper = ({
   useEffect(() => {
     const refetchActivityLog = async () => {
       await mutate(cacheKey)
-      setLastUpdated(task?.lastActivityLogUpdated)
     }
-    if (lastUpdated !== task?.lastActivityLogUpdated) {
+    if (lastUpdated && lastUpdated !== task?.lastActivityLogUpdated) {
       refetchActivityLog()
     }
+    setLastUpdated(task?.lastActivityLogUpdated)
   }, [task?.lastActivityLogUpdated])
 
   const currentUserId = tokenPayload.internalUserId ?? tokenPayload.clientId


### PR DESCRIPTION
## Changes

- [x] Added a logic to prevent the `activityLogs` api from being fetched multiple times when the details page is mounted.

## Testing Criteria

- [LOOM](https://www.loom.com/share/5564607656e84cbaa97069de276c5cf5)



