### PR TITLE
OUT-1697 | Implement deletedBy column in Tasks

### DIFF
--- a/src/app/api/tasks/public/public.dto.ts
+++ b/src/app/api/tasks/public/public.dto.ts
@@ -26,6 +26,7 @@ export const PublicTaskDtoSchema = z.object({
   isDeleted: z.boolean().nullable(),
   deletedDate: RFC3339DateSchema.nullable(),
   source: TaskSourceSchema,
+  deletedBy: z.string().uuid().nullable(),
 })
 export type PublicTaskDto = z.infer<typeof PublicTaskDtoSchema>
 

--- a/src/app/api/tasks/public/public.serializer.ts
+++ b/src/app/api/tasks/public/public.serializer.ts
@@ -42,6 +42,7 @@ export class PublicTaskSerializer {
       isDeleted: task.deletedAt ? true : false,
       deletedDate: toRFC3339(task.deletedAt),
       source: task.source,
+      deletedBy: task.deletedBy,
     }
   }
 

--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -344,12 +344,12 @@ export class TasksService extends BaseService {
     policyGate.authorize(UserAction.Delete, Resource.Tasks)
     const deletedBy = this.user.internalUserId
     if (!deletedBy) {
-      throw new Error('Cannot delete task. could not find user.') //validation for deletedBy
+      throw new APIError(httpStatus.BAD_REQUEST, 'Cannot delete task. could not find user.') //validation for deletedBy
     }
     await this.db.task.update({
       where: { id, workspaceId: this.user.workspaceId },
       data: {
-        deletedBy: deletedBy,
+        deletedBy,
       },
     })
     // Try to delete existing client notification related to this task if exists

--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -342,7 +342,16 @@ export class TasksService extends BaseService {
   async deleteOneTask(id: string, recursive: boolean = true) {
     const policyGate = new PoliciesService(this.user)
     policyGate.authorize(UserAction.Delete, Resource.Tasks)
-
+    const deletedBy = this.user.internalUserId
+    if (!deletedBy) {
+      throw new Error('Cannot delete task. could not find user.') //validation for deletedBy
+    }
+    await this.db.task.update({
+      where: { id, workspaceId: this.user.workspaceId },
+      data: {
+        deletedBy: deletedBy,
+      },
+    })
     // Try to delete existing client notification related to this task if exists
     const task = await this.db.task.findFirst({
       where: { id, workspaceId: this.user.workspaceId },


### PR DESCRIPTION
## Changes

- [x] filled the new field deletedBy in task whenever the task is deleted.
- [x] exposed deletedBy on public endpoints LIST+GET+DELETE.
- [x] validated that deletedBy must exist whenever a DELETE request on a particular task is recieved.

## Testing Criteria

![image](https://github.com/user-attachments/assets/cc513e27-0986-4bf9-8e92-cebbc0eeb444)
