### PR TITLE
OUT-1888 | Label wrong for a client task with different companyId.

### DIFF
--- a/src/app/api/label-mapping/label-mapping.service.ts
+++ b/src/app/api/label-mapping/label-mapping.service.ts
@@ -11,8 +11,9 @@ export class LabelMappingService extends BaseService {
    * @param assigneeType
    * @returns string | null
    */
-  async getLabel(assigneeId: string | null | undefined, assigneeType: string | null | undefined) {
-    if (!assigneeId) {
+  async getLabel(userIds: { internalUserId: string | null; clientId: string | null; companyId: string | null }) {
+    const { internalUserId, clientId, companyId } = userIds
+    if (!internalUserId && !clientId && !companyId) {
       const existingLabel = await this.db.label.findFirst({
         where: {
           labelledEntity: 'Unassigned',
@@ -33,21 +34,21 @@ export class LabelMappingService extends BaseService {
 
     const copilotUtils = new CopilotAPI(this.user.token, this.customApiKey)
 
-    if (assigneeType === AssigneeType.internalUser) {
+    if (internalUserId) {
       const workspace = await copilotUtils.getWorkspace()
       return await this.generateLabel(z.string().parse(workspace.brandName))
     }
-    if (assigneeType === AssigneeType.client) {
-      const client = await copilotUtils.getClient(assigneeId)
-      const company = await copilotUtils.getCompany(client.companyId)
+    if (clientId) {
+      const client = await copilotUtils.getClient(clientId)
+      const company = await copilotUtils.getCompany(companyId ?? client.companyId)
       //client is not assigned in a company
       if (company.isPlaceholder) {
         return await this.generateLabel(client.givenName)
       }
       return await this.generateLabel(company.name)
     }
-    if (assigneeType === AssigneeType.company) {
-      const company = await copilotUtils.getCompany(assigneeId)
+    if (companyId) {
+      const company = await copilotUtils.getCompany(companyId)
       return await this.generateLabel(company.name)
     }
   }

--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -5,6 +5,7 @@ import { sendClientUpdateTaskNotifications } from '@/jobs/notifications/send-cli
 import { ClientResponse, CompanyResponse, InternalUsers } from '@/types/common'
 import { TaskWithWorkflowState } from '@/types/db'
 import { AncestorTaskResponse, CreateTaskRequest, UpdateTaskRequest } from '@/types/dto/tasks.dto'
+import { IUserIds } from '@/types/interfaces'
 import { DISPATCHABLE_EVENT } from '@/types/webhook'
 import { CopilotAPI } from '@/utils/CopilotAPI'
 import { isPastDateString } from '@/utils/dateHelper'
@@ -175,7 +176,7 @@ export class TasksService extends BaseService {
 
     //generate the label
     const labelMappingService = new LabelMappingService(this.user)
-    const label = z.string().parse(await labelMappingService.getLabel(assigneeId, assigneeType))
+    const label = z.string().parse(await labelMappingService.getLabel(validatedIds))
 
     if (data.parentId) {
       const canCreateSubTask = await this.canCreateSubTask(data.parentId)
@@ -336,7 +337,7 @@ export class TasksService extends BaseService {
       [internalUserId, clientId, companyId].some((id) => id !== undefined) &&
       (internalUserId !== prevTask?.internalUserId || clientId !== prevTask?.clientId || companyId !== prevTask?.companyId)
 
-    let validatedIds
+    let validatedIds: IUserIds | undefined
 
     if (shouldUpdateUserIds) {
       validatedIds = await this.validateUserIds(internalUserId, clientId, companyId)
@@ -371,7 +372,9 @@ export class TasksService extends BaseService {
         labelMappingService.setTransaction(tx as PrismaClient)
         //delete the existing label
         await labelMappingService.deleteLabel(prevTask.label)
-        label = z.string().parse(await labelMappingService.getLabel(assigneeId, assigneeType))
+        if (validatedIds) {
+          label = z.string().parse(await labelMappingService.getLabel(validatedIds))
+        }
       }
 
       // Set / reset lastArchivedDate if isArchived has been triggered, else remove it from the update query


### PR DESCRIPTION
## Changes

- [x] changed label mapping service getLabel method parameters to use userIds instead of assigneeId/assigneeType
- [x] applied relevant changes on createTask and updateTask to create labels. the changes being arguments for the getLabel method.

## Testing Criteria

<img width="348" alt="image" src="https://github.com/user-attachments/assets/2cc04ff5-e2e1-4980-a5a0-a8851e0b495c" />



