### PR TITLE
OUT-1767 (Selector Changes)

### DIFF
--- a/src/app/detail/ui/NewTaskCard.tsx
+++ b/src/app/detail/ui/NewTaskCard.tsx
@@ -361,6 +361,7 @@ export const NewTaskCard = ({
             gap={'6px'}
           />
           <CopilotSelector
+            name="Set assignee"
             onChange={(inputValue) => {
               const newUserIds = getSelectedUserIds(inputValue)
               const areUserIdsEmpty = Object.values(newUserIds).every((value) => value === null) // remove this while adding support for no assignee.

--- a/src/app/detail/ui/styledComponent.tsx
+++ b/src/app/detail/ui/styledComponent.tsx
@@ -4,6 +4,7 @@ import { MenuBox } from '@/components/inputs/MenuBox'
 import { EmojiIcon, ReplyIcon } from '@/icons'
 import { KeyboardArrowRight } from '@mui/icons-material'
 import { Box, Modal, Stack, Typography, styled } from '@mui/material'
+import { UserCompanySelector } from 'copilot-design-system'
 
 export const StyledTypography = styled(Typography)(({ theme }) => ({
   color: theme.color.gray[500],
@@ -239,4 +240,8 @@ export const CustomDivider = styled(Box)(({ theme }) => ({
   backgroundColor: theme.color.gray[150],
   marginLeft: '-10px',
   marginRight: '-10px',
+}))
+
+export const StyledUserCompanySelector = styled(UserCompanySelector)(() => ({
+  width: '200px',
 }))

--- a/src/app/detail/ui/styledComponent.tsx
+++ b/src/app/detail/ui/styledComponent.tsx
@@ -241,7 +241,3 @@ export const CustomDivider = styled(Box)(({ theme }) => ({
   marginLeft: '-10px',
   marginRight: '-10px',
 }))
-
-export const StyledUserCompanySelector = styled(UserCompanySelector)(() => ({
-  width: '200px',
-}))

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,6 +9,7 @@ import { ProviderWrapper } from '@/redux/ProviderWrapper'
 import './tapwrite.css'
 import { InterrupCmdK } from '@/hoc/Interrupt_CmdK'
 import { ProgressLoad } from '@/components/TopLoader'
+import 'copilot-design-system/dist/styles/main.css'
 
 const inter = Inter({ subsets: ['latin'] })
 

--- a/src/app/ui/NewTaskForm.tsx
+++ b/src/app/ui/NewTaskForm.tsx
@@ -49,11 +49,8 @@ interface NewTaskFormProps {
 }
 
 export const NewTaskForm = ({ handleCreate, handleClose }: NewTaskFormProps) => {
-  const { activeWorkflowStateId, errors } = useSelector(selectCreateTask)
-  const { workflowStates, assignee, token, filterOptions, previewMode } = useSelector(selectTaskBoard)
-  const [filteredAssignees, setFilteredAssignees] = useState(assignee)
-  const [activeDebounceTimeoutId, setActiveDebounceTimeoutId] = useState<NodeJS.Timeout | null>(null)
-  const [loading, setLoading] = useState(false)
+  const { activeWorkflowStateId } = useSelector(selectCreateTask)
+  const { workflowStates } = useSelector(selectTaskBoard)
 
   const todoWorkflowState = workflowStates.find((el) => el.key === 'todo') || workflowStates[0]
   const defaultWorkflowState = activeWorkflowStateId
@@ -64,28 +61,12 @@ export const NewTaskForm = ({ handleCreate, handleClose }: NewTaskFormProps) => 
     item: defaultWorkflowState,
     type: SelectorType.STATUS_SELECTOR,
   })
-  const { renderingItem: _assigneeValue, updateRenderingItem: updateAssigneeValue } = useHandleSelectorComponent({
-    item:
-      filteredAssignees.find(
-        (item) => item.id == filterOptions[FilterOptions.ASSIGNEE] || item.id == filterOptions[FilterOptions.TYPE],
-      ) ?? null,
-    type: SelectorType.ASSIGNEE_SELECTOR,
-    mode: HandleSelectorComponentModes.CreateTaskFieldUpdate,
-  })
 
   const statusValue = _statusValue as WorkflowStateResponse //typecasting
-  const assigneeValue = _assigneeValue as IAssigneeCombined //typecasting
-  // use temp state pattern so that we don't fall into an infinite loop of assigneeValue set -> trigger -> set
-  const [tempAssignee, setTempAssignee] = useState<IAssigneeCombined | null>(assigneeValue)
-
-  const [inputStatusValue, setInputStatusValue] = useState('')
 
   const [isEditorReadonly, setIsEditorReadonly] = useState(false)
 
   const handleCreateWithAssignee = () => {
-    if (!!tempAssignee?.id && !assignee.find((assignee) => assignee.id === tempAssignee.id)) {
-      store.dispatch(setAssigneeList([...assignee, tempAssignee]))
-    }
     handleCreate()
   }
 

--- a/src/app/ui/NewTaskForm.tsx
+++ b/src/app/ui/NewTaskForm.tsx
@@ -115,6 +115,7 @@ export const NewTaskForm = ({ handleCreate, handleClose }: NewTaskFormProps) => 
           </Box>
           <Stack alignSelf="flex-start">
             <CopilotSelector
+              name="Set assignee"
               onChange={(inputValue) => {
                 const newUserIds = getSelectedUserIds(inputValue)
                 const areUserIdsEmpty = Object.values(newUserIds).every((value) => value === null) // remove this while adding support for no assignee.

--- a/src/components/inputs/CopilotSelector.tsx
+++ b/src/components/inputs/CopilotSelector.tsx
@@ -3,13 +3,13 @@ import { selectTaskBoard } from '@/redux/features/taskBoardSlice'
 import 'copilot-design-system/dist/styles/main.css'
 import { UserCompanySelector, InputValue } from 'copilot-design-system'
 
-export const CopilotSelector = ({ onChange }: { onChange: (inputValue: InputValue[]) => void }) => {
+export const CopilotSelector = ({ onChange, name }: { onChange: (inputValue: InputValue[]) => void; name: string }) => {
   const { selectorAssignee } = useSelector(selectTaskBoard)
   return (
     <>
       <UserCompanySelector
         clientUsers={selectorAssignee.clients}
-        name="Assignee"
+        name={name}
         internalUsers={selectorAssignee.internalUsers}
         companies={selectorAssignee.companies}
         onChange={onChange}

--- a/src/components/inputs/CopilotSelector.tsx
+++ b/src/components/inputs/CopilotSelector.tsx
@@ -1,0 +1,22 @@
+import { useSelector } from 'react-redux'
+import { selectTaskBoard } from '@/redux/features/taskBoardSlice'
+import 'copilot-design-system/dist/styles/main.css'
+import { StyledUserCompanySelector } from '@/app/detail/ui/styledComponent'
+
+export const CopilotSelector = () => {
+  const { selectorAssignee } = useSelector(selectTaskBoard)
+  return (
+    <>
+      <StyledUserCompanySelector
+        clientUsers={selectorAssignee.clients}
+        name="Assignee"
+        internalUsers={selectorAssignee.internalUsers}
+        companies={selectorAssignee.companies}
+        onChange={(inputValue) => {
+          console.log(inputValue)
+        }}
+        grouped={true}
+      />
+    </>
+  )
+}

--- a/src/components/inputs/CopilotSelector.tsx
+++ b/src/components/inputs/CopilotSelector.tsx
@@ -1,20 +1,18 @@
 import { useSelector } from 'react-redux'
 import { selectTaskBoard } from '@/redux/features/taskBoardSlice'
 import 'copilot-design-system/dist/styles/main.css'
-import { StyledUserCompanySelector } from '@/app/detail/ui/styledComponent'
+import { UserCompanySelector, InputValue } from 'copilot-design-system'
 
-export const CopilotSelector = () => {
+export const CopilotSelector = ({ onChange }: { onChange: (inputValue: InputValue[]) => void }) => {
   const { selectorAssignee } = useSelector(selectTaskBoard)
   return (
     <>
-      <StyledUserCompanySelector
+      <UserCompanySelector
         clientUsers={selectorAssignee.clients}
         name="Assignee"
         internalUsers={selectorAssignee.internalUsers}
         companies={selectorAssignee.companies}
-        onChange={(inputValue) => {
-          console.log(inputValue)
-        }}
+        onChange={onChange}
         grouped={true}
       />
     </>

--- a/src/hoc/ClientSideStateUpdate.tsx
+++ b/src/hoc/ClientSideStateUpdate.tsx
@@ -67,7 +67,6 @@ export const ClientSideStateUpdate = ({
   selectorAssignee?: ISelectorAssignee
 }) => {
   const { tasks: tasksInStore, viewSettingsTemp } = useSelector(selectTaskBoard)
-  console.log(selectorAssignee)
   useEffect(() => {
     if (workflowStates) {
       store.dispatch(setWorkflowStates(workflowStates))

--- a/src/hoc/ClientSideStateUpdate.tsx
+++ b/src/hoc/ClientSideStateUpdate.tsx
@@ -9,6 +9,7 @@ import {
   setAssigneeList,
   setFilteredAssgineeList,
   setPreviewMode,
+  setSelectorAssignee,
   setTasks,
   setToken,
   setViewSettings,
@@ -21,7 +22,7 @@ import { Token } from '@/types/common'
 import { TaskResponse } from '@/types/dto/tasks.dto'
 import { CreateViewSettingsDTO } from '@/types/dto/viewSettings.dto'
 import { WorkflowStateResponse } from '@/types/dto/workflowStates.dto'
-import { IAssigneeCombined, IAssigneeSuggestions, ITemplate } from '@/types/interfaces'
+import { IAssignee, IAssigneeCombined, IAssigneeSuggestions, ISelectorAssignee, ITemplate } from '@/types/interfaces'
 import { filterOptionsMap } from '@/types/objectMaps'
 import { getPreviewMode, handlePreviewMode } from '@/utils/previewMode'
 import { ReactNode, useEffect } from 'react'
@@ -47,6 +48,7 @@ export const ClientSideStateUpdate = ({
   accesibleTaskIds,
   accessibleTasks,
   activeTaskAssignees,
+  selectorAssignee,
 }: {
   children: ReactNode
   workflowStates?: WorkflowStateResponse[]
@@ -62,8 +64,10 @@ export const ClientSideStateUpdate = ({
   accesibleTaskIds?: string[]
   accessibleTasks?: TaskResponse[]
   activeTaskAssignees?: IAssigneeCombined[]
+  selectorAssignee?: ISelectorAssignee
 }) => {
   const { tasks: tasksInStore, viewSettingsTemp } = useSelector(selectTaskBoard)
+  console.log(selectorAssignee)
   useEffect(() => {
     if (workflowStates) {
       store.dispatch(setWorkflowStates(workflowStates))
@@ -126,6 +130,9 @@ export const ClientSideStateUpdate = ({
     }
     if (activeTaskAssignees) {
       store.dispatch(setActiveTaskAssignees(activeTaskAssignees))
+    }
+    if (selectorAssignee) {
+      store.dispatch(setSelectorAssignee(selectorAssignee))
     }
     return () => {
       store.dispatch(setActiveTask(undefined))

--- a/src/hooks/useHandleSelectorComponent.tsx
+++ b/src/hooks/useHandleSelectorComponent.tsx
@@ -30,27 +30,6 @@ export const useHandleSelectorComponent = ({
       store.dispatch(setCreateTemplateFields({ targetField: 'workflowStateId', value: (item as WorkflowStateResponse)?.id }))
     }
 
-    if (mode === HandleSelectorComponentModes.CreateTaskFieldUpdate && type === SelectorType.ASSIGNEE_SELECTOR && item) {
-      const activeKey = userIdFieldMap[(item as IAssigneeCombined)?.type as keyof typeof userIdFieldMap]
-      const newUserIds: IUserIds = {
-        [UserIds.INTERNAL_USER_ID]: null,
-        [UserIds.CLIENT_ID]: null,
-        [UserIds.COMPANY_ID]: null,
-        [activeKey]: (item as IAssigneeCombined).id,
-      }
-      if ((item as IAssigneeCombined).type === 'clients' && (item as IAssigneeCombined).companyId) {
-        newUserIds[UserIds.COMPANY_ID] = (item as IAssigneeCombined).companyId ?? null
-      } //set companyId if clientId is selected
-
-      store.dispatch(setCreateTaskFields({ targetField: 'userIds', value: newUserIds }))
-
-      store.dispatch(
-        setCreateTemplateFields({
-          targetField: 'assigneeType',
-          value: getAssigneeTypeCorrected(item as IAssigneeCombined),
-        }),
-      )
-    }
     setRenderingItem(item)
   }, [type, item])
 

--- a/src/redux/features/taskBoardSlice.tsx
+++ b/src/redux/features/taskBoardSlice.tsx
@@ -3,7 +3,7 @@ import { PreviewMode } from '@/types/common'
 import { TaskResponse } from '@/types/dto/tasks.dto'
 import { CreateViewSettingsDTO, FilterOptionsType } from '@/types/dto/viewSettings.dto'
 import { WorkflowStateResponse } from '@/types/dto/workflowStates.dto'
-import { FilterByOptions, FilterOptions, IAssigneeCombined, IFilterOptions } from '@/types/interfaces'
+import { FilterByOptions, FilterOptions, IAssigneeCombined, IFilterOptions, ISelectorAssignee } from '@/types/interfaces'
 import { ViewMode } from '@prisma/client'
 import { createSlice } from '@reduxjs/toolkit'
 
@@ -26,6 +26,7 @@ interface IInitialState {
   accessibleTasks: TaskResponse[]
   confirmAssignModalId: string | undefined
   assigneeCache: Record<string, IAssigneeCombined>
+  selectorAssignee: ISelectorAssignee
 }
 
 const initialState: IInitialState = {
@@ -52,6 +53,11 @@ const initialState: IInitialState = {
   accessibleTasks: [],
   confirmAssignModalId: '',
   assigneeCache: {},
+  selectorAssignee: {
+    clients: [],
+    internalUsers: [],
+    companies: [],
+  },
 }
 
 const taskBoardSlice = createSlice({
@@ -155,6 +161,10 @@ const taskBoardSlice = createSlice({
     setAssigneeCache: (state, action: { payload: { key: string; value: IAssigneeCombined } }) => {
       state.assigneeCache[action.payload.key] = action.payload.value
     }, //used in memory cache rather than useMemo for cross-view(board and list) caching. The alternate idea would be to include assignee object in the response of getTasks api for each task but that would be a bit expensive.
+
+    setSelectorAssignee: (state, action: { payload: ISelectorAssignee }) => {
+      state.selectorAssignee = action.payload
+    },
   },
 })
 
@@ -179,6 +189,7 @@ export const {
   setAccessibleTasks,
   setConfirmAssigneeModalId,
   setAssigneeCache,
+  setSelectorAssignee,
 } = taskBoardSlice.actions
 
 export default taskBoardSlice.reducer

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -1,6 +1,6 @@
 import { UserSchema } from '@/types/common'
 import { UpdateTaskRequestSchema } from '@/types/dto/tasks.dto'
-import { Option } from 'copilot-design-system'
+import { ObjectType } from '@/utils/addTypeToAssignee'
 import { z } from 'zod'
 
 export enum TargetMethod {
@@ -91,10 +91,19 @@ export interface IAssignee {
   companies: Omit<ICompany, 'type'>[]
 }
 
+export interface ISelectorOption {
+  value: string
+  label: string
+  avatarSrc?: string
+  avatarFallbackColor?: string
+  companyId?: string
+  type: ObjectType
+}
+
 export interface ISelectorAssignee {
-  clients: Option[]
-  internalUsers: Option[]
-  companies: Option[]
+  clients: ISelectorOption[]
+  internalUsers: Omit<ISelectorOption, 'companyId'>[]
+  companies: Omit<ISelectorOption, 'companyId'>[]
 }
 
 export interface IIus {

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -1,6 +1,6 @@
 import { UserSchema } from '@/types/common'
 import { UpdateTaskRequestSchema } from '@/types/dto/tasks.dto'
-import { PropsWithChildren } from 'react'
+import { Option } from 'copilot-design-system'
 import { z } from 'zod'
 
 export enum TargetMethod {
@@ -89,6 +89,12 @@ export interface IAssignee {
   internalUsers: Omit<IIus, 'type'>[]
   clients: Omit<IClient, 'type'>[]
   companies: Omit<ICompany, 'type'>[]
+}
+
+export interface ISelectorAssignee {
+  clients: Option[]
+  internalUsers: Option[]
+  companies: Option[]
 }
 
 export interface IIus {

--- a/src/types/objectMaps.ts
+++ b/src/types/objectMaps.ts
@@ -20,7 +20,7 @@ export const filterOptionsToAssigneeMap: Record<string, (assignee: IAssigneeComb
 }
 
 export const userIdFieldMap = {
-  internalUsers: UserIds.INTERNAL_USER_ID,
-  clients: UserIds.CLIENT_ID,
-  companies: UserIds.COMPANY_ID,
+  internalUser: UserIds.INTERNAL_USER_ID,
+  client: UserIds.CLIENT_ID,
+  company: UserIds.COMPANY_ID,
 } as const

--- a/src/utils/addTypeToAssignee.ts
+++ b/src/utils/addTypeToAssignee.ts
@@ -1,6 +1,5 @@
-import { IAssignee, IAssigneeCombined } from '@/types/interfaces'
+import { IAssignee, IAssigneeCombined, ISelectorOption } from '@/types/interfaces'
 import { getAssigneeName } from '@/utils/assignee'
-import { Option } from 'copilot-design-system'
 
 export type ObjectType = 'client' | 'internalUser' | 'company'
 
@@ -15,9 +14,9 @@ export function addTypeToAssignee(assignee?: IAssignee): IAssigneeCombined[] {
 }
 
 export function parseAssigneeToSelectorOption(assignee?: IAssignee): {
-  clients: Option[]
-  internalUsers: Option[]
-  companies: Option[]
+  clients: ISelectorOption[]
+  internalUsers: ISelectorOption[]
+  companies: ISelectorOption[]
 } {
   if (!assignee) {
     return {
@@ -27,7 +26,7 @@ export function parseAssigneeToSelectorOption(assignee?: IAssignee): {
     }
   }
 
-  const parseCategory = (category: Record<string, any> | undefined, type: ObjectType): Option[] => {
+  const parseCategory = (category: Record<string, any> | undefined, type: ObjectType): ISelectorOption[] => {
     if (!category) return []
     return Object.values(category).map((item: any) => ({
       value: item.id,

--- a/src/utils/addTypeToAssignee.ts
+++ b/src/utils/addTypeToAssignee.ts
@@ -1,4 +1,8 @@
 import { IAssignee, IAssigneeCombined } from '@/types/interfaces'
+import { getAssigneeName } from '@/utils/assignee'
+import { Option } from 'copilot-design-system'
+
+export type ObjectType = 'client' | 'internalUser' | 'company'
 
 export function addTypeToAssignee(assignee?: IAssignee): IAssigneeCombined[] {
   if (!assignee) return []
@@ -8,4 +12,36 @@ export function addTypeToAssignee(assignee?: IAssignee): IAssigneeCombined[] {
       type: key,
     }))
   })
+}
+
+export function parseAssigneeToSelectorOption(assignee?: IAssignee): {
+  clients: Option[]
+  internalUsers: Option[]
+  companies: Option[]
+} {
+  if (!assignee) {
+    return {
+      clients: [],
+      internalUsers: [],
+      companies: [],
+    }
+  }
+
+  const parseCategory = (category: Record<string, any> | undefined, type: ObjectType): Option[] => {
+    if (!category) return []
+    return Object.values(category).map((item: any) => ({
+      value: item.id,
+      label: getAssigneeName(item),
+      avatarSrc: item.avatarImageUrl ?? item.iconImageUrl,
+      avatarFallbackColor: item.fallbackColor,
+      companyId: item.companyId,
+      type,
+    }))
+  }
+
+  return {
+    clients: parseCategory(assignee.clients, 'client'),
+    internalUsers: parseCategory(assignee.internalUsers, 'internalUser'),
+    companies: parseCategory(assignee.companies, 'company'),
+  }
 }

--- a/src/utils/getSelectedUserIds.ts
+++ b/src/utils/getSelectedUserIds.ts
@@ -2,13 +2,6 @@ import { IUserIds, UserIds } from '@/types/interfaces'
 import { userIdFieldMap } from '@/types/objectMaps'
 import { InputValue } from 'copilot-design-system'
 
-/**
- * A utility function to extract selected user IDs from the input values of a UserCompanySelector component from the copilot-design-system.
- *
- * @param {InputValue[]} inputValue
- * @returns {IUserIds}
- */
-
 export const getSelectedUserIds = (inputValue: InputValue[]): IUserIds => {
   let userIds: IUserIds = {
     [UserIds.INTERNAL_USER_ID]: null,
@@ -19,7 +12,7 @@ export const getSelectedUserIds = (inputValue: InputValue[]): IUserIds => {
     return userIds
   } // when no user is selected.
 
-  const newValue = inputValue[0]
+  const newValue = inputValue[0] //done to support single selection only, once the UserCompanySelector component supports single selection, this logic will need to be updated.
   const activeKey = userIdFieldMap[newValue.object as keyof typeof userIdFieldMap]
   userIds = {
     [UserIds.INTERNAL_USER_ID]: null,

--- a/src/utils/getSelectedUserIds.ts
+++ b/src/utils/getSelectedUserIds.ts
@@ -1,0 +1,35 @@
+import { IUserIds, UserIds } from '@/types/interfaces'
+import { userIdFieldMap } from '@/types/objectMaps'
+import { InputValue } from 'copilot-design-system'
+
+/**
+ * A utility function to extract selected user IDs from the input values of a UserCompanySelector component from the copilot-design-system.
+ *
+ * @param {InputValue[]} inputValue
+ * @returns {IUserIds}
+ */
+
+export const getSelectedUserIds = (inputValue: InputValue[]): IUserIds => {
+  let userIds: IUserIds = {
+    [UserIds.INTERNAL_USER_ID]: null,
+    [UserIds.CLIENT_ID]: null,
+    [UserIds.COMPANY_ID]: null,
+  }
+  if (!inputValue?.length) {
+    return userIds
+  } // when no user is selected.
+
+  const newValue = inputValue[0]
+  const activeKey = userIdFieldMap[newValue.object as keyof typeof userIdFieldMap]
+  userIds = {
+    [UserIds.INTERNAL_USER_ID]: null,
+    [UserIds.CLIENT_ID]: null,
+    [UserIds.COMPANY_ID]: null,
+    [activeKey]: newValue.id,
+  }
+  if (newValue.companyId) {
+    userIds[UserIds.COMPANY_ID] = newValue.companyId
+  }
+
+  return userIds
+}


### PR DESCRIPTION
## Changes

- [x] added a separate selectorAssignee State in redux to store the assignee according to assignee type and Option type from the copilot-design-system instead of IAssigneeCombined.
- [x] used the selectorAssignee.internalUsers, selectorAssignee.clients and selectorAssignee.companies states for passing prop to the UserCompanySelector component.
- [x] integrated the component replacing previous assignee selector for task creation and sub task creation with a new OnChange function.
- [x] added utility functions and objectMap called getSelectedUserIds and userIdFieldMap to handle the selected values.
- [ ] Remaining : flattening client list according to `companyIds[]`. Blocker : `copilot-node-sdk` still providing empty array in `companyIds` in client list response.

## Testing Criteria 

- [LOOM]()