### PR TITLE
OUT-1693 | Create initial migrations for new Tasks columns

### DIFF
--- a/prisma/migrations/20250430060129_add_optional_task_columns_m14_b/migration.sql
+++ b/prisma/migrations/20250430060129_add_optional_task_columns_m14_b/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable
+ALTER TABLE "Tasks" ADD COLUMN     "archivedBy" UUID,
+ADD COLUMN     "completedBy" UUID,
+ADD COLUMN     "completedByUserType" "AssigneeType",
+ADD COLUMN     "deletedBy" UUID,
+ADD COLUMN     "templateId" UUID;

--- a/prisma/schema/task.prisma
+++ b/prisma/schema/task.prisma
@@ -46,6 +46,12 @@ model Task {
 
   source Source @default(web)
 
+  templateId              String? @db.Uuid 
+  completedBy             String? @db.Uuid
+  completedByUserType     AssigneeType? 
+  archivedBy              String? @db.Uuid
+  deletedBy               String? @db.Uuid
+
   @@index([path], type: Gist)
   @@map("Tasks")
 }

--- a/src/cmd/load-testing/load-testing.service.ts
+++ b/src/cmd/load-testing/load-testing.service.ts
@@ -99,6 +99,11 @@ class LoadTester {
         | 'lastArchivedDate'
         | 'parentId'
         | 'subtaskCount'
+        | 'templateId'
+        | 'completedBy'
+        | 'completedByUserType'
+        | 'archivedBy'
+        | 'deletedBy'
       >[] = []
       const currentUser = await authenticateWithToken(this.token, this.apiKey)
       const labelsService = new LabelMappingService(currentUser, this.apiKey)


### PR DESCRIPTION
## Changes

- [x] added new optional fields on the tasks table with their appropriate data types :
	- [x] templateId
	- [x] completedBy
	- [x] completeByUserType
	- [x] archivedBy
	- [x] deletedBy
