### PR TITLE
OUT-1674 | Add support for exposing Update Task API

### DIFF
--- a/src/app/api/tasks/public/[id]/route.ts
+++ b/src/app/api/tasks/public/[id]/route.ts
@@ -1,5 +1,6 @@
 import { withErrorHandler } from '@api/core/utils/withErrorHandler'
-import { deleteOneTaskPublic, getOneTaskPublic } from '@api/tasks/public/public.controller'
+import { deleteOneTaskPublic, getOneTaskPublic, updateTaskPublic } from '@api/tasks/public/public.controller'
 
 export const GET = withErrorHandler(getOneTaskPublic)
+export const PATCH = withErrorHandler(updateTaskPublic)
 export const DELETE = withErrorHandler(deleteOneTaskPublic)

--- a/src/app/api/tasks/public/public.controller.ts
+++ b/src/app/api/tasks/public/public.controller.ts
@@ -58,8 +58,8 @@ export const updateTaskPublic = async (req: NextRequest, { params: { id } }: IdP
   const user = await authenticate(req)
   const data = PublicTaskUpdateDtoSchema.parse(await req.json())
   const tasksService = new TasksService(user)
-  const updatedTask = await tasksService.updateOneTask(id, data)
-  return NextResponse.json({ updatedTask })
+  const updatedTask = await tasksService.updateOneTask(id, PublicTaskSerializer.deserializeUpdatePayload(data))
+  return NextResponse.json(updatedTask)
 }
 
 export const deleteOneTaskPublic = async (req: NextRequest, { params: { id } }: IdParams) => {

--- a/src/app/api/tasks/public/public.controller.ts
+++ b/src/app/api/tasks/public/public.controller.ts
@@ -4,6 +4,7 @@ import { StateTypeSchema } from '@/types/common'
 import { getSearchParams } from '@/utils/request'
 import { IdParams } from '@api/core/types/api'
 import authenticate from '@api/core/utils/authenticate'
+import { PublicTaskUpdateDtoSchema } from '@api/tasks/public/public.dto'
 import { PublicTaskSerializer } from '@api/tasks/public/public.serializer'
 import { TasksService } from '@api/tasks/tasks.service'
 import { decode, encode } from 'js-base64'
@@ -53,6 +54,16 @@ export const getOneTaskPublic = async (req: NextRequest, { params: { id } }: IdP
   return NextResponse.json({ ...PublicTaskSerializer.serialize(task) })
 }
 
+export const updateTask = async (req: NextRequest, { params: { id } }: IdParams) => {
+  const user = await authenticate(req)
+
+  const data = PublicTaskUpdateDtoSchema.parse(await req.json())
+  const tasksService = new TasksService(user)
+  const updatedTask = await tasksService.updateOneTask(id, data)
+
+  return NextResponse.json({ updatedTask })
+}
+
 export const deleteOneTaskPublic = async (req: NextRequest, { params: { id } }: IdParams) => {
   const recursive = req.nextUrl.searchParams.get('recursive')
   const user = await authenticate(req)
@@ -60,6 +71,7 @@ export const deleteOneTaskPublic = async (req: NextRequest, { params: { id } }: 
   const task = await tasksService.deleteOneTask(id, z.coerce.boolean().parse(recursive))
   return NextResponse.json({ ...PublicTaskSerializer.serialize(task) })
 }
+
 export const createTaskPublic = async (req: NextRequest) => {
   const user = await authenticate(req)
   const data = PublicTaskCreateDtoSchema.parse(await req.json())

--- a/src/app/api/tasks/public/public.controller.ts
+++ b/src/app/api/tasks/public/public.controller.ts
@@ -51,15 +51,18 @@ export const getOneTaskPublic = async (req: NextRequest, { params: { id } }: IdP
   const user = await authenticate(req)
   const tasksService = new TasksService(user)
   const task = await tasksService.getOneTask(id)
-  return NextResponse.json({ ...PublicTaskSerializer.serialize(task) })
+  return NextResponse.json(PublicTaskSerializer.serialize(task))
 }
 
 export const updateTaskPublic = async (req: NextRequest, { params: { id } }: IdParams) => {
   const user = await authenticate(req)
   const data = PublicTaskUpdateDtoSchema.parse(await req.json())
+
   const tasksService = new TasksService(user)
-  const updatedTask = await tasksService.updateOneTask(id, PublicTaskSerializer.deserializeUpdatePayload(data))
-  return NextResponse.json(updatedTask)
+  const updatePayload = await PublicTaskSerializer.deserializeUpdatePayload(data, user.workspaceId)
+  const updatedTask = await tasksService.updateOneTask(id, updatePayload)
+
+  return NextResponse.json(PublicTaskSerializer.serialize(updatedTask))
 }
 
 export const deleteOneTaskPublic = async (req: NextRequest, { params: { id } }: IdParams) => {

--- a/src/app/api/tasks/public/public.controller.ts
+++ b/src/app/api/tasks/public/public.controller.ts
@@ -54,13 +54,11 @@ export const getOneTaskPublic = async (req: NextRequest, { params: { id } }: IdP
   return NextResponse.json({ ...PublicTaskSerializer.serialize(task) })
 }
 
-export const updateTask = async (req: NextRequest, { params: { id } }: IdParams) => {
+export const updateTaskPublic = async (req: NextRequest, { params: { id } }: IdParams) => {
   const user = await authenticate(req)
-
   const data = PublicTaskUpdateDtoSchema.parse(await req.json())
   const tasksService = new TasksService(user)
   const updatedTask = await tasksService.updateOneTask(id, data)
-
   return NextResponse.json({ updatedTask })
 }
 

--- a/src/app/api/tasks/public/public.dto.ts
+++ b/src/app/api/tasks/public/public.dto.ts
@@ -45,7 +45,7 @@ export const PublicTaskUpdateDtoSchema = z.object({
   description: z.string().optional(),
   assigneeId: z.string().uuid().optional(),
   assigneeType: z.nativeEnum(AssigneeType).optional(),
-  dueDate: RFC3339DateSchema.optional(),
+  dueDate: RFC3339DateSchema.nullish(),
   status: z.enum(['todo', 'inProgress', 'completed']).optional(),
   isArchived: z.boolean().optional(),
 })

--- a/src/app/api/tasks/public/public.dto.ts
+++ b/src/app/api/tasks/public/public.dto.ts
@@ -38,5 +38,15 @@ export const PublicTaskCreateDtoSchema = z.object({
   dueDate: RFC3339DateSchema.optional(),
   //TODO : add templateId after it has been implemented for tasks.
 })
-
 export type PublicTaskCreateDto = z.infer<typeof PublicTaskCreateDtoSchema>
+
+export const PublicTaskUpdateDtoSchema = z.object({
+  name: z.string().max(255).optional(),
+  description: z.string().optional(),
+  assigneeId: z.string().uuid().optional(),
+  assigneeType: z.nativeEnum(AssigneeType).optional(),
+  dueDate: RFC3339DateSchema.optional(),
+  status: z.enum(['todo', 'inProgress', 'completed']).optional(),
+  isArchived: z.boolean().optional(),
+})
+export type PublicTaskUpdateDto = z.infer<typeof PublicTaskUpdateDtoSchema>

--- a/src/app/api/tasks/public/public.serializer.ts
+++ b/src/app/api/tasks/public/public.serializer.ts
@@ -83,13 +83,18 @@ export class PublicTaskSerializer {
 
   static async deserializeUpdatePayload(payload: PublicTaskUpdateDto, workspaceId: string): Promise<UpdateTaskRequest> {
     const workflowStateId = await PublicTaskSerializer.getWorkflowStateIdForStatus(payload.status, workspaceId)
+    const deserializedDueDate = (() => {
+      if (payload.dueDate === null) return null
+      if (!payload.dueDate) return undefined
+      return new Date(payload.dueDate).toISOString().slice(0, 10)
+    })()
 
     return {
       title: payload.name,
       body: payload.description,
       assigneeId: payload.assigneeId,
       assigneeType: payload.assigneeType,
-      dueDate: payload.dueDate,
+      dueDate: deserializedDueDate,
       isArchived: payload.isArchived,
       workflowStateId,
     }

--- a/src/app/api/tasks/public/public.serializer.ts
+++ b/src/app/api/tasks/public/public.serializer.ts
@@ -90,7 +90,7 @@ export class PublicTaskSerializer {
       assigneeId: payload.assigneeId,
       assigneeType: payload.assigneeType,
       dueDate: payload.dueDate,
-      isArchived: payload.status === 'completed',
+      isArchived: payload.isArchived,
       workflowStateId,
     }
   }

--- a/src/app/api/tasks/public/public.serializer.ts
+++ b/src/app/api/tasks/public/public.serializer.ts
@@ -19,6 +19,7 @@ const workflowStateTypeMap: Record<PublicTaskDto['status'], WorkflowState['type'
   inProgress: 'started',
   completed: 'completed',
 })
+
 export class PublicTaskSerializer {
   static serializeUnsafe(task: Task & { workflowState: WorkflowState }): PublicTaskDto {
     return {
@@ -80,7 +81,9 @@ export class PublicTaskSerializer {
     })
   }
 
-  static deserializeUpdatePayload(payload: PublicTaskUpdateDto): UpdateTaskRequest {
+  static async deserializeUpdatePayload(payload: PublicTaskUpdateDto, workspaceId: string): Promise<UpdateTaskRequest> {
+    const workflowStateId = await PublicTaskSerializer.getWorkflowStateIdForStatus(payload.status, workspaceId)
+
     return {
       title: payload.name,
       body: payload.description,
@@ -88,6 +91,7 @@ export class PublicTaskSerializer {
       assigneeType: payload.assigneeType,
       dueDate: payload.dueDate,
       isArchived: payload.status === 'completed',
+      workflowStateId,
     }
   }
 }

--- a/src/app/api/tasks/public/public.serializer.ts
+++ b/src/app/api/tasks/public/public.serializer.ts
@@ -1,8 +1,8 @@
 import DBClient from '@/lib/db'
 import { RFC3339DateSchema } from '@/types/common'
-import { CreateTaskRequest, CreateTaskRequestSchema } from '@/types/dto/tasks.dto'
+import { CreateTaskRequest, CreateTaskRequestSchema, UpdateTaskRequest } from '@/types/dto/tasks.dto'
 import { rfc3339ToDateString, toRFC3339 } from '@/utils/dateHelper'
-import { PublicTaskDto, PublicTaskDtoSchema, PublicTaskCreateDto } from '@api/tasks/public/public.dto'
+import { PublicTaskCreateDto, PublicTaskDto, PublicTaskDtoSchema, PublicTaskUpdateDto } from '@api/tasks/public/public.dto'
 import { Task, WorkflowState } from '@prisma/client'
 import { z } from 'zod'
 
@@ -78,5 +78,16 @@ export class PublicTaskSerializer {
       dueDate: rfc3339ToDateString(payload.dueDate),
       parentId: payload.parentTaskId,
     })
+  }
+
+  static deserializeUpdatePayload(payload: PublicTaskUpdateDto): UpdateTaskRequest {
+    return {
+      title: payload.name,
+      body: payload.description,
+      assigneeId: payload.assigneeId,
+      assigneeType: payload.assigneeType,
+      dueDate: payload.dueDate,
+      isArchived: payload.status === 'completed',
+    }
   }
 }

--- a/src/app/api/tasks/public/public.serializer.ts
+++ b/src/app/api/tasks/public/public.serializer.ts
@@ -83,18 +83,12 @@ export class PublicTaskSerializer {
 
   static async deserializeUpdatePayload(payload: PublicTaskUpdateDto, workspaceId: string): Promise<UpdateTaskRequest> {
     const workflowStateId = await PublicTaskSerializer.getWorkflowStateIdForStatus(payload.status, workspaceId)
-    const deserializedDueDate = (() => {
-      if (payload.dueDate === null) return null
-      if (!payload.dueDate) return undefined
-      return new Date(payload.dueDate).toISOString().slice(0, 10)
-    })()
-
     return {
       title: payload.name,
       body: payload.description,
       assigneeId: payload.assigneeId,
       assigneeType: payload.assigneeType,
-      dueDate: deserializedDueDate,
+      dueDate: rfc3339ToDateString(payload.dueDate),
       isArchived: payload.isArchived,
       workflowStateId,
     }

--- a/src/app/api/tasks/task-notifications.service.ts
+++ b/src/app/api/tasks/task-notifications.service.ts
@@ -87,7 +87,7 @@ export class TaskNotificationsService extends BaseService {
     // -- If task is moved to archived -> Mark as read notifications
     // -- If task is moved to uarchived -> Add appropriate notification
     if (prevTask.isArchived !== updatedTask.isArchived) {
-      return await this.handleTaskArchiveToggle(prevTask, updatedTask)
+      await this.handleTaskArchiveToggle(prevTask, updatedTask)
     }
 
     // Return if not workflowState / assignee updated
@@ -97,8 +97,9 @@ export class TaskNotificationsService extends BaseService {
     // Case 2
     // -- Handle previous assignee notification "Mark as read" if it is updated
     if (prevTask.assigneeId !== updatedTask.assigneeId && updatedTask.workflowState.type !== StateType.completed) {
-      return await this.handleIncompleteTaskReassignment(prevTask, updatedTask)
+      await this.handleIncompleteTaskReassignment(prevTask, updatedTask)
     }
+
     // Case 3
     // -- Check if prev assignee was IU. If so, delete any and all past in-product notifications related to this task
     if (

--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -281,7 +281,10 @@ export class TasksService extends BaseService {
       }
 
       // Set / reset lastArchivedDate if isArchived has been triggered, else remove it from the update query
-      const lastArchivedDate = data.isArchived === true ? new Date() : data.isArchived === false ? null : undefined
+      let lastArchivedDate: Date | undefined | null = undefined
+      if (data.isArchived && prevTask.isArchived !== data.isArchived) {
+        lastArchivedDate = data.isArchived === true ? new Date() : data.isArchived === false ? null : undefined
+      }
 
       // Get the updated task
       const updatedTask = await tx.task.update({
@@ -297,7 +300,7 @@ export class TasksService extends BaseService {
       })
 
       // Archive / unarchive all subtasks if parent task is archived / unarchived
-      if (data.isArchived !== undefined) {
+      if (prevTask.isArchived !== data.isArchived && data.isArchived !== undefined) {
         const subtaskService = new SubtaskService(this.user)
         subtaskService.setTransaction(tx as PrismaClient)
         await subtaskService.toggleArchiveForAllSubtasks(id, data.isArchived)

--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -19,6 +19,7 @@ import { SubtaskService } from '@api/tasks/subtasks.service'
 import { getArchivedStatus, getTaskTimestamps } from '@api/tasks/tasks.helpers'
 import { TasksActivityLogger } from '@api/tasks/tasks.logger'
 import { AssigneeType, Prisma, PrismaClient, StateType, Task, WorkflowState } from '@prisma/client'
+import dayjs from 'dayjs'
 import httpStatus from 'http-status'
 import { z } from 'zod'
 import { maxSubTaskDepth } from '@/constants/tasks'
@@ -262,6 +263,11 @@ export class TasksService extends BaseService {
 
     // Query previous task
     const filters = this.buildTaskPermissions(id)
+    // Validate updated due date to not be in the past
+    if (data.dueDate && dayjs(new Date(data.dueDate)).isBefore(dayjs())) {
+      throw new APIError(httpStatus.BAD_REQUEST, 'Due date cannot be in the past')
+    }
+
     const prevTask = await this.db.task.findFirst({
       where: filters,
       relationLoadStrategy: 'join',

--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -282,7 +282,7 @@ export class TasksService extends BaseService {
 
       // Set / reset lastArchivedDate if isArchived has been triggered, else remove it from the update query
       let lastArchivedDate: Date | undefined | null = undefined
-      if (data.isArchived && prevTask.isArchived !== data.isArchived) {
+      if (data.isArchived !== undefined && prevTask.isArchived !== data.isArchived) {
         lastArchivedDate = data.isArchived === true ? new Date() : data.isArchived === false ? null : undefined
       }
 


### PR DESCRIPTION
## Changes

- [x] Add endpoint for public tasks update at PATCH `/tasks/:id`
- [x] Add deserializer for public tasks update payload 
- [x] Change update tasks notifications job to support multiple update types at once
- [x] Fix edge cases where backend logic was dependent on update only containing one payload type at a time 

## Testing Criteria

- [x] Screencast


https://github.com/user-attachments/assets/90857738-e804-445d-b1a8-3c8c4cc26a28

## Note:
Latest update-task notification job has been deployed to staging environment on trigger