### PR TITLE
OUT-1734 | do not require name when templateId is present when creating a task

### DIFF
--- a/src/app/api/tasks/public/public.dto.ts
+++ b/src/app/api/tasks/public/public.dto.ts
@@ -34,23 +34,34 @@ export const PublicTaskDtoSchema = z.object({
 })
 export type PublicTaskDto = z.infer<typeof PublicTaskDtoSchema>
 
-export const PublicTaskCreateDtoSchema = z.object({
-  name: z
-    .string()
-    .min(1)
-    .max(255)
-    .refine((name) => name.trim().length > 0, {
-      message: 'Required',
-    })
-    .transform((val) => val.trim()),
-  description: z.string().optional(),
-  parentTaskId: z.string().uuid().optional(),
-  status: StatusSchema,
-  assigneeId: z.string().uuid(),
-  assigneeType: z.nativeEnum(AssigneeType),
-  dueDate: RFC3339DateSchema.optional(),
-  templateId: z.string().uuid().nullish(),
-})
+export const PublicTaskCreateDtoSchema = z
+  .object({
+    name: z
+      .string()
+      .min(1)
+      .max(255)
+      .refine((name) => name.trim().length > 0, {
+        message: 'Required',
+      })
+      .transform((val) => val.trim())
+      .optional(),
+    description: z.string().optional(),
+    parentTaskId: z.string().uuid().optional(),
+    status: StatusSchema,
+    assigneeId: z.string().uuid(),
+    assigneeType: z.nativeEnum(AssigneeType),
+    dueDate: RFC3339DateSchema.optional(),
+    templateId: z.string().uuid().nullish(),
+  })
+  .superRefine((data, ctx) => {
+    if (!data.templateId && !data.name) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Name is required when templateId is not provided',
+        path: ['name'],
+      })
+    }
+  })
 export type PublicTaskCreateDto = z.infer<typeof PublicTaskCreateDtoSchema>
 
 export const PublicTaskUpdateDtoSchema = z.object({

--- a/src/app/api/tasks/public/public.serializer.ts
+++ b/src/app/api/tasks/public/public.serializer.ts
@@ -97,8 +97,8 @@ export class PublicTaskSerializer {
       throw new APIError(httpStatus.NOT_FOUND, 'The requested template was not found')
     }
 
-    const title = (existingTitle ?? '') + (existingTitle ? ' ' : '') + template.title
-    const body = (existingBody ?? '') + (existingBody ? ' ' : '') + template.body
+    const title = (existingTitle ? `${existingTitle} ` : '') + template.title
+    const body = (existingBody ? `${existingBody} ` : '') + template.body
 
     return { title, body }
   }

--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -178,22 +178,6 @@ export class TasksService extends BaseService {
       throw new APIError(httpStatus.BAD_REQUEST, 'Due date cannot be in the past')
     }
 
-    if (opts?.isPublicApi && data.templateId) {
-      const template = await this.db.taskTemplate.findFirst({
-        where: {
-          id: data.templateId,
-          workspaceId: this.user.workspaceId,
-        },
-      })
-      if (!template) {
-        throw new APIError(httpStatus.NOT_FOUND, 'The requested template was not found')
-      }
-      if (template.body) {
-        data.body = (data.body ?? '') + template.body
-      }
-      data.title = data.title + ' ' + template.title
-    }
-
     const { completedBy, completedByUserType } = await this.getCompletionInfo(data?.workflowStateId)
 
     // NOTE: This block strictly doesn't allow clients to create tasks


### PR DESCRIPTION
## Changes

- [x] name should not be required when templateId is present when creating a task from public api
- [x] moved applying template name and body to task from service to deseriazer of public create task dto separating concerns on task creation api from web and public.
- [x] applied name to be an optional body props when creating a template from public api if tempalteId is present.

## Testing Criteria

- [LOOM](https://www.loom.com/share/84ff656d4a0243bf9227702c58a08e90) 


