### PR TITLE
OUT-1730 | Backfill companyId for all existing tasks assigned to a client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ next-env.d.ts
 
 # Trigger
 .trigger
+
+# Dumps
+dump.sql

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "seed:activity-logs": "tsx ./src/cmd/fill-activity-logs",
     "cmd:delete-duplicate-notifications": "tsx ./src/cmd/delete-duplicate-notifications",
     "cmd:backfill-archived-by": "tsx ./src/cmd/backfill-archived-by",
-    "cmd:backfill-completed-tasks": "tsx ./src/cmd/backfill-completed-tasks"
+    "cmd:backfill-completed-tasks": "tsx ./src/cmd/backfill-completed-tasks",
+    "cmd:backfill-new-user-ids": "tsx ./src/cmd/backfill-new-user-ids"
   },
   "dependencies": {
     "@cyntler/react-doc-viewer": "^1.17.0",

--- a/src/cmd/backfill-new-user-ids/index.ts
+++ b/src/cmd/backfill-new-user-ids/index.ts
@@ -1,0 +1,89 @@
+import { API_DOMAIN } from '@/constants/domains'
+import DBClient from '@/lib/db'
+import { AssigneeType } from '@prisma/client'
+import { z } from 'zod'
+
+interface Clientable {
+  id: string
+  companyId: string
+}
+
+const copilotAPIKey = process.env.COPILOT_API_KEY // Make sure to source the var beforehand
+const COPILOT_CLIENTS_ENDPOINT = `${API_DOMAIN}/v1/clients?limit=10000`
+
+const getCompanyMap = async (uniqueWorkspaceIds: Array<string>) => {
+  const workspaceClientCompanyIdMap: Record<string, Record<string, string>> = {}
+  const failedWorkspaces: Array<string> = []
+
+  // Fetch and set workspaceId + client-company id mapping
+  for (let workspaceId of uniqueWorkspaceIds) {
+    console.log(`backfill-company-id#run | Running backfill for tasks under workspace id ${workspaceId}`)
+    const resp = await fetch(COPILOT_CLIENTS_ENDPOINT, {
+      headers: {
+        'Content-Type': 'application/json',
+        'X-API-KEY': `${workspaceId}/${copilotAPIKey}`,
+      },
+    })
+    const clients: Clientable[] = (await resp.json())?.data
+    if (!clients) {
+      console.error(`backfill-company-id#run | Failed to fetch client data for ${workspaceId}`)
+      failedWorkspaces.push(workspaceId)
+      continue
+    }
+    workspaceClientCompanyIdMap[workspaceId] = clients.reduce(
+      (acc, client) => {
+        if (client.id && client.companyId) {
+          acc[client.id] = client.companyId
+        }
+        return acc
+      },
+      {} as Record<string, string>,
+    )
+  }
+  return { workspaceClientCompanyIdMap, failedWorkspaces }
+}
+
+const run = async () => {
+  console.log(`backfill-company-id#run | Using clients endpoint:`, COPILOT_CLIENTS_ENDPOINT)
+
+  const db = DBClient.getInstance()
+  const tasks = await db.task.findMany({
+    where: { assigneeType: { not: null } },
+  })
+
+  const uniqueWorkspaceIds = [...new Set(tasks.map((t) => t.workspaceId))]
+  console.log(`backfill-company-id#run | All workspace ids (${uniqueWorkspaceIds.length})`, uniqueWorkspaceIds)
+  // Map with workspaceId -> clientId -> companyId
+  const { workspaceClientCompanyIdMap, failedWorkspaces } = await getCompanyMap(uniqueWorkspaceIds)
+
+  const failedTasks: Array<string> = []
+  for (let task of tasks) {
+    if (failedWorkspaces.includes(task.workspaceId)) {
+      failedTasks.push(task.id)
+      continue
+    }
+
+    if (task.assigneeType === AssigneeType.internalUser) {
+      await db.task.update({
+        where: { id: task.id },
+        data: { internalUserId: task.assigneeId },
+      })
+    } else if (task.assigneeType === AssigneeType.client) {
+      const companyId = workspaceClientCompanyIdMap[task.workspaceId][z.string().uuid().parse(task.assigneeId)]
+      await db.task.update({
+        where: { id: task.id },
+        data: { clientId: task.assigneeId, companyId },
+      })
+    } else if (task.assigneeType === AssigneeType.company) {
+      await db.task.update({
+        where: { id: task.id },
+        data: { companyId: task.assigneeId },
+      })
+    }
+  }
+
+  console.log(`Failed workspaces (${failedWorkspaces.length})`, failedWorkspaces)
+  console.log(`Failed tasks (${failedTasks.length})`, failedTasks)
+}
+
+run()

--- a/src/cmd/backfill-new-user-ids/index.ts
+++ b/src/cmd/backfill-new-user-ids/index.ts
@@ -1,6 +1,7 @@
 import { API_DOMAIN } from '@/constants/domains'
 import DBClient from '@/lib/db'
-import { AssigneeType } from '@prisma/client'
+import { AssigneeType, Task } from '@prisma/client'
+import Bottleneck from 'bottleneck'
 import { z } from 'zod'
 
 interface Clientable {
@@ -43,20 +44,17 @@ const getCompanyMap = async (uniqueWorkspaceIds: Array<string>) => {
   return { workspaceClientCompanyIdMap, failedWorkspaces }
 }
 
-const run = async () => {
-  console.log(`backfill-company-id#run | Using clients endpoint:`, COPILOT_CLIENTS_ENDPOINT)
-
+const updateTasks = async (
+  tasks: Task[],
+  workspaceClientCompanyIdMap: Record<string, Record<string, string>>,
+  failedWorkspaces: Array<string>,
+) => {
   const db = DBClient.getInstance()
-  const tasks = await db.task.findMany({
-    where: { assigneeType: { not: null } },
-  })
-
-  const uniqueWorkspaceIds = [...new Set(tasks.map((t) => t.workspaceId))]
-  console.log(`backfill-company-id#run | All workspace ids (${uniqueWorkspaceIds.length})`, uniqueWorkspaceIds)
-  // Map with workspaceId -> clientId -> companyId
-  const { workspaceClientCompanyIdMap, failedWorkspaces } = await getCompanyMap(uniqueWorkspaceIds)
+  const dbBottleneck = new Bottleneck({ minTime: 200, maxConcurrent: 50 })
 
   const failedTasks: Array<string> = []
+  const updatePromises = []
+
   for (let task of tasks) {
     if (failedWorkspaces.includes(task.workspaceId)) {
       failedTasks.push(task.id)
@@ -64,23 +62,50 @@ const run = async () => {
     }
 
     if (task.assigneeType === AssigneeType.internalUser) {
-      await db.task.update({
-        where: { id: task.id },
-        data: { internalUserId: task.assigneeId },
-      })
+      updatePromises.push(
+        db.task.update({
+          where: { id: task.id },
+          data: { internalUserId: task.assigneeId },
+        }),
+      )
     } else if (task.assigneeType === AssigneeType.client) {
       const companyId = workspaceClientCompanyIdMap[task.workspaceId][z.string().uuid().parse(task.assigneeId)]
-      await db.task.update({
-        where: { id: task.id },
-        data: { clientId: task.assigneeId, companyId },
-      })
+      updatePromises.push(
+        db.task.update({
+          where: { id: task.id },
+          data: { clientId: task.assigneeId, companyId },
+        }),
+      )
     } else if (task.assigneeType === AssigneeType.company) {
-      await db.task.update({
-        where: { id: task.id },
-        data: { companyId: task.assigneeId },
-      })
+      updatePromises.push(
+        db.task.update({
+          where: { id: task.id },
+          data: { companyId: task.assigneeId },
+        }),
+      )
     }
   }
+
+  await Promise.all(updatePromises.map((promise) => dbBottleneck.schedule(() => promise)))
+
+  return { failedTasks }
+}
+
+const run = async () => {
+  console.log(`backfill-company-id#run | Using clients endpoint:`, COPILOT_CLIENTS_ENDPOINT)
+
+  const db = DBClient.getInstance()
+  const tasks = await db.task.findMany({
+    where: { assigneeId: { not: null }, assigneeType: { not: null } },
+  })
+
+  const uniqueWorkspaceIds = [...new Set(tasks.map((t) => t.workspaceId))]
+  console.log(`backfill-company-id#run | All workspace ids (${uniqueWorkspaceIds.length})`, uniqueWorkspaceIds)
+  // Map with workspaceId -> clientId -> companyId
+  const { workspaceClientCompanyIdMap, failedWorkspaces } = await getCompanyMap(uniqueWorkspaceIds)
+
+  // Update tasks in db
+  const { failedTasks } = await updateTasks(tasks, workspaceClientCompanyIdMap, failedWorkspaces)
 
   console.log(`Failed workspaces (${failedWorkspaces.length})`, failedWorkspaces)
   console.log(`Failed tasks (${failedTasks.length})`, failedTasks)


### PR DESCRIPTION
## Changes

- [x] Add backfill script to populate `internalUserId`, `clientId`, `companyId` from `assigneeId` and `assigneeType`
- [x] Fix diverging migrations in prod (this has not been affecting new features, however replicating a dump of prod again causes issues)

## Testing Criteria

- [x] Screenshot

The task failed for 107 faulty workspaces out of total 18,047 workspaces
A subset of them were confirmed to be faulty (uninstalled app, deleted workspace, etc)

<img width="474" alt="image" src="https://github.com/user-attachments/assets/71885185-0f56-4dad-811a-a7f938c83dde" />

<img width="768" alt="image" src="https://github.com/user-attachments/assets/51b45d6a-3ea2-47a4-a4fb-ef1914afa2f9" />


## Notes

- The script is purposefully synchronous due to ratelimit restrictions