### PR TITLE
OUT-1687 | Fix nextToken being sent even when page ends when filters are applied

### DIFF
--- a/src/app/api/tasks/public/public.dto.ts
+++ b/src/app/api/tasks/public/public.dto.ts
@@ -4,6 +4,7 @@ import { z } from 'zod'
 
 export const TaskSourceSchema = z.enum(['web', 'api'])
 export type TaskSource = z.infer<typeof TaskSourceSchema>
+export const StatusSchema = z.enum(['todo', 'inProgress', 'completed'])
 
 export const PublicTaskDtoSchema = z.object({
   id: z.string(),
@@ -15,7 +16,7 @@ export const PublicTaskDtoSchema = z.object({
   assigneeType: z.nativeEnum(AssigneeType).nullable(),
   dueDate: RFC3339DateSchema.nullable(),
   label: z.string(),
-  status: z.enum(['todo', 'inProgress', 'completed']),
+  status: StatusSchema,
   completedDate: RFC3339DateSchema.nullable(),
   createdBy: z.string().uuid(),
   createdDate: RFC3339DateSchema,
@@ -32,7 +33,7 @@ export const PublicTaskCreateDtoSchema = z.object({
   name: z.string().min(1).max(255),
   description: z.string().nullable(),
   parentTaskId: z.string().uuid().optional(),
-  status: z.enum(['todo', 'inProgress', 'completed']),
+  status: StatusSchema,
   assigneeId: z.string().uuid(),
   assigneeType: z.nativeEnum(AssigneeType),
   dueDate: RFC3339DateSchema.optional(),
@@ -46,7 +47,7 @@ export const PublicTaskUpdateDtoSchema = z.object({
   assigneeId: z.string().uuid().optional(),
   assigneeType: z.nativeEnum(AssigneeType).optional(),
   dueDate: RFC3339DateSchema.nullish(),
-  status: z.enum(['todo', 'inProgress', 'completed']).optional(),
+  status: StatusSchema.optional(),
   isArchived: z.boolean().optional(),
 })
 export type PublicTaskUpdateDto = z.infer<typeof PublicTaskUpdateDtoSchema>

--- a/src/app/api/tasks/public/public.serializer.ts
+++ b/src/app/api/tasks/public/public.serializer.ts
@@ -6,7 +6,7 @@ import { PublicTaskCreateDto, PublicTaskDto, PublicTaskDtoSchema, PublicTaskUpda
 import { Task, WorkflowState } from '@prisma/client'
 import { z } from 'zod'
 
-const statusMap: Record<WorkflowState['type'], PublicTaskDto['status']> = Object.freeze({
+export const statusMap: Record<WorkflowState['type'], PublicTaskDto['status']> = Object.freeze({
   backlog: 'todo',
   unstarted: 'todo',
   started: 'inProgress',
@@ -14,7 +14,7 @@ const statusMap: Record<WorkflowState['type'], PublicTaskDto['status']> = Object
   cancelled: 'todo',
 })
 
-const workflowStateTypeMap: Record<PublicTaskDto['status'], WorkflowState['type']> = Object.freeze({
+export const workflowStateTypeMap: Record<PublicTaskDto['status'], WorkflowState['type']> = Object.freeze({
   todo: 'unstarted',
   inProgress: 'started',
   completed: 'completed',
@@ -53,7 +53,7 @@ export class PublicTaskSerializer {
     return z.array(PublicTaskDtoSchema).parse(tasks.map((task) => PublicTaskSerializer.serializeUnsafe(task)))
   }
 
-  private static async getWorkflowStateIdForStatus(
+  static async getWorkflowStateIdForStatus(
     status: PublicTaskDto['status'] | undefined,
     workspaceId: string,
   ): Promise<string | undefined> {

--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -60,7 +60,7 @@ export class TasksService extends BaseService {
     assigneeId?: string
     createdById?: string
     parentId?: string | null
-    workflowStateType?: StateType
+    workflowState?: { type: StateType }
     limit?: number
     lastIdCursor?: string // When this id field cursor is provided, we return data AFTER this id
   }): Promise<TaskWithWorkflowState[]> {
@@ -109,7 +109,7 @@ export class TasksService extends BaseService {
       ...disjointTasksFilter,
       assigneeId: queryFilters.assigneeId,
       createdById: queryFilters.createdById,
-      workflowState: queryFilters.workflowStateType ? { type: queryFilters.workflowStateType } : undefined,
+      workflowState: queryFilters.workflowState,
       isArchived,
     }
 
@@ -677,9 +677,12 @@ export class TasksService extends BaseService {
     }) as T
   }
 
-  async hasMoreTasksAfterCursor(id: string): Promise<boolean> {
+  async hasMoreTasksAfterCursor(
+    id: string,
+    publicFilters: Partial<Parameters<TasksService['getAllTasks']>[0]>,
+  ): Promise<boolean> {
     const nextTask = await this.db.task.findFirst({
-      where: { workspaceId: this.user.workspaceId },
+      where: { ...publicFilters, workspaceId: this.user.workspaceId },
       cursor: { id },
       skip: 1,
       orderBy: { createdAt: 'desc' },


### PR DESCRIPTION
## Changes

- [x] Send public filters to `hasMoreTasksAfterCursor` method to apply proper ordering and filtering
- [x] Refactor implementation of Status  

## Testing Criteria

- [x] Screenshots

<img width="1061" alt="image" src="https://github.com/user-attachments/assets/34951e1c-cf40-4d16-8e39-db000900687f" />


- Also tested all available filter combinations for getAllTasksPublic

