### PR TITLE
OUT-1736 | createdBy in body is ignored when creating a task

### DIFF
--- a/src/app/api/tasks/tasks.logger.ts
+++ b/src/app/api/tasks/tasks.logger.ts
@@ -8,7 +8,7 @@ import { WorkflowStateUpdatedSchema } from '@api/activity-logs/schemas/WorkflowS
 import { ActivityLogger } from '@api/activity-logs/services/activity-logger.service'
 import User from '@api/core/models/User.model'
 import { BaseService } from '@api/core/services/base.service'
-import { ActivityType, Task, WorkflowState } from '@prisma/client'
+import { ActivityType, AssigneeType, Task, WorkflowState } from '@prisma/client'
 
 /**
  * Wrapper over ActivityLogger to implement a clean abstraction for task creation / update events
@@ -28,8 +28,8 @@ export class TasksActivityLogger extends BaseService {
     this.activityLogger = new ActivityLogger({ taskId: this.task.id, user })
   }
 
-  async logNewTask() {
-    await this.logTaskCreated()
+  async logNewTask(createdBy?: { userId: string; role: AssigneeType }) {
+    await this.logTaskCreated(createdBy)
   }
 
   async logTaskUpdated(prevTask: Task & { workflowState: WorkflowState }) {
@@ -102,12 +102,13 @@ export class TasksActivityLogger extends BaseService {
     )
   }
 
-  private async logTaskCreated() {
+  private async logTaskCreated(createdBy?: { userId: string; role: AssigneeType }) {
     await this.activityLogger.log(
       ActivityType.TASK_CREATED,
       TaskCreatedSchema.parse({
         taskId: this.task.id,
       }),
+      createdBy,
     )
   }
 }

--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -210,7 +210,10 @@ export class TasksService extends BaseService {
     if (newTask) {
       // Add activity logs
       const activityLogger = new TasksActivityLogger(this.user, newTask)
-      await activityLogger.logNewTask()
+      await activityLogger.logNewTask({
+        userId: createdById,
+        role: AssigneeType.internalUser,
+      }) //hardcoding internalUser as role since task can only be created by IUs.
 
       try {
         if (newTask.body) {


### PR DESCRIPTION
## Changes

- [x] Added a support on task creation service to pass createdBy and createdBy role to activity logger for logging new task creation activity.
- [x] Previously, it the userId of the activityLog would be the token user, but since createdBy can be manually passed, we needed to change it.

## Testing Criteria

- [LOOM](https://www.loom.com/share/5772aac12cb246489bc3e6eee8aeeba7)

