### PR TITLE
OUT-1727, OUT-1725 | Description should not be required when creating a task

### DIFF
--- a/src/app/api/tasks/public/public.dto.ts
+++ b/src/app/api/tasks/public/public.dto.ts
@@ -35,8 +35,16 @@ export const PublicTaskDtoSchema = z.object({
 export type PublicTaskDto = z.infer<typeof PublicTaskDtoSchema>
 
 export const PublicTaskCreateDtoSchema = z.object({
-  name: z.string().min(1).max(255),
-  description: z.string().nullable(),
+  name: z
+    .string()
+    .min(1)
+    .max(255)
+
+    .refine((name) => name.trim().length > 0, {
+      message: 'Required',
+    })
+    .transform((val) => val.trim()),
+  description: z.string().optional(),
   parentTaskId: z.string().uuid().optional(),
   status: StatusSchema,
   assigneeId: z.string().uuid(),
@@ -47,7 +55,14 @@ export const PublicTaskCreateDtoSchema = z.object({
 export type PublicTaskCreateDto = z.infer<typeof PublicTaskCreateDtoSchema>
 
 export const PublicTaskUpdateDtoSchema = z.object({
-  name: z.string().max(255).optional(),
+  name: z
+    .string()
+    .max(255)
+    .optional()
+    .refine((name) => name === undefined || name.trim().length > 0, {
+      message: 'Name must not be empty',
+    })
+    .transform((val) => (val === undefined ? val : val.trim())),
   description: z.string().optional(),
   assigneeId: z.string().uuid().optional(),
   assigneeType: z.nativeEnum(AssigneeType).optional(),

--- a/src/app/api/tasks/public/public.dto.ts
+++ b/src/app/api/tasks/public/public.dto.ts
@@ -39,7 +39,6 @@ export const PublicTaskCreateDtoSchema = z.object({
     .string()
     .min(1)
     .max(255)
-
     .refine((name) => name.trim().length > 0, {
       message: 'Required',
     })


### PR DESCRIPTION
## Changes

- [x] replaced nullable properties on description validation with optional builder method.
- [x] added whitespace validation for titles while updating and creating a task. A title can't have whitespaces only. Also title is transformed with a trim function.

## Testing Criteria

- [LOOM](https://www.loom.com/share/adc0e0f778694bb8b006f428eb3eb9a2)

