### PR TITLE
OUT-1695 | Implement completedBy and completedByUserType in Tasks

### DIFF
--- a/src/app/api/tasks/public/public.dto.ts
+++ b/src/app/api/tasks/public/public.dto.ts
@@ -29,6 +29,8 @@ export const PublicTaskDtoSchema = z.object({
   deletedDate: RFC3339DateSchema.nullable(),
   source: TaskSourceSchema,
   deletedBy: z.string().uuid().nullable(),
+  completedBy: z.string().uuid().nullable(),
+  completedByUserType: z.nativeEnum(AssigneeType).nullable(),
 })
 export type PublicTaskDto = z.infer<typeof PublicTaskDtoSchema>
 

--- a/src/app/api/tasks/public/public.serializer.ts
+++ b/src/app/api/tasks/public/public.serializer.ts
@@ -45,6 +45,8 @@ export class PublicTaskSerializer {
       deletedDate: toRFC3339(task.deletedAt),
       source: task.source,
       deletedBy: task.deletedBy,
+      completedBy: task.completedBy,
+      completedByUserType: task.completedByUserType,
     }
   }
 

--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -170,7 +170,7 @@ export class TasksService extends BaseService {
     let completedByUserType: AssigneeType | null = null
 
     if (data.workflowStateId) {
-      const isCompleted = await this.getCompletedByStatus(data.workflowStateId)
+      const isCompleted = await this.getIsCompletedStatus(data.workflowStateId)
       if (isCompleted) {
         completedBy = z.string().parse(this.user.internalUserId)
         completedByUserType = this.user.role
@@ -287,7 +287,7 @@ export class TasksService extends BaseService {
     let completedBy: string | null = null
     let completedByUserType: AssigneeType | null = null
     if (data.workflowStateId) {
-      const isCompleted = await this.getCompletedByStatus(data.workflowStateId)
+      const isCompleted = await this.getIsCompletedStatus(data.workflowStateId)
       if (isCompleted) {
         completedBy = z.string().parse(this.user.internalUserId)
         completedByUserType = this.user.role
@@ -642,7 +642,7 @@ export class TasksService extends BaseService {
     let completedBy: string | null = null
     let completedByUserType: AssigneeType | null = null
     if (targetWorkflowStateId) {
-      const isCompleted = await this.getCompletedByStatus(targetWorkflowStateId)
+      const isCompleted = await this.getIsCompletedStatus(targetWorkflowStateId)
       if (isCompleted) {
         completedBy = z.string().parse(this.user.clientId)
         completedByUserType = this.user.role
@@ -760,7 +760,7 @@ export class TasksService extends BaseService {
     return uuidLength <= maxSubTaskDepth
   }
 
-  async getCompletedByStatus(workflowStateId: string) {
+  async getIsCompletedStatus(workflowStateId: string) {
     const workflowState = await this.db.workflowState.findFirst({
       where: { id: workflowStateId, workspaceId: this.user.workspaceId },
       select: { type: true },


### PR DESCRIPTION
## Changes

- [x] filled the new field completedBy and completedByUserType in tasks row if the task is completed  while updating tasks through iu, client or creating a task.
- [x] exposed completedBy and completedByUserType for public facing api for LIST, GET, CREATE and UPDATE apis.

## Testing Criteria

![image](https://github.com/user-attachments/assets/ca103695-e1df-4b19-9a34-260d9ff23283)
![image](https://github.com/user-attachments/assets/3967ef37-8aa6-4441-afdc-52c564d14f42)
![image](https://github.com/user-attachments/assets/ccdbef3f-7993-4821-9b1e-f9f76c96e736)


