### PR TITLE
OUT-1738 | Refresh attachments url for templates while fetching templates and applying templates.

### DIFF
--- a/src/app/api/tasks/templates/templates.service.ts
+++ b/src/app/api/tasks/templates/templates.service.ts
@@ -37,7 +37,16 @@ export class TemplatesService extends BaseService {
       findOptions.skip = 1
     }
 
-    return this.db.taskTemplate.findMany(findOptions)
+    const templates = await this.db.taskTemplate.findMany(findOptions)
+
+    const updatedTemplates = await Promise.all(
+      templates.map(async (template) => ({
+        ...template,
+        body: template.body ? await replaceImageSrc(template.body, getSignedUrl) : null,
+      })),
+    )
+
+    return updatedTemplates
   }
 
   async getAppliedTemplateDescription(id: string) {

--- a/src/utils/signedTemplateUrlReplacer.ts
+++ b/src/utils/signedTemplateUrlReplacer.ts
@@ -23,7 +23,8 @@ const extractTemplatePath = (url: string): string | null => {
 export const copyTemplateMediaToTask = async (workspaceId: string, body: string): Promise<string | null> => {
   // Regex to match template img srcs
   // Eg https://abcd.supabase.co/storage/v1/object/sign/media/{workspaceId}/templates/
-  const templateUrlRegex = /^https:\/\/([^\/]+)\.supabase\.co\/storage\/v1\/object\/sign\/media\/([^\/]+)\/templates\//
+  const templateUrlRegex =
+    /^https?:\/\/(?:[^\/]+\.supabase\.co|127\.0\.0\.1:\d+)\/storage\/v1\/object\/sign\/media\/([^\/]+)\/templates\// //accepting local supabase urls too
 
   const dom = new JSDOM(body)
   const document = dom.window.document


### PR DESCRIPTION
## Changes

- [x] Added a mechanism to refresh urls of all images while fetching templates on the manage templates page, since urls get expired after an hour.
- [x] Added a missing feature to move all the attachments to `storage/media/{workspaceid}/` directory for getting the attachments/images ready to be applied in a task.

## Testing Criteria

- [LOOM](https://www.loom.com/share/64c244e71a7442328e11e755f87a81c4)
