### PR TITLE
OUT-1732 | Outdated deleted task object received in webhook response

### DIFF
--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -433,7 +433,7 @@ export class TasksService extends BaseService {
     await Promise.all([
       deleteTaskNotifications.trigger({ user: this.user, task }),
       copilot.dispatchWebhook(DISPATCHABLE_EVENT.TaskDeleted, {
-        payload: PublicTaskSerializer.serialize(task),
+        payload: PublicTaskSerializer.serialize(updatedTask),
         workspaceId: this.user.workspaceId,
       }),
     ])


### PR DESCRIPTION
## Changes

- [x] Sent the updated task from delete task services to the webhook instead of task fetched earlier before deleting it. 

## Testing Criteria

![image](https://github.com/user-attachments/assets/cf1b7998-2c7d-4fad-a4c1-245d075d949f)

