### PR TITLE
OUT-1720 | Passing in a bad token throws a 400 bad request

### DIFF
--- a/src/app/api/core/utils/authenticate.ts
+++ b/src/app/api/core/utils/authenticate.ts
@@ -8,7 +8,13 @@ import httpStatus from 'http-status'
 import { withRetry } from './withRetry'
 
 export const _authenticateWithToken = async (token: string, customApiKey?: string): Promise<User> => {
-  const copilotClient = new CopilotAPI(token, customApiKey)
+  let copilotClient: CopilotAPI
+  try {
+    copilotClient = new CopilotAPI(token, customApiKey)
+  } catch (err) {
+    throw new APIError(httpStatus.UNAUTHORIZED, 'Failed to authenticate token')
+  }
+
   const payload = TokenSchema.safeParse(await copilotClient.getTokenPayload())
 
   if (!payload.success) {


### PR DESCRIPTION
## Changes

- [x] added a try, catch to throw custom 401 error while initializing the CopilotAPI object from copilot SDK

## Testing Criteria

In case of invalid token : 
![image](https://github.com/user-attachments/assets/51cd31a8-d054-488d-854c-caefdb6a6ec9)


