### PR TITLE
OUT-1927 | CU can see the in-product notification for a completed company task

### DIFF
--- a/src/app/api/webhook/webhook.controller.ts
+++ b/src/app/api/webhook/webhook.controller.ts
@@ -17,7 +17,11 @@ export const handleWebhookEvent = async (req: NextRequest) => {
   const { assigneeId, assigneeType } = webhookService.parseAssigneeData(webhookEvent, eventType)
 
   switch (eventType) {
-    case HANDLEABLE_EVENT.ClientCreated:
+    // The reason we handle notifications on client.activated, not client.created, is because there might be a time
+    // offset between the creation and activation of the client.
+    // Any notifications dispatched / deleted in this time period will not be synced to this not-yet activated client!
+    // See: https://linear.app/copilotplatforms/issue/OUT-1927/cu-can-see-the-in-product-notification-for-a-completed-company-task
+    case HANDLEABLE_EVENT.ClientActivated:
       await webhookService.handleClientCreated(assigneeId)
       break
     case HANDLEABLE_EVENT.ClientUpdated:

--- a/src/app/api/webhook/webhook.service.ts
+++ b/src/app/api/webhook/webhook.service.ts
@@ -32,7 +32,7 @@ class WebhookService extends BaseService {
     const eventType = webhookEvent.eventType as HANDLEABLE_EVENT
     const isValidWebhook = [
       HANDLEABLE_EVENT.InternalUserDeleted,
-      HANDLEABLE_EVENT.ClientCreated,
+      HANDLEABLE_EVENT.ClientActivated,
       HANDLEABLE_EVENT.ClientUpdated,
       HANDLEABLE_EVENT.ClientDeleted,
       HANDLEABLE_EVENT.CompanyDeleted,
@@ -45,7 +45,7 @@ class WebhookService extends BaseService {
     const assigneeId = deletedEntity.id
     const assigneeType = {
       [HANDLEABLE_EVENT.InternalUserDeleted]: AssigneeType.internalUser,
-      [HANDLEABLE_EVENT.ClientCreated]: AssigneeType.client,
+      [HANDLEABLE_EVENT.ClientActivated]: AssigneeType.client,
       [HANDLEABLE_EVENT.ClientUpdated]: AssigneeType.client,
       [HANDLEABLE_EVENT.ClientDeleted]: AssigneeType.client,
       [HANDLEABLE_EVENT.CompanyDeleted]: AssigneeType.company,
@@ -71,7 +71,6 @@ class WebhookService extends BaseService {
 
     const tasksService = new TasksService(this.user)
     const tasks = await tasksService.getIncompleteTasksForCompany(company.id)
-    console.log('xxxtasks', tasks)
     if (!tasks.length) return
 
     // Then trigger appropriate notifications
@@ -86,10 +85,8 @@ class WebhookService extends BaseService {
     for (let task of tasks) {
       const actionUser = internalUsers.find((iu) => iu.id === task.createdById)
       if (!actionUser) {
-        throw new APIError(
-          httpStatus.INTERNAL_SERVER_ERROR,
-          `webhookController :: could not get action user for company task ${task.id}`,
-        )
+        console.error(`WebhookService#handleClientCreated :: could not get action user for company task ${task.id}`)
+        continue
       }
 
       const existingNotification = existingNotifications.find((notification) => notification.taskId === task.id)

--- a/src/types/webhook.ts
+++ b/src/types/webhook.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 
 export enum HANDLEABLE_EVENT {
   InternalUserDeleted = 'internalUser.deleted',
-  ClientCreated = 'client.created',
+  ClientActivated = 'client.activated',
   ClientUpdated = 'client.updated',
   ClientDeleted = 'client.deleted',
   CompanyDeleted = 'company.deleted',


### PR DESCRIPTION
## Changes

- [x] Switch new notifications creation from `client.created` to `client.activated`

## Testing Criteria

- [x] Screenshots when `client.activated` webhook event is triggered manually:

*Notice there are no stale notifications for completed tasks*

<img width="1413" alt="image" src="https://github.com/user-attachments/assets/cb167c29-779e-461d-8085-2ff5e44b8e26" />
 
<img width="1276" alt="image" src="https://github.com/user-attachments/assets/c9e789c2-a4d7-43c8-a0b4-f40546156d80" />

## NOTE
The reason we still use 'handleClientCreated' is because even if we're triggering the method only on `client.activated`, the purpose of it is to handle client creation ultimately