### PR TITLE
OUT-1794 | Add internalUserId/companyId/clientId filter query params to LIST tasks endpoint

### DIFF
--- a/src/app/api/tasks/public/public.controller.ts
+++ b/src/app/api/tasks/public/public.controller.ts
@@ -13,20 +13,18 @@ import { z } from 'zod'
 export const getAllTasksPublic = async (req: NextRequest) => {
   const user = await authenticate(req)
 
-  const { parentTaskId, assigneeId, createdBy, status, limit, nextToken } = getSearchParams(req.nextUrl.searchParams, [
-    'parentTaskId',
-    'assigneeId',
-    'createdBy',
-    'status',
-    'limit',
-    'nextToken',
-  ])
+  const { parentTaskId, internalUserId, clientId, companyId, createdBy, status, limit, nextToken } = getSearchParams(
+    req.nextUrl.searchParams,
+    ['parentTaskId', 'internalUserId', 'clientId', 'companyId', 'createdBy', 'status', 'limit', 'nextToken'],
+  )
 
   const statusParsed = StatusSchema.optional().parse(status || undefined)
   const workflowStateType = statusParsed && workflowStateTypeMap[statusParsed]
 
   const publicFilters: Partial<Parameters<TasksService['getAllTasks']>[0]> = {
-    assigneeId: assigneeId || undefined,
+    internalUserId: internalUserId || undefined,
+    clientId: clientId || undefined,
+    companyId: companyId || undefined,
     createdById: createdBy || undefined,
     // Note - this technically messes up getting only parent tasks, but that doesn't seem to be in scope for API
     parentId: parentTaskId || undefined,

--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -64,7 +64,9 @@ export class TasksService extends BaseService {
     // Column filters
     showArchived: boolean
     showUnarchived: boolean
-    assigneeId?: string
+    internalUserId?: string
+    clientId?: string
+    companyId?: string
     createdById?: string
     parentId?: string | null
     workflowState?: { type: StateType }
@@ -114,7 +116,9 @@ export class TasksService extends BaseService {
     const where: Prisma.TaskWhereInput = {
       ...filters,
       ...disjointTasksFilter,
-      assigneeId: queryFilters.assigneeId,
+      internalUserId: queryFilters.internalUserId,
+      clientId: queryFilters.clientId,
+      companyId: queryFilters.companyId,
       createdById: queryFilters.createdById,
       workflowState: queryFilters.workflowState,
       isArchived,


### PR DESCRIPTION
## Changes

- [x] Added support for filtering all tasks api according to userIds (internalUserId, clientId and companyId) instead of a single assigneeId. 


## Testing Criteria

- [LOOM](https://www.loom.com/share/49da995a2b894bc1bfa36931f8990576)

