### PR TITLE
OUT-1723 | Not getting a webhook for delete task

### DIFF
--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -416,6 +416,7 @@ export class TasksService extends BaseService {
     await Promise.all([
       deleteTaskNotifications.trigger({ user: this.user, task }),
       copilot.dispatchWebhook(DISPATCHABLE_EVENT.TaskDeleted, {
+        payload: PublicTaskSerializer.serialize(task),
         workspaceId: this.user.workspaceId,
       }),
     ])


### PR DESCRIPTION
## Changes

- [x] added payload for dispatching webhook for task.deleted. The missing payload was triggering an error for the webhook dispatch request.

## Testing Criteria

![image](https://github.com/user-attachments/assets/3904f315-2efe-4451-b32a-34f7e71b5354)



