### PR TITLE
OUT-1892 | Issue on reassignment on task update realtime.

### DIFF
--- a/src/lib/realtime.ts
+++ b/src/lib/realtime.ts
@@ -299,7 +299,9 @@ export class RealtimeHandler {
     })()
 
     if (isReassignedIntoClientScope || isReassignedIntoLimitedIUScope) {
-      store.dispatch(setTasks([...tasks.filter((task) => task.id !== updatedTask.id), updatedTask]))
+      store.dispatch(
+        setTasks([...tasks.filter((task) => task.id !== updatedTask.id && task.parentId !== updatedTask.id), updatedTask]), //also removing previous stand alone tasks after the reassignment.
+      )
       store.dispatch(
         setAccessibleTasks([
           ...accessibleTasks.filter((accessibleTask) => accessibleTask.id !== updatedTask.id),


### PR DESCRIPTION
## Changes

- [x] added a mechanism to remove standalone tasks from the task board after parent task has been reassigned to the client/LimitedInternal users.

## Testing Criteria

- [LOOM]()

