### PR TITLE
OUT-1750 | Assignee selector unstable, changes placement rapidly on certain dimensions.

### DIFF
--- a/src/components/inputs/Selector.tsx
+++ b/src/components/inputs/Selector.tsx
@@ -143,19 +143,16 @@ export default function Selector<T extends keyof SelectorOptionsType>({
   const [placement, setPlacement] = useState<Placement>('bottom')
   const timeoutRef = useRef<NodeJS.Timeout>()
 
-  const handlePlacementChange = useCallback(
-    (data: ModifierArguments<any>) => {
-      if (data.state?.placement && data.state.placement !== placement) {
-        if (timeoutRef.current) {
-          clearTimeout(timeoutRef.current)
-        }
-        timeoutRef.current = setTimeout(() => {
-          setPlacement(data.state.placement)
-        }, 100)
+  const handlePlacementChange = useCallback((data: ModifierArguments<any>) => {
+    if (data.state?.placement && data.state.placement !== placement) {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current)
       }
-    },
-    [placement],
-  )
+      timeoutRef.current = setTimeout(() => {
+        setPlacement(data.state.placement)
+      }, 100)
+    }
+  }, [])
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
## Changes

- [x] removed placement dependency for handling placement change of the autocomplete which caused an infinite loop on placement change of the popper in the selector component.

## Testing Criteria

- [LOOM](https://www.loom.com/share/0a50ac2d0fd5450c855bdde84be22dab)