### PR TITLE
OUT-1710 | Missing createdBy support for creating tasks through public API.

### DIFF
--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -157,6 +157,8 @@ export class TasksService extends BaseService {
     const policyGate = new PoliciesService(this.user)
     policyGate.authorize(UserAction.Create, Resource.Tasks)
 
+    const copilot = new CopilotAPI(this.user.token)
+
     //generate the label
     const labelMappingService = new LabelMappingService(this.user)
     const label = z.string().parse(await labelMappingService.getLabel(data.assigneeId, data.assigneeType))
@@ -173,12 +175,18 @@ export class TasksService extends BaseService {
 
     const { completedBy, completedByUserType } = await this.getCompletionInfo(data?.workflowStateId)
 
+    // NOTE: This block strictly doesn't allow clients to create tasks
+    let createdById = z.string().parse(this.user.internalUserId)
+    if (opts?.isPublicApi) {
+      createdById = (await copilot.getApiKeyOwner()).id
+    }
+
     // Create a new task associated with current workspaceId. Also inject current request user as the creator.
     const newTask = await this.db.task.create({
       data: {
         ...data,
         workspaceId: this.user.workspaceId,
-        createdById: this.user.internalUserId as string,
+        createdById,
         label: label,
         completedBy,
         completedByUserType,
@@ -225,7 +233,6 @@ export class TasksService extends BaseService {
     }
 
     // Send task created notifications to users + dispatch webhook
-    const copilot = new CopilotAPI(this.user.token)
     await Promise.all([
       sendTaskCreateNotifications.trigger({ user: this.user, task: newTask }),
       copilot.dispatchWebhook(DISPATCHABLE_EVENT.TaskCreated, {

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -158,6 +158,14 @@ export const InternalUsersResponseSchema = z.object({
 })
 export type InternalUsersResponse = z.infer<typeof InternalUsersResponseSchema>
 
+export const ApiKeyOwnerResponseSchema = InternalUsersSchema.pick({
+  id: true,
+  givenName: true,
+  familyName: true,
+  email: true,
+})
+export type ApiKeyOwnerResponse = z.infer<typeof ApiKeyOwnerResponseSchema>
+
 /**
  * Notification RequestBody schema - accepted by SDK#createNotification
  */

--- a/src/utils/CopilotAPI.ts
+++ b/src/utils/CopilotAPI.ts
@@ -2,6 +2,8 @@ import { withRetry } from '@/app/api/core/utils/withRetry'
 import { copilotAPIKey as apiKey, APP_ID } from '@/config'
 import { API_DOMAIN } from '@/constants/domains'
 import {
+  ApiKeyOwnerResponse,
+  ApiKeyOwnerResponseSchema,
   ClientRequest,
   ClientResponse,
   ClientResponseSchema,
@@ -224,6 +226,11 @@ export class CopilotAPI {
     await Promise.all(deletePromises)
   }
 
+  async _getApiKeyOwner(): Promise<ApiKeyOwnerResponse> {
+    const data = await this.manualFetch('me')
+    return ApiKeyOwnerResponseSchema.parse(data)
+  }
+
   async getNotifications(recipientId: string, opts: { limit?: number } = { limit: 100 }) {
     const data = await this.manualFetch('notifications', {
       recipientId,
@@ -276,6 +283,7 @@ export class CopilotAPI {
   getCustomFields = this.wrapWithRetry(this._getCustomFields)
   getInternalUsers = this.wrapWithRetry(this._getInternalUsers)
   getInternalUser = this.wrapWithRetry(this._getInternalUser)
+  getApiKeyOwner = this.wrapWithRetry(this._getApiKeyOwner)
   createNotification = this.wrapWithRetry(this._createNotification)
   markNotificationAsRead = this.wrapWithRetry(this._markNotificationAsRead)
   bulkMarkNotificationsAsRead = this.wrapWithRetry(this._bulkMarkNotificationsAsRead)


### PR DESCRIPTION
## Changes

- [x] Add support for ApiKeyOwner method in CopilotAPI through manual fetching of `me` endpoint
- [x] Make creator of all tasks from public create api as API Key owner. 

## Testing Criteria

- [x] Screencasts

https://github.com/user-attachments/assets/f221b94a-e1f7-44ba-87be-c8e2ec054ffe

