### PR TITLE
OUT-1933 | Improve create task api validation

### DIFF
--- a/src/app/api/tasks/public/public.controller.ts
+++ b/src/app/api/tasks/public/public.controller.ts
@@ -1,4 +1,4 @@
-import { PublicTaskCreateDtoSchema, StatusSchema } from '@/app/api/tasks/public/public.dto'
+import { publicTaskCreateDtoSchemaFactory, StatusSchema } from '@/app/api/tasks/public/public.dto'
 import { defaultLimit } from '@/constants/public-api'
 import { getSearchParams } from '@/utils/request'
 import { IdParams } from '@api/core/types/api'
@@ -61,7 +61,7 @@ export const getOneTaskPublic = async (req: NextRequest, { params: { id } }: IdP
 
 export const createTaskPublic = async (req: NextRequest) => {
   const user = await authenticate(req)
-  const data = PublicTaskCreateDtoSchema.parse(await req.json())
+  const data = await publicTaskCreateDtoSchemaFactory(user.token).parseAsync(await req.json())
   const createPayload = await PublicTaskSerializer.deserializeCreatePayload(data, user.workspaceId)
   const tasksService = new TasksService(user)
   const newTask = await tasksService.createTask(createPayload, { isPublicApi: true })

--- a/src/app/api/tasks/public/public.serializer.ts
+++ b/src/app/api/tasks/public/public.serializer.ts
@@ -107,7 +107,6 @@ export class PublicTaskSerializer {
       throw new APIError(httpStatus.NOT_FOUND, 'The requested template was not found')
     }
 
-    console.info({ existingTitle, templateTitle: template.title })
     const title = (existingTitle && existingTitle !== template.title ? `${existingTitle} ` : '') + template.title
     const body = (existingBody ? `${existingBody} ` : '') + (replacedBody || template.body)
     return { title, body }

--- a/src/types/dto/tasks.dto.ts
+++ b/src/types/dto/tasks.dto.ts
@@ -4,16 +4,18 @@ import { WorkflowStateResponseSchema } from './workflowStates.dto'
 import { DateStringSchema } from '@/types/date'
 import { ClientResponseSchema, CompanyResponseSchema, InternalUsersSchema } from '../common'
 
-const requireAssigneeTypeIfAssigneeId =
-  () => (data: { assigneeId?: string | null; assigneeType?: AssigneeType }, ctx: z.RefinementCtx) => {
-    if (data.assigneeId && !data.assigneeType) {
-      ctx.addIssue({
-        path: ['assigneeType'],
-        message: 'assigneeType is required when assigneeId is provided',
-        code: z.ZodIssueCode.custom,
-      })
-    }
+const requireAssigneeTypeIfAssigneeId = (
+  data: { assigneeId?: string | null; assigneeType?: AssigneeType },
+  ctx: z.RefinementCtx,
+) => {
+  if (data.assigneeId && !data.assigneeType) {
+    ctx.addIssue({
+      path: ['assigneeType'],
+      message: 'assigneeType is required when assigneeId is provided',
+      code: z.ZodIssueCode.custom,
+    })
   }
+}
 
 export const AssigneeTypeSchema = z.nativeEnum(PrismaAssigneeType).nullish()
 export type AssigneeType = z.infer<typeof AssigneeTypeSchema>
@@ -33,7 +35,7 @@ export const CreateTaskRequestSchema = z
     clientId: z.string().uuid().nullish(),
     companyId: z.string().uuid().nullish(),
   })
-  .superRefine(requireAssigneeTypeIfAssigneeId())
+  .superRefine(requireAssigneeTypeIfAssigneeId)
 
 export type CreateTaskRequest = z.infer<typeof CreateTaskRequestSchema>
 
@@ -50,7 +52,7 @@ export const UpdateTaskRequestSchema = z
     clientId: z.string().uuid().nullish(),
     companyId: z.string().uuid().nullish(),
   })
-  .superRefine(requireAssigneeTypeIfAssigneeId())
+  .superRefine(requireAssigneeTypeIfAssigneeId)
 export type UpdateTaskRequest = z.infer<typeof UpdateTaskRequestSchema>
 
 export const TaskResponseSchema = z.object({


### PR DESCRIPTION
## Changes

- [x] Infer `companyId` for a client if client has only one company

## Testing Criteria

- [x] Screenshot for prod (ONE company)

<img width="1087" alt="image" src="https://github.com/user-attachments/assets/5ad4f1ec-43bc-4225-855d-e61a4f840175" />

companyId validation:
- Token was from "ClientRojan Raj" with following company & companyId:
<img width="392" alt="image" src="https://github.com/user-attachments/assets/324f7f72-82a5-4d09-8d8f-7343d5739979" />
<img width="378" alt="image" src="https://github.com/user-attachments/assets/ddf7ef35-4c2c-4c89-8a84-fd9ca9934afa" />
