### PR TITLE
OUT-1915 | No webhook events triggered when client moves task stages

### DIFF
--- a/src/app/api/tasks/tasks.helpers.ts
+++ b/src/app/api/tasks/tasks.helpers.ts
@@ -88,19 +88,14 @@ export const dispatchUpdatedWebhookEvent = async (
   }
 
   if (isDispatchableUpdateChange) {
-    if (updatedTask.workflowState.type === StateType.completed) {
-      event = DISPATCHABLE_EVENT.TaskCompleted
-    } else {
-      event = DISPATCHABLE_EVENT.TaskUpdated
-    }
+    event =
+      updatedTask.workflowState.type === StateType.completed
+        ? DISPATCHABLE_EVENT.TaskCompleted
+        : DISPATCHABLE_EVENT.TaskUpdated
   }
 
   if (prevTask.isArchived !== updatedTask.isArchived) {
-    if (updatedTask.isArchived === true) {
-      event = DISPATCHABLE_EVENT.TaskArchived
-    } else {
-      event = DISPATCHABLE_EVENT.TaskUpdated
-    }
+    event = updatedTask.isArchived ? DISPATCHABLE_EVENT.TaskArchived : DISPATCHABLE_EVENT.TaskUpdated
   }
 
   if (event) {

--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -738,7 +738,10 @@ export class TasksService extends BaseService {
 
     if (updatedTask) {
       const activityLogger = new TasksActivityLogger(this.user, updatedTask)
-      await activityLogger.logTaskUpdated(prevTask)
+      await Promise.all([
+        activityLogger.logTaskUpdated(prevTask),
+        dispatchUpdatedWebhookEvent(this.user, prevTask, updatedTask, false),
+      ])
     }
 
     await sendClientUpdateTaskNotifications.trigger({ user: this.user, prevTask, updatedTask, updatedWorkflowState })

--- a/src/utils/CopilotAPI.ts
+++ b/src/utils/CopilotAPI.ts
@@ -238,7 +238,7 @@ export class CopilotAPI {
 
   async dispatchWebhook(eventName: DISPATCHABLE_EVENT, { workspaceId, payload }: { workspaceId: string; payload?: object }) {
     const url = `${API_DOMAIN}/v1/webhooks/${eventName}`
-    console.info('CopilotAPI#dispatchWebhook | Dispatching webhook to ', url)
+    console.info('CopilotAPI#dispatchWebhook | Dispatching webhook to ', url, 'with payload', payload ?? null)
 
     try {
       await fetch(url, {


### PR DESCRIPTION
## Changes

- [x] Dispatch `task.updated` webhook for client workflow state updates.

## Testing Criteria

- [x] Screenshot
<img width="1115" alt="image" src="https://github.com/user-attachments/assets/4ead29ad-e8d0-449d-af03-605b5779805c" />
