### PR TITLE
OUT-1943 | Error in client details

### DIFF
--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -520,7 +520,7 @@ export class TasksService extends BaseService {
     // E.g. A -> B -> C, where A is assigned to user 1, B is assigned to user 2, C is assigned to user 2
     // For user 2, task B should show up as a parent task in the main task board
     const disjointTasksFilter: Promise<Prisma.TaskWhereInput> = (async () => {
-      if (this.user.role === UserRole.IU || parentId) {
+      if ((this.user.role === UserRole.IU && !this.user.clientId) || parentId) {
         return {}
       }
 
@@ -561,7 +561,7 @@ export class TasksService extends BaseService {
       return z.string().uuid().parse(parentId)
     }
     // If user is IU, no need to flatten subtasks
-    if (this.user.role === UserRole.IU) {
+    if (this.user.role === UserRole.IU && !this.user.clientId) {
       const copilot = new CopilotAPI(this.user.token)
       if (this.user.internalUserId) {
         const currentInternalUser = await copilot.getInternalUser(this.user.internalUserId)

--- a/src/utils/previewMode.ts
+++ b/src/utils/previewMode.ts
@@ -15,10 +15,16 @@ export const getPreviewMode = (tokenPayload: Token): PreviewMode => {
 
 export const handlePreviewMode = (previewMode: NonNullable<PreviewMode>, tokenPayload: Token) => {
   // If clientId is provided, ignore corresponding companyId. Else pick up the companyId
-  const previewId = tokenPayload.clientId || tokenPayload.companyId
-  if (!previewId) {
+  const previewClientId = tokenPayload.clientId
+  const previewCompanyId = tokenPayload.companyId
+  if (!previewClientId && !previewCompanyId) {
     throw new Error('Could not find preview client / company id')
   }
 
-  store.dispatch(setFilterOptions({ optionType: FilterOptions.ASSIGNEE, newValue: previewId }))
+  store.dispatch(
+    setFilterOptions({
+      optionType: FilterOptions.ASSIGNEE,
+      newValue: { internalUserId: null, clientId: previewClientId!, companyId: previewCompanyId! },
+    }),
+  )
 }

--- a/src/utils/previewMode.ts
+++ b/src/utils/previewMode.ts
@@ -24,7 +24,7 @@ export const handlePreviewMode = (previewMode: NonNullable<PreviewMode>, tokenPa
   store.dispatch(
     setFilterOptions({
       optionType: FilterOptions.ASSIGNEE,
-      newValue: { internalUserId: null, clientId: previewClientId!, companyId: previewCompanyId! },
+      newValue: { internalUserId: null, clientId: previewClientId ?? null, companyId: previewCompanyId ?? null },
     }),
   )
 }


### PR DESCRIPTION
## Changes

- [x] fixed zod error by setting userIds in filterOptions.Assignee instead of string in PreviewMode.ts' handlePreviewMode
- [x] changed logic for IUs on disjointTaskFilters and getParentIdFilter adding a check for user.clientId. If the logged in user is an IU and has user.clientId in payload, then its a preview mode login and should act as a client user instead of an IU.

## Testing Criteria

Preview Mode : 
<img width="1449" alt="image" src="https://github.com/user-attachments/assets/a83ec0eb-166b-4a7f-9720-f689c218aacf" />

Normal Mode from client : 
![image](https://github.com/user-attachments/assets/e5b25fe4-ce13-43f5-9416-928a0ea3b56f)



