### PR TITLE
OUT-1715 | Backfill completedBy and completedByUserType for older tasks

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "loadtest:delete-clients": "tsx ./src/cmd/load-testing/deleteClients.ts",
     "seed:activity-logs": "tsx ./src/cmd/fill-activity-logs",
     "cmd:delete-duplicate-notifications": "tsx ./src/cmd/delete-duplicate-notifications",
-    "cmd:backfill-archived-by": "tsx ./src/cmd/backfill-archived-by"
+    "cmd:backfill-archived-by": "tsx ./src/cmd/backfill-archived-by",
+    "cmd:backfill-completed-tasks": "tsx ./src/cmd/backfill-completed-tasks"
   },
   "dependencies": {
     "@cyntler/react-doc-viewer": "^1.17.0",

--- a/src/cmd/backfill-completed-tasks/index.ts
+++ b/src/cmd/backfill-completed-tasks/index.ts
@@ -1,0 +1,64 @@
+import DBClient from '@/lib/db'
+import { AssigneeType } from '@prisma/client'
+
+export const fillCompletedTasks = async () => {
+  const db = DBClient.getInstance()
+  const completedWorkflowStates = await db.workflowState.findMany({
+    where: { type: 'completed' },
+  })
+  if (!completedWorkflowStates.length) {
+    throw new Error("No 'completed' workflow states found.")
+  }
+  for (const completedWorkflowState of completedWorkflowStates) {
+    const tasks = await db.task.findMany({
+      where: {
+        workflowStateId: completedWorkflowState.id,
+        OR: [{ completedBy: null }, { completedByUserType: null }],
+      },
+    })
+    if (tasks.length === 0) {
+      console.info('No tasks to backfill')
+      return
+    }
+    for (const [index, task] of tasks.entries()) {
+      console.info(`🛠️ Backfilling task ${index + 1}/${tasks.length} (${task.id} - ${task.title})...`)
+
+      const latestLog = await db.activityLog.findFirst({
+        where: {
+          taskId: task.id,
+          type: 'WORKFLOW_STATE_UPDATED',
+        },
+        orderBy: { createdAt: 'desc' },
+      })
+
+      const fallbackUserId = task.createdById
+      const fallbackUserType = AssigneeType.internalUser
+
+      let completedBy = fallbackUserId
+      let completedByUserType: AssigneeType = fallbackUserType
+
+      if (
+        latestLog &&
+        typeof latestLog.details === 'object' &&
+        latestLog.details !== null &&
+        'newValue' in latestLog.details
+      ) {
+        const { newValue } = latestLog.details as { newValue: string }
+        if (newValue === completedWorkflowState.id) {
+          completedBy = latestLog.userId
+          completedByUserType = latestLog.userRole
+        }
+      }
+
+      await db.task.update({
+        where: { id: task.id },
+        data: {
+          completedBy,
+          completedByUserType,
+        },
+      })
+    }
+  }
+}
+
+fillCompletedTasks()

--- a/src/cmd/backfill-completed-tasks/index.ts
+++ b/src/cmd/backfill-completed-tasks/index.ts
@@ -17,8 +17,8 @@ export const fillCompletedTasks = async () => {
       },
     })
     if (tasks.length === 0) {
-      console.info('No tasks to backfill')
-      return
+      console.info('No tasks to backfill for completed workflow state:', completedWorkflowState.id)
+      continue
     }
     for (const [index, task] of tasks.entries()) {
       console.info(`🛠️ Backfilling task ${index + 1}/${tasks.length} (${task.id} - ${task.title})...`)


### PR DESCRIPTION
## Changes

- [x] added a function to populate completedBy and completedByUserType for each completed workflowState of every workspace.
- [x] added a script to run the function in package.json

## Testing Criteria

- [LOOM](https://www.loom.com/share/e93eeda2721e45e4b2de59e282398159)


