### PR TITLE
OUT-1741 | Use text cursor when hovering over description and comment input boxes

### DIFF
--- a/src/app/tapwrite.css
+++ b/src/app/tapwrite.css
@@ -1,5 +1,6 @@
 .tapwrite-comment-input {
   min-height: 22px;
+  cursor: text;
   /* pb is 26px because size of the arrow button is 24px and text should start wrapping just above the button */
 }
 
@@ -12,12 +13,23 @@
 .tapwrite-comment {
   min-height: 2vh;
 }
+.tapwrite-comment-editable {
+  min-height: 2vh;
+  cursor: text;
+}
 
 .tapwrite-comment img,
 .tapwrite-task-description img,
 .tapwrite-comment-input img,
+.tapwrite-reply-input {
+  cursor: text;
+}
 .tapwrite-reply-input img {
   cursor: pointer;
+}
+
+.tapwrite-task-editor {
+  cursor: text;
 }
 
 .tapwrite-task-editor img {

--- a/src/components/cards/CommentCard.tsx
+++ b/src/components/cards/CommentCard.tsx
@@ -310,7 +310,7 @@ export const CommentCard = ({
                 getContent={setEditedContent}
                 readonly={isReadOnly}
                 editorRef={editRef}
-                editorClass={'tapwrite-comment'}
+                editorClass={isReadOnly ? 'tapwrite-comment' : 'tapwrite-comment-editable'}
                 addAttachmentButton={!isReadOnly}
                 uploadFn={uploadFn}
                 deleteEditorAttachments={(url) => deleteEditorAttachmentsHandler(url, token ?? '', task_id, null)}

--- a/src/components/cards/ReplyCard.tsx
+++ b/src/components/cards/ReplyCard.tsx
@@ -222,7 +222,7 @@ export const ReplyCard = ({
               getContent={setEditedContent}
               readonly={isReadOnly}
               editorRef={editRef}
-              editorClass="tapwrite-comment"
+              editorClass={isReadOnly ? 'tapwrite-comment' : 'tapwrite-comment-editable'}
               addAttachmentButton={!isReadOnly}
               uploadFn={uploadFn}
               deleteEditorAttachments={(url) => deleteEditorAttachmentsHandler(url, token ?? '', task_id, null)}


### PR DESCRIPTION
## Changes

- [x] used text cursor on task description, comment input, reply input, comment edit and reply edit components.


## Testing Criteria

- [LOOM](https://www.loom.com/share/a3141625cc32437abac24e8c506f6ad1)
