### PR TITLE
OUT-1733 | task body showing up as undefined + tempalte.body  

### DIFF
--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -189,7 +189,7 @@ export class TasksService extends BaseService {
         throw new APIError(httpStatus.NOT_FOUND, 'The requested template was not found')
       }
       if (template.body) {
-        data.body = data.body + template.body
+        data.body = (data.body ?? '') + template.body
       }
       data.title = data.title + ' ' + template.title
     }


### PR DESCRIPTION
## Changes

- [x] applied a null check while updating task.body if template id is provided from the public api

## Testing Criteria

![image](https://github.com/user-attachments/assets/0bf20bf1-e38c-4068-a343-bdcf941c8b3b)

