### PR TITLE
TRYFIX OUT-1897 | 'Something went wrong' error in production workspace after clicking on a task in the Tasks App as an IU

### DIFF
--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -336,7 +336,7 @@ export class TasksService extends BaseService {
     const { internalUserId, clientId, companyId, ...dataWithoutUserIds } = data
 
     const shouldUpdateUserIds =
-      [internalUserId, clientId, companyId].some((id) => id !== null) || !!(data.assigneeId && data.assigneeType)
+      [internalUserId, clientId, companyId].some((id) => id !== undefined) || !!(data.assigneeId && data.assigneeType)
 
     let validatedIds = {
       internalUserId: internalUserId ?? null,

--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -336,7 +336,7 @@ export class TasksService extends BaseService {
     const { internalUserId, clientId, companyId, ...dataWithoutUserIds } = data
 
     const shouldUpdateUserIds =
-      [internalUserId, clientId, companyId].some((id) => id !== undefined) || !!(data.assigneeId && data.assigneeType)
+      [internalUserId, clientId, companyId].some((id) => !!id) || !!(data.assigneeId && data.assigneeType)
 
     let validatedIds = {
       internalUserId: internalUserId ?? null,


### PR DESCRIPTION
## Note

Problem that was noticed : userIds rolling back to null after updating due date/ workflowstate from details page.

## Changes

- [x] modified a condition where the update task function strictly updates userIds only when task is reassigned and not when due date and workflowstates are changed.


