### PR TITLE
OUT-1735 | CreatedBy field is incorrect

### DIFF
--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -198,9 +198,8 @@ export class TasksService extends BaseService {
 
     // NOTE: This block strictly doesn't allow clients to create tasks
     let createdById = z.string().parse(this.user.internalUserId)
-    if (opts?.isPublicApi) {
-      createdById = (await copilot.getApiKeyOwner()).id
-    }
+
+    //todo : implement data.createdBy functionality if it is provided from public api here.
 
     // Create a new task associated with current workspaceId. Also inject current request user as the creator.
     const newTask = await this.db.task.create({


### PR DESCRIPTION
## Changes

- [x] createdBy field is incorrect, change functionality of setting createdBy to userId from the token provided instead of APIKeyOwner.

## Testing Criteria

![image](https://github.com/user-attachments/assets/58ede368-93c3-427a-9700-f82df39ec146)
