### PR TITLE
OUT-1736 | createdBy in body is ignored when creating a task

### DIFF
--- a/src/app/api/tasks/public/public.dto.ts
+++ b/src/app/api/tasks/public/public.dto.ts
@@ -52,6 +52,7 @@ export const PublicTaskCreateDtoSchema = z
     assigneeType: z.nativeEnum(AssigneeType),
     dueDate: RFC3339DateSchema.optional(),
     templateId: z.string().uuid().nullish(),
+    createdBy: z.string().uuid().optional(),
   })
   .superRefine((data, ctx) => {
     if (!data.templateId && !data.name) {

--- a/src/app/api/tasks/public/public.serializer.ts
+++ b/src/app/api/tasks/public/public.serializer.ts
@@ -122,6 +122,7 @@ export class PublicTaskSerializer {
       dueDate: rfc3339ToDateString(payload.dueDate),
       parentId: payload.parentTaskId,
       templateId: payload.templateId,
+      createdById: payload.createdBy,
     })
   }
 

--- a/src/types/dto/tasks.dto.ts
+++ b/src/types/dto/tasks.dto.ts
@@ -28,6 +28,7 @@ export const CreateTaskRequestSchema = z
     dueDate: DateStringSchema.nullish(),
     parentId: z.string().uuid().nullish(),
     templateId: z.string().uuid().nullish(),
+    createdById: z.string().uuid().optional(),
   })
   .superRefine(requireAssigneeTypeIfAssigneeId())
 export type CreateTaskRequest = z.infer<typeof CreateTaskRequestSchema>


### PR DESCRIPTION
## Changes

- [x] added a functionality to cater createdBy prop from create task (public) body.
- [x] fetched a list of internal user and matched createdBy with error handling, and created task with the createdBy value if provided.

## Testing Criteria

![image](https://github.com/user-attachments/assets/9acc864c-4add-4b13-83e3-c58150d083c2)

![image](https://github.com/user-attachments/assets/1ba6f9e6-2735-4fd1-b63e-917bfcaecbaf)
