### PR TITLE
OUT-1913 | Breadcrumbs issue on standalone sub tasks.

### DIFF
--- a/src/app/api/tasks/subtasks.service.ts
+++ b/src/app/api/tasks/subtasks.service.ts
@@ -11,6 +11,9 @@ import { z } from 'zod'
 interface Assignable {
   assigneeId: string
   assigneeType: AssigneeType
+  internalUserId: string | null
+  clientId: string | null
+  companyId: string | null
 }
 
 export class SubtaskService extends BaseService {
@@ -119,7 +122,11 @@ export class SubtaskService extends BaseService {
     } else if (this.user.role === UserRole.Client) {
       // If user is a client, just check index of which task was last assigned to client
       latestAccessibleTaskIndex = tasks.findLastIndex(
-        (task) => task.assigneeId !== this.user.clientId && task.assigneeId !== this.user.companyId,
+        (task) =>
+          !(
+            (task.clientId === this.user.clientId && task.companyId === this.user.companyId) ||
+            (task.clientId === null && task.companyId === this.user.companyId)
+          ),
       )
     } else {
       throw new APIError(httpStatus.BAD_REQUEST, 'Failed to parse user role from token')

--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -756,7 +756,16 @@ export class TasksService extends BaseService {
       parents.map((id) =>
         this.db.task.findFirstOrThrow({
           where: { id, workspaceId: this.user.workspaceId },
-          select: { id: true, title: true, label: true, assigneeId: true, assigneeType: true },
+          select: {
+            id: true,
+            title: true,
+            label: true,
+            assigneeId: true,
+            assigneeType: true,
+            clientId: true,
+            companyId: true,
+            internalUserId: true,
+          },
         }),
       ) as Promise<AncestorTaskResponse>[],
     )

--- a/src/types/dto/tasks.dto.ts
+++ b/src/types/dto/tasks.dto.ts
@@ -101,4 +101,7 @@ export type SubTaskStatusResponse = z.infer<typeof SubTaskStatusSchema>
 export type AncestorTaskResponse = Pick<Task, 'id' | 'title' | 'label'> & {
   assigneeId: string
   assigneeType: NonNullable<AssigneeType>
+  internalUserId: string | null
+  clientId: string | null
+  companyId: string | null
 }


### PR DESCRIPTION
## Changes

- [x] added task.clientId and task.companyId chek for getAccessiblePathTasks for breadcrumbs instead of task.assigneeId
- [ ] also need to completely wipe out assigneeId check for getAccessiblePathTask to support this on limited access iu too. 

## Testing Criteria

- [LOOM](https://www.loom.com/share/403f5414dc5f4e9c821fef4a9426668d)


