### PR TITLE
OUT-1889 | Subtasks and Parent tasks relation between same clientId with different companyIds issue in multi companies workspace.

### DIFF
--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -526,7 +526,10 @@ export class TasksService extends BaseService {
           {
             ...this.getClientOrCompanyAssigneeFilter(), // Prevent overwriting of OR statement
             parent: {
-              AND: [{ assigneeId: { not: this.user.clientId } }, { assigneeId: { not: this.user.companyId } }],
+              OR: [
+                { assigneeId: { not: this.user.clientId } },
+                { OR: [{ companyId: null }, { companyId: { not: this.user.companyId } }] },
+              ],
             },
           },
           // Task is a parent / standalone task

--- a/src/lib/realtime.ts
+++ b/src/lib/realtime.ts
@@ -63,7 +63,13 @@ export class RealtimeHandler {
       }
     } else if (this.userRole === AssigneeType.client) {
       // Ignore all tasks that don't belong to client
-      if (newTask.assigneeId !== this.tokenPayload.clientId && newTask.assigneeId !== this.tokenPayload.companyId) {
+
+      if (
+        !(
+          (newTask.clientId == this.tokenPayload.clientId && newTask.companyId == this.tokenPayload.companyId) ||
+          (newTask.clientId == null && newTask.companyId == this.tokenPayload.companyId)
+        )
+      ) {
         return false
       }
     } else {
@@ -291,7 +297,9 @@ export class RealtimeHandler {
 
     // CASE III: Reassignment into scope
     const isReassignedIntoClientScope =
-      this.userRole === AssigneeType.client && updatedTask.companyId === this.tokenPayload.companyId
+      this.userRole === AssigneeType.client &&
+      updatedTask.companyId === this.tokenPayload.companyId &&
+      updatedTask.clientId == this.tokenPayload.clientId
     const isReassignedIntoLimitedIUScope = (() => {
       if (this.userRole !== AssigneeType.internalUser) return false
       const iu = InternalUsersSchema.parse(this.user)


### PR DESCRIPTION
## Changes

- [x] changed logic of isReassignedIntoClientScope on realtime tasks update for client users. Added a check for clientId as well as companyId.
- [x] changed realtime isSubtaskAccessible logic for clients to extend support for clients having same clientId but different company ids.
- [x] changed logic for disjoint task filter for clients. added a check for companyId. The logic in simple terms states that for a client task to be disjoint, the parent task should not contain the client user as its assigneeId, OR the parent task should not have null companyId, or companyId that is not equal to user's companyId. If one of the case is true, the sub task wont be stanalone.

## Testing Criteria

- [LOOM](https://www.loom.com/share/897a382ba85240f7a4fdce79d278ff5a)


