### PR TITLE
OUT-1872 | Tasks are not being filtered from the api for 2 different companies on client portal

### DIFF
--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -496,17 +496,16 @@ export class TasksService extends BaseService {
 
     const clientId = parsedClientId.data
     const parsedCompanyId = z.string().safeParse(this.user.companyId)
-
     if (!parsedCompanyId.data) {
       return {
-        OR: [{ assigneeId: clientId, assigneeType: 'client' }],
+        OR: [{ clientId }],
       }
     }
 
     return {
       OR: [
-        { assigneeId: clientId as string, assigneeType: 'client' },
-        { assigneeId: parsedCompanyId.data, assigneeType: 'company' },
+        { clientId, companyId: parsedCompanyId.data },
+        { companyId: parsedCompanyId.data, clientId: null },
       ],
     }
   }
@@ -876,6 +875,10 @@ export class TasksService extends BaseService {
         throw new APIError(httpStatus.BAD_REQUEST, `Invalid clientId`)
       }
 
+      if (!companyId) {
+        throw new APIError(httpStatus.BAD_REQUEST, `CompanyId is required for client tasks`)
+      }
+
       if (companyId && !isValidCompany) {
         throw new APIError(httpStatus.BAD_REQUEST, `Invalid company for the provided clientId`)
       }
@@ -883,7 +886,7 @@ export class TasksService extends BaseService {
       return {
         internalUserId: null,
         clientId,
-        companyId: client.companyId,
+        companyId,
       }
     }
 

--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -875,11 +875,7 @@ export class TasksService extends BaseService {
         throw new APIError(httpStatus.BAD_REQUEST, `Invalid clientId`)
       }
 
-      if (!companyId) {
-        throw new APIError(httpStatus.BAD_REQUEST, `CompanyId is required for client tasks`)
-      }
-
-      if (companyId && !isValidCompany) {
+      if (!companyId || !isValidCompany) {
         throw new APIError(httpStatus.BAD_REQUEST, `Invalid company for the provided clientId`)
       }
 


### PR DESCRIPTION
## Changes

- [x] Changed getClientorCompanyAssigneeFilter() to support userIds instead of old assigneeId which was outdated for the multi companies portal.
- [x] Returned the provided companyId instead of client.companyId while validating user Ids on task creation.

## Testing Criteria

- [LOOM](https://www.loom.com/share/d8d4f7c41d3445c1ad39a00bdaa3a8be)