### PR TITLE
OUT-1699 | Implement transactional log + dispatch-once mechanism for task.updated

### DIFF
--- a/prisma/migrations/20250501103013_add_task_update_backlogs_table/migration.sql
+++ b/prisma/migrations/20250501103013_add_task_update_backlogs_table/migration.sql
@@ -1,0 +1,16 @@
+-- CreateEnum
+CREATE TYPE "LogStatus" AS ENUM ('waiting', 'processing');
+
+-- CreateTable
+CREATE TABLE "TaskUpdateBacklogs" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "taskId" UUID NOT NULL,
+    "status" "LogStatus" NOT NULL DEFAULT 'waiting',
+    "createdAt" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "deletedAt" TIMESTAMPTZ,
+
+    CONSTRAINT "TaskUpdateBacklogs_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "TaskUpdateBacklogs" ADD CONSTRAINT "TaskUpdateBacklogs_taskId_fkey" FOREIGN KEY ("taskId") REFERENCES "Tasks"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema/task.prisma
+++ b/prisma/schema/task.prisma
@@ -52,6 +52,7 @@ model Task {
   archivedBy              String? @db.Uuid
   deletedBy               String? @db.Uuid
 
+  taskUpdateBacklogs      TaskUpdateBacklog[]
   @@index([path], type: Gist)
   @@map("Tasks")
 }

--- a/prisma/schema/taskUpdateBacklog.prisma
+++ b/prisma/schema/taskUpdateBacklog.prisma
@@ -1,0 +1,15 @@
+enum LogStatus {
+    waiting
+    processing
+}
+
+model TaskUpdateBacklog {
+  id             String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  taskId         String    @db.Uuid
+  task           Task      @relation(fields: [taskId], references: [id], onDelete: Cascade)
+  status         LogStatus @default(waiting)
+  createdAt      DateTime  @default(now()) @db.Timestamptz()
+  deletedAt      DateTime? @db.Timestamptz()
+
+  @@map("TaskUpdateBacklogs")
+}

--- a/src/app/api/tasks/public/public.controller.ts
+++ b/src/app/api/tasks/public/public.controller.ts
@@ -77,7 +77,7 @@ export const updateTaskPublic = async (req: NextRequest, { params: { id } }: IdP
 
   const tasksService = new TasksService(user)
   const updatePayload = await PublicTaskSerializer.deserializeUpdatePayload(data, user.workspaceId)
-  const updatedTask = await tasksService.updateOneTask(id, updatePayload)
+  const updatedTask = await tasksService.updateOneTask(id, updatePayload, { isPublicApi: true })
 
   return NextResponse.json(PublicTaskSerializer.serialize(updatedTask))
 }

