### PR TITLE
OUT-1935 | Activity logs shows Company users as undefined when task is unassigned from the company Users.

### DIFF
--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -334,7 +334,9 @@ export class TasksService extends BaseService {
     const { internalUserId, clientId, companyId, ...dataWithoutUserIds } = data
 
     const shouldUpdateUserIds =
-      internalUserId !== prevTask?.internalUserId || clientId !== prevTask?.clientId || companyId !== prevTask?.companyId
+      (internalUserId !== undefined && internalUserId !== prevTask?.internalUserId) ||
+      (clientId !== undefined && clientId !== prevTask?.clientId) ||
+      (companyId !== undefined && companyId !== prevTask?.companyId)
 
     let validatedIds: UserIdsType | undefined
 

--- a/src/app/detail/ui/ActivityLog.tsx
+++ b/src/app/detail/ui/ActivityLog.tsx
@@ -54,7 +54,7 @@ export const ActivityLog = ({ log }: Prop) => {
         case ActivityType.TASK_UNASSIGNED:
           const { oldValue: oldId } = TaskUnassignedSchema.parse(log.details)
           const oldAssignee = assignee.find((el) => el.id === oldId)
-          return [oldAssignee ? `${oldAssignee.givenName} ${oldAssignee.familyName}` : 'Deleted User']
+          return [getAssigneeName(oldAssignee, 'Deleted User')]
 
         case ActivityType.TITLE_UPDATED:
           const titles = TitleUpdatedSchema.parse(log.details)


### PR DESCRIPTION
## Changes

- [x] added getAssigneeName for task unassignment log instead of using given name and family name. Companies donot have given name and family names.
- [x] added undefined checks for updated userIds in updateOneTask service. Before this fix, the issue was task being unassigned on every task update, even when assignee was not being updated.

## Testing Criteria

<img width="1180" alt="image" src="https://github.com/user-attachments/assets/5587dc98-3b39-472a-a5a2-c890f0be1d31" />

