### PR TITLE
OUT-1779, OUT-1819 | Fix task board FilterByAssignee selector to use new userId columns

### DIFF
--- a/src/components/layouts/FilterBar.tsx
+++ b/src/components/layouts/FilterBar.tsx
@@ -2,6 +2,7 @@
 
 import { UserRole } from '@/app/api/core/types/user'
 import FilterButtonGroup from '@/components/buttonsGroup/FilterButtonsGroup'
+import { CopilotSelector } from '@/components/inputs/CopilotSelector'
 import { DisplaySelector } from '@/components/inputs/DisplaySelector'
 import { SelectorType } from '@/components/inputs/Selector'
 import SearchBar from '@/components/searchBar'
@@ -31,7 +32,6 @@ import { NoAssigneeExtraOptions } from '@/utils/noAssignee'
 import { Box, Stack } from '@mui/material'
 import { useEffect, useState } from 'react'
 import { useSelector } from 'react-redux'
-import { CopilotSelector } from '../inputs/CopilotSelector'
 
 interface FilterBarProps {
   mode: UserRole

--- a/src/components/layouts/FilterBar.tsx
+++ b/src/components/layouts/FilterBar.tsx
@@ -188,7 +188,6 @@ export const FilterBar = ({ mode, updateViewModeSetting }: FilterBarProps) => {
                     <CopilotSelector
                       name="Filter by assignee"
                       onChange={(inputValue) => {
-                        console.log('VALUE CHANGED')
                         const newUserIds = getSelectedUserIds(inputValue)
                         const newAssignee = getAssigneeId(newUserIds)
                         if (newAssignee) {


### PR DESCRIPTION
## Changes

- [x] Replaced filter by assignee button in the task board with new `UserCompanySelector` component. 
- [x] Made use of userIds in the filter by assignee button. 
- [x] added support to filter assignee through keyword when the keyword matches the assignee Name. Also, added extra logic to match client tasks' whose company name matches the keyword.
- [x] added support to use userIds while filtering by assignee selection. If filtered through a company user, its corresponding client tasks are also shown.


## Testing Criteria

- [LOOM](https://www.loom.com/share/711db181bc82479797329241a201fa44)