--- a/src/app/api/tasks/tasks.helpers.ts
+++ b/src/app/api/tasks/tasks.helpers.ts
@@ -72,15 +72,20 @@ export const dispatchUpdatedWebhookEvent = async (
   user: User,
   prevTask: Task,
   updatedTask: TaskWithWorkflowState,
+  isPublicApi: boolean,
 ): Promise<void> => {
   let event: DISPATCHABLE_EVENT | undefined
   const copilot = new CopilotAPI(user.token)
 
-  const isDispatchableUpdateChange =
+  let isDispatchableUpdateChange =
     prevTask.assigneeId !== updatedTask.assigneeId ||
     prevTask.title !== updatedTask.title ||
     prevTask.workflowStateId !== updatedTask.workflowStateId ||
     prevTask.dueDate !== updatedTask.dueDate
+
+  if (isPublicApi) {
+    isDispatchableUpdateChange = isDispatchableUpdateChange || prevTask.body !== updatedTask.body
+  }
 
   if (isDispatchableUpdateChange) {
     if (updatedTask.workflowState.type === StateType.completed) {

--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -276,7 +276,7 @@ export class TasksService extends BaseService {
     }
   }
 
-  async updateOneTask(id: string, data: UpdateTaskRequest) {
+  async updateOneTask(id: string, data: UpdateTaskRequest, opts?: { isPublicApi: boolean }) {
     const policyGate = new PoliciesService(this.user)
     policyGate.authorize(UserAction.Update, Resource.Tasks)
 
@@ -347,8 +347,8 @@ export class TasksService extends BaseService {
       await Promise.all([
         activityLogger.logTaskUpdated(prevTask),
         sendTaskUpdateNotifications.trigger({ prevTask, updatedTask, user: this.user }),
-        dispatchUpdatedWebhookEvent(this.user, prevTask, updatedTask),
-        isBodyChanged ? queueBodyUpdatedWebhook(this.user, updatedTask) : undefined,
+        dispatchUpdatedWebhookEvent(this.user, prevTask, updatedTask, opts?.isPublicApi || false),
+        isBodyChanged && opts?.isPublicApi ? queueBodyUpdatedWebhook(this.user, updatedTask) : undefined,
       ])
     }
 

--- a/src/jobs/webhook-dispatch/index.ts
+++ b/src/jobs/webhook-dispatch/index.ts
@@ -1,0 +1,1 @@
+export { queueTaskUpdatedBacklogWebhook } from './queue-task-update-backlog-webhook'

--- a/src/jobs/webhook-dispatch/queue-task-update-backlog-webhook.ts
+++ b/src/jobs/webhook-dispatch/queue-task-update-backlog-webhook.ts
@@ -1,0 +1,50 @@
+import User from '@/app/api/core/models/User.model'
+import { PublicTaskSerializer } from '@/app/api/tasks/public/public.serializer'
+import DBClient from '@/lib/db'
+import { DISPATCHABLE_EVENT } from '@/types/webhook'
+import { CopilotAPI } from '@/utils/CopilotAPI'
+import { LogStatus } from '@prisma/client'
+import { logger, task } from '@trigger.dev/sdk/v3'
+
+export const queueTaskUpdatedBacklogWebhook = task({
+  id: 'queue-task-update-backlog-webhook',
+  maxDuration: 10,
+  queue: { concurrencyLimit: 25 },
+  run: async (payload: { taskId: string; user: User }, { ctx }) => {
+    logger.log('Processing task update backlog to dispatch webhook', { payload, ctx })
+
+    // Mark all waiting backlogs as processing
+    const db = DBClient.getInstance()
+    const updatedBacklogs = await db.taskUpdateBacklog.updateMany({
+      where: { taskId: payload.taskId },
+      data: { status: LogStatus.processing },
+    })
+
+    // Extract the latest task data
+    const task = await db.task.findFirst({
+      where: { id: payload.taskId },
+      include: { workflowState: true },
+    })
+    if (!task) {
+      throw new Error('Failed to find task for task update backlog webhook')
+    }
+
+    // Dispatch webhooks
+    const copilot = new CopilotAPI(payload.user.token)
+    await copilot.dispatchWebhook(DISPATCHABLE_EVENT.TaskUpdated, {
+      payload: PublicTaskSerializer.serialize(task),
+      workspaceId: payload.user.workspaceId,
+    })
+
+    // Hard delete processed backlogs
+    await db.$executeRaw`
+      DELETE FROM "TaskUpdateBacklogs"
+      WHERE "taskId" = ${payload.taskId}::uuid
+        AND "status" = ${LogStatus.processing}::"LogStatus"
+    `
+
+    return {
+      message: `task.updated webhook was dispatched for ${updatedBacklogs.count} transactions`,
+    }
+  },
+})


### PR DESCRIPTION
## Changes

- [x] Add `TaskUpdateBacklogs` table
- [x] Implement dispatch-once mechanism for task `body`  field updates

## Testing Criteria

- [x] Screencast (here the contents of the table were already processed so it was empty. You can see the two webhook dispatches in 20 seconds in the trigger logs)


https://github.com/user-attachments/assets/eaeab00c-515e-4069-9c35-946c4174b8b0


## NOTES:
- `task.updated` hasn't been implemented yet by the Copilot team so the only way to check if this works is by looking at the logs for how many events were dispatched
- Job has been deployed to staging environment on trigger
