### PR TITLE
OUT-1687 | Add support for creating/back-filling "source" column in tasks schema

### DIFF
--- a/prisma/migrations/20250428092115_add_source_to_tasks/migration.sql
+++ b/prisma/migrations/20250428092115_add_source_to_tasks/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "Source" AS ENUM ('web', 'api');
+
+-- AlterTable
+ALTER TABLE "Tasks" ADD COLUMN     "source" "Source" NOT NULL DEFAULT 'web';

--- a/prisma/schema/task.prisma
+++ b/prisma/schema/task.prisma
@@ -4,6 +4,11 @@ enum AssigneeType {
   company
 }
 
+enum Source {
+  web
+  api
+}
+
 model Task {
   id              String        @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   label           String
@@ -38,6 +43,8 @@ model Task {
 
   isArchived       Boolean   @default(false)
   lastArchivedDate DateTime?
+
+  source Source @default(web)
 
   @@index([path], type: Gist)
   @@map("Tasks")

--- a/src/app/api/tasks/public/public.controller.ts
+++ b/src/app/api/tasks/public/public.controller.ts
@@ -68,7 +68,7 @@ export const createTaskPublic = async (req: NextRequest) => {
   const tasksService = new TasksService(user)
   const newTask = await tasksService.createTask(createPayload, { isPublicApi: true })
 
-  return NextResponse.json(PublicTaskSerializer.serialize(newTask), { status: 200 })
+  return NextResponse.json(PublicTaskSerializer.serialize(newTask))
 }
 
 export const updateTaskPublic = async (req: NextRequest, { params: { id } }: IdParams) => {

--- a/src/app/api/tasks/public/public.controller.ts
+++ b/src/app/api/tasks/public/public.controller.ts
@@ -61,6 +61,16 @@ export const getOneTaskPublic = async (req: NextRequest, { params: { id } }: IdP
   return NextResponse.json(PublicTaskSerializer.serialize(task))
 }
 
+export const createTaskPublic = async (req: NextRequest) => {
+  const user = await authenticate(req)
+  const data = PublicTaskCreateDtoSchema.parse(await req.json())
+  const createPayload = await PublicTaskSerializer.deserializeCreatePayload(data, user.workspaceId)
+  const tasksService = new TasksService(user)
+  const newTask = await tasksService.createTask(createPayload, { isPublicApi: true })
+
+  return NextResponse.json(PublicTaskSerializer.serialize(newTask), { status: 200 })
+}
+
 export const updateTaskPublic = async (req: NextRequest, { params: { id } }: IdParams) => {
   const user = await authenticate(req)
   const data = PublicTaskUpdateDtoSchema.parse(await req.json())
@@ -78,13 +88,4 @@ export const deleteOneTaskPublic = async (req: NextRequest, { params: { id } }: 
   const tasksService = new TasksService(user)
   const task = await tasksService.deleteOneTask(id, z.coerce.boolean().parse(recursive))
   return NextResponse.json({ ...PublicTaskSerializer.serialize(task) })
-}
-
-export const createTaskPublic = async (req: NextRequest) => {
-  const user = await authenticate(req)
-  const data = PublicTaskCreateDtoSchema.parse(await req.json())
-  const createPayload = await PublicTaskSerializer.deserializeCreatePayload(data, user.workspaceId)
-  const tasksService = new TasksService(user)
-  const newTask = await tasksService.createTask(createPayload)
-  return NextResponse.json(PublicTaskSerializer.serialize(newTask), { status: 200 })
 }

--- a/src/app/api/tasks/public/public.serializer.ts
+++ b/src/app/api/tasks/public/public.serializer.ts
@@ -41,7 +41,7 @@ export class PublicTaskSerializer {
       archivedDate: toRFC3339(task.lastArchivedDate),
       isDeleted: task.deletedAt ? true : false,
       deletedDate: toRFC3339(task.deletedAt),
-      source: 'web', // Placeholder for now
+      source: task.source,
     }
   }
 

--- a/src/cmd/load-testing/load-testing.service.ts
+++ b/src/cmd/load-testing/load-testing.service.ts
@@ -11,7 +11,7 @@ import {
 import { CopilotAPI } from '@/utils/CopilotAPI'
 import { getRandomBool, getRandomFutureDate, getRandomFutureDateTime } from '@/utils/random'
 import { faker } from '@faker-js/faker'
-import { AssigneeType, PrismaClient, Task } from '@prisma/client'
+import { AssigneeType, PrismaClient, Source, Task } from '@prisma/client'
 import Bottleneck from 'bottleneck'
 import { z } from 'zod'
 
@@ -125,6 +125,7 @@ class LoadTester {
           assignedAt: getRandomBool() ? getRandomFutureDate() : null,
           createdAt: new Date(),
           dueDate: getRandomBool() ? getRandomFutureDateTime() : null,
+          source: Source.web,
         })
       }
       seedPromises.push(this.bottlenecks.db.schedule(() => this.db.task.createMany({ data })))


### PR DESCRIPTION
## Changes

- [x] Add schema & migrations for `source` column
- [x] Backfill `source` as "web" using default value
- [x] Implement saving source as "api" when request is handled through public task create endpoint  

## Testing Criteria

- [x] Screenshot

<img width="1042" alt="image" src="https://github.com/user-attachments/assets/19ffb3b0-d91e-4fad-9053-0d912fde44f9" />

- [x] Newly created from webapp
<img width="1040" alt="image" src="https://github.com/user-attachments/assets/55f8f36f-66f2-42dd-9c11-1e9d8d4f97fc" />

- [x] Backfilled data

<img width="1040" alt="image" src="https://github.com/user-attachments/assets/e541aecb-992d-4a33-a35d-e1847c00dc9e" />


