### PR TITLE
OUT-1911 | On a stand alone sub task events like task deletion or moving subtask out of scope for client, redirection to board is not working.

### DIFF
--- a/src/app/detail/ui/Sidebar.tsx
+++ b/src/app/detail/ui/Sidebar.tsx
@@ -162,17 +162,24 @@ export const Sidebar = ({
         </Box>
         <Box
           sx={{
+            border: (theme) => `1px solid ${theme.color.borders.border}`,
             borderRadius: '4px',
             width: 'fit-content',
+            height: '30px',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
           }}
         >
           <CopilotPopSelector
             name="Set assignee"
             onChange={handleAssigneeChange}
+            disabled={disabled}
             onEmptySelection={handleUnassignment}
             initialValue={assigneeValue}
             buttonContent={
               <SelectorButton
+                disabled={disabled}
                 padding="4px 8px"
                 startIcon={
                   (assigneeValue as IAssigneeCombined)?.name == 'No assignee' ? (
@@ -203,6 +210,7 @@ export const Sidebar = ({
         </Box>
         <Box sx={{}}>
           <DatePickerComponent
+            height={'30px'}
             getDate={(date) => {
               const isoDate = DateStringSchema.parse(formatDate(date))
               updateTask({
@@ -303,7 +311,7 @@ export const Sidebar = ({
           <Box
             sx={{
               ':hover': {
-                bgcolor: (theme) => theme.color.background.bgCallout,
+                bgcolor: (theme) => (disabled ? 'none' : theme.color.background.bgCallout),
               },
               padding: '4px',
               borderRadius: '4px',
@@ -313,10 +321,12 @@ export const Sidebar = ({
             <CopilotPopSelector
               name="Set assignee"
               onChange={handleAssigneeChange}
+              disabled={disabled}
               onEmptySelection={handleUnassignment}
               initialValue={assigneeValue}
               buttonContent={
                 <SelectorButton
+                  disabled={disabled}
                   padding="4px 8px"
                   startIcon={
                     (assigneeValue as IAssigneeCombined)?.name == 'No assignee' ? (

--- a/src/lib/realtime.ts
+++ b/src/lib/realtime.ts
@@ -183,7 +183,7 @@ export class RealtimeHandler {
         store.dispatch(setTasks(tasks.filter((task) => task.id !== newTask.id)))
         store.dispatch(setAccessibleTasks(accessibleTasks.filter((task) => task.id !== newTask.id)))
       }
-      return
+      return this.redirectToBoard(newTask)
     }
 
     if (this.payload.eventType === 'INSERT') {


### PR DESCRIPTION
## Changes

- [x] Added redirection to board logic when a subtask gets updated to out of scope for a client in details page. 
- [x] Disabled assignee selector in sidebar for client users, styled selectors for mobile in top bar - details page.

## Testing Criteria

- [LOOM](https://www.loom.com/share/d4baee3769b847e5a9164018a141472a)


