### PR TITLE
OUT-1895 | Creating a Task while on filter mode not working

### DIFF
--- a/src/app/ui/NewTaskForm.tsx
+++ b/src/app/ui/NewTaskForm.tsx
@@ -71,7 +71,7 @@ export const NewTaskForm = ({ handleCreate, handleClose }: NewTaskFormProps) => 
   })
   const { renderingItem: _assigneeValue, updateRenderingItem: updateAssigneeValue } = useHandleSelectorComponent({
     item:
-      filteredAssignees.find(
+      assignee.find(
         (item) => item.id == filterOptions[FilterOptions.ASSIGNEE] || item.id == filterOptions[FilterOptions.TYPE],
       ) ?? null,
     type: SelectorType.ASSIGNEE_SELECTOR,

--- a/src/hooks/useHandleSelectorComponent.tsx
+++ b/src/hooks/useHandleSelectorComponent.tsx
@@ -34,12 +34,6 @@ export const useHandleSelectorComponent = ({
       store.dispatch(
         setCreateTaskFields({ targetField: 'assigneeType', value: getAssigneeTypeCorrected(item as IAssigneeCombined) }),
       )
-      store.dispatch(
-        setCreateTemplateFields({
-          targetField: 'assigneeType',
-          value: getAssigneeTypeCorrected(item as IAssigneeCombined),
-        }),
-      )
     }
     setRenderingItem(item)
   }, [type, item])


### PR DESCRIPTION
## Changes

- [x] a hook specifically made for selector called useHandleSelectorComponent had a dependency issue and was rerendering the selector component and setting assigneeId for createTaskSlice 2 times.
- [x] applied a fix by removing filteredAssignee as a dependency and used assignee which doesnt change multiple times on the lifecycle of the app.

## Testing Criteria

- [LOOM](https://www.loom.com/share/93ee6f5393e84707af227f459d93e8cb)


