### PR TITLE
OUT-1937 | Fix Trigger deployments failing due to esbuild error

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "lint-staged": "npx lint-staged",
     "postinstall": "prisma generate",
     "test": "jest",
+    "predeploy": "node src/lib/patch-jsdom-xhr.cjs",
+    "deploy": "npx trigger.dev@latest deploy",
     "trigger": "npx trigger.dev@3.3.17",
     "trigger:deploy-staging": "yarn trigger deploy -e staging",
     "loadtest": "tsx ./src/cmd/load-testing",

--- a/src/lib/patch-jsdom-xhr.cjs
+++ b/src/lib/patch-jsdom-xhr.cjs
@@ -1,0 +1,33 @@
+/**
+ * This patch fixes a dynamic import being made in the XMLHttpRequest-impl.js file.
+ * The dynamic import is used to load the xhr-sync-worker.js file, however esbuild being astatic
+ * bundler cannot resolve the path to it.
+ *
+ * Basically, we resolve the path to the xhr-sync-worker.js file then monkey patch the code
+ * to use that instead of the dynamic erquire.resolve way
+ */
+const fs = require('fs')
+const path = require('path')
+
+const filePath = path.resolve('node_modules/jsdom/lib/jsdom/living/xhr/XMLHttpRequest-impl.js')
+
+const resolvedPath = require.resolve('jsdom/lib/jsdom/living/xhr/xhr-sync-worker.js')
+
+fs.readFile(filePath, 'utf8', (err, data) => {
+  if (err) throw err
+
+  const oldLine = /const\s+syncWorkerFile\s+=\s+require\.resolve\s+\?[^;]+;/
+  const newLine = `const syncWorkerFile = "${resolvedPath}";`
+
+  if (!oldLine.test(data)) {
+    console.log('⚠️ Patch not applied: Pattern not found.')
+    return
+  }
+
+  const updated = data.replace(oldLine, newLine)
+
+  fs.writeFile(filePath, updated, 'utf8', (err) => {
+    if (err) throw err
+    console.log('✅ Patched XMLHttpRequest-impl.js with resolved syncWorker path.')
+  })
+})


### PR DESCRIPTION
## Changes

- [x] Patch `XMLRequest-impl.js` used by jsdom to use a static import instead of a dynamic import

## Testing Criteria

- [x] Trigger jobs are now deploying as intended 🔥 🔥 

![image](https://github.com/user-attachments/assets/3df24014-c7cd-46d4-a011-30b9c6f772aa)
