### PR TITLE
OUT-1815 | There should only be one separator line in the task template dropdown

### DIFF
--- a/src/app/detail/ui/NewTaskCard.tsx
+++ b/src/app/detail/ui/NewTaskCard.tsx
@@ -297,7 +297,7 @@ export const NewTaskCard = ({
             placeholder="Search..."
             value={templateValue}
             selectorType={SelectorType.TEMPLATE_SELECTOR}
-            endOption={<ManageTemplatesEndOption />}
+            endOption={<ManageTemplatesEndOption hasTemplates={!!templates?.length} />}
             endOptionHref={`/manage-templates?token=${token}`}
             listAutoHeightMax="147px"
             variant="normal"

--- a/src/app/ui/NewTaskForm.tsx
+++ b/src/app/ui/NewTaskForm.tsx
@@ -308,7 +308,7 @@ const NewTaskFooter = ({
             placeholder="Search..."
             value={templateValue}
             selectorType={SelectorType.TEMPLATE_SELECTOR}
-            endOption={<ManageTemplatesEndOption />}
+            endOption={<ManageTemplatesEndOption hasTemplates={!!templates?.length} />}
             endOptionHref={`/manage-templates?token=${token}`}
             listAutoHeightMax="147px"
             buttonContent={

--- a/src/components/buttons/ManageTemplatesEndOptions.tsx
+++ b/src/components/buttons/ManageTemplatesEndOptions.tsx
@@ -1,7 +1,7 @@
 import { ArrowRightIcon } from '@/icons'
 import { Box, Stack, Typography } from '@mui/material'
 
-export const ManageTemplatesEndOption = () => {
+export const ManageTemplatesEndOption = ({ hasTemplates }: { hasTemplates: boolean }) => {
   return (
     <Stack
       id="manage-templates-btn"
@@ -11,7 +11,7 @@ export const ManageTemplatesEndOption = () => {
       py="6px"
       justifyContent="space-between"
       sx={{
-        borderTop: (theme) => `1px solid ${theme.color.borders.borderDisabled}`,
+        borderTop: (theme) => `${hasTemplates ? '1px' : '0px'} solid ${theme.color.borders.borderDisabled}`,
         borderBottom: (theme) => `0px solid ${theme.color.borders.borderDisabled}`,
         cursor: 'pointer',
         lineHeight: '21px',


### PR DESCRIPTION
## Changes

- [x] double border on manage templates end option when on empty template options - template selector. 

## Testing Criteria

<img width="232" alt="image" src="https://github.com/user-attachments/assets/9f82de6f-4985-4853-933a-6860ef3eacc1" />


