### PR TITLE
OUT-1938 | Sub tasks whose parent task is accessible seen on board for Limited Access IUs.

### DIFF
--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -529,7 +529,7 @@ export class TasksService extends BaseService {
         return {
           OR: [
             {
-              parent: { OR: [{ companyId: { notIn: accesibleCompanyIds } }, { companyId: null }] },
+              parent: { companyId: { notIn: accesibleCompanyIds } },
             },
             {
               parentId: null,

--- a/src/app/api/users/users.controller.ts
+++ b/src/app/api/users/users.controller.ts
@@ -15,7 +15,7 @@ export const getUsers = async (req: NextRequest) => {
 
   // "search" param condition has been separated so we can unplug it in the future after CopilotAPI implements keyword match natively
   const users = await (keyword
-    ? usersService.getFilteredUsersStartingWith(keyword, userType, limit, nextToken)
+    ? usersService.getFilteredUsersStartingWith(keyword, userType, limit, nextToken) //keyword is not being used after we migrated to new Assignee Selector (UserCompanySelector). This was primarily used to filter out assignee on the old selector's autocomplete.
     : usersService.getGroupedUsers(limit, undefined))
 
   return NextResponse.json({ users })

--- a/src/app/api/users/users.controller.ts
+++ b/src/app/api/users/users.controller.ts
@@ -12,12 +12,11 @@ export const getUsers = async (req: NextRequest) => {
   const userType = req.nextUrl.searchParams.get('userType') || undefined
   const limit = rawLimit ? +rawLimit : undefined
   const nextToken = req.nextUrl.searchParams.get('nextToken') || undefined
-  const clientCompanyId = req.nextUrl.searchParams.get('clientCompanyId') || undefined
-  //Added a clientCompanyId param here to incorporate filtering of limited access IU for subtask creation if the parent task is assigned to client out of scope.
+
   // "search" param condition has been separated so we can unplug it in the future after CopilotAPI implements keyword match natively
   const users = await (keyword
-    ? usersService.getFilteredUsersStartingWith(keyword, userType, limit, nextToken, clientCompanyId)
-    : usersService.getGroupedUsers(limit, undefined, clientCompanyId))
+    ? usersService.getFilteredUsersStartingWith(keyword, userType, limit, nextToken)
+    : usersService.getGroupedUsers(limit, undefined))
 
   return NextResponse.json({ users })
 }

--- a/src/app/detail/[task_id]/[user_type]/page.tsx
+++ b/src/app/detail/[task_id]/[user_type]/page.tsx
@@ -198,7 +198,6 @@ export default async function TaskDetailPage({
                   userType={params.user_type}
                   isPreview={!!getPreviewMode(tokenPayload)}
                   task={task}
-                  clientCompanyId={task.assigneeType !== 'internalUser' ? task.assigneeId : undefined}
                 />
                 <Sidebar
                   task_id={task_id}

--- a/src/app/detail/ui/NewTaskCard.tsx
+++ b/src/app/detail/ui/NewTaskCard.tsx
@@ -14,16 +14,14 @@ import { useHandleSelectorComponent } from '@/hooks/useHandleSelectorComponent'
 import { AssigneePlaceholderSmall, TempalteIconMd } from '@/icons'
 import { selectAuthDetails } from '@/redux/features/authDetailsSlice'
 import { selectTaskBoard } from '@/redux/features/taskBoardSlice'
-import { selectTaskDetails, setActiveTaskAssignees } from '@/redux/features/taskDetailsSlice'
 import { selectCreateTemplate } from '@/redux/features/templateSlice'
-import store from '@/redux/store'
 import { DateString } from '@/types/date'
 import { CreateTaskRequest } from '@/types/dto/tasks.dto'
 import { WorkflowStateResponse } from '@/types/dto/workflowStates.dto'
 import { IAssigneeCombined, ITemplate, UserIds } from '@/types/interfaces'
 import { getAssigneeName, UserIdsType } from '@/utils/assignee'
-import { getSelectedUserIds } from '@/utils/selector'
 import { deleteEditorAttachmentsHandler, uploadImageHandler } from '@/utils/inlineImage'
+import { getSelectedUserIds } from '@/utils/selector'
 import { trimAllTags } from '@/utils/trimTags'
 import { Box, Stack, Typography } from '@mui/material'
 import dayjs from 'dayjs'
@@ -46,9 +44,7 @@ export const NewTaskCard = ({
   handleClose: () => void
   handleSubTaskCreation: (payload: CreateTaskRequest) => void
 }) => {
-  const { workflowStates, assignee, token, filterOptions, activeTask } = useSelector(selectTaskBoard)
-  const { activeTaskAssignees } = useSelector(selectTaskDetails)
-
+  const { workflowStates, assignee, token, activeTask } = useSelector(selectTaskBoard)
   const { templates } = useSelector(selectCreateTemplate)
 
   const [isEditorReadonly, setIsEditorReadonly] = useState(false)
@@ -206,17 +202,6 @@ export const NewTaskCard = ({
     handleSubTaskCreation(payload)
     clearSubTaskFields()
     handleClose()
-
-    if (subTaskFields.userIds[UserIds.CLIENT_ID] || subTaskFields.userIds[UserIds.COMPANY_ID]) {
-      const assigneeTypes = new Set(activeTaskAssignees.map((a) => a.type))
-      if (assigneeTypes.has('ius') || assigneeTypes.has('internalUsers')) {
-        store.dispatch(
-          setActiveTaskAssignees(
-            activeTaskAssignees.filter((assignee) => assignee.type === 'clients' || assignee.type === 'companies'),
-          ),
-        )
-      }
-    }
   }
 
   return (

--- a/src/hoc/ClientSideStateUpdate.tsx
+++ b/src/hoc/ClientSideStateUpdate.tsx
@@ -15,7 +15,7 @@ import {
   setViewSettings,
   setWorkflowStates,
 } from '@/redux/features/taskBoardSlice'
-import { setActiveTaskAssignees, setAssigneeSuggestion, setExpandedComments } from '@/redux/features/taskDetailsSlice'
+import { setAssigneeSuggestion, setExpandedComments } from '@/redux/features/taskDetailsSlice'
 import { setTemplates } from '@/redux/features/templateSlice'
 import store from '@/redux/store'
 import { Token } from '@/types/common'
@@ -47,7 +47,6 @@ export const ClientSideStateUpdate = ({
   clearExpandedComments,
   accesibleTaskIds,
   accessibleTasks,
-  activeTaskAssignees,
   selectorAssignee,
 }: {
   children: ReactNode
@@ -63,7 +62,6 @@ export const ClientSideStateUpdate = ({
   clearExpandedComments?: boolean
   accesibleTaskIds?: string[]
   accessibleTasks?: TaskResponse[]
-  activeTaskAssignees?: IAssigneeCombined[]
   selectorAssignee?: ISelectorAssignee
 }) => {
   const { tasks: tasksInStore, viewSettingsTemp } = useSelector(selectTaskBoard)
@@ -127,15 +125,11 @@ export const ClientSideStateUpdate = ({
     if (accessibleTasks) {
       store.dispatch(setAccessibleTasks(accessibleTasks))
     }
-    if (activeTaskAssignees) {
-      store.dispatch(setActiveTaskAssignees(activeTaskAssignees))
-    }
     if (selectorAssignee) {
       store.dispatch(setSelectorAssignee(selectorAssignee))
     }
     return () => {
       store.dispatch(setActiveTask(undefined))
-      store.dispatch(setActiveTaskAssignees([]))
     } //when component is unmounted, we need to clear the active task.
   }, [
     workflowStates,
@@ -149,7 +143,6 @@ export const ClientSideStateUpdate = ({
     task,
     accesibleTaskIds,
     accessibleTasks,
-    activeTaskAssignees,
   ])
 
   return children

--- a/src/redux/features/taskDetailsSlice.ts
+++ b/src/redux/features/taskDetailsSlice.ts
@@ -12,7 +12,6 @@ interface IInitialState {
   // URL of an image opened in preview modal for task description / comments
   openImage: string | null
   expandedComments: string[]
-  activeTaskAssignees: IAssigneeCombined[]
 }
 
 const initialState: IInitialState = {
@@ -23,7 +22,6 @@ const initialState: IInitialState = {
   showConfirmAssignModal: false,
   openImage: null,
   expandedComments: [],
-  activeTaskAssignees: [],
 }
 
 const taskDetailsSlice = createSlice({
@@ -51,9 +49,6 @@ const taskDetailsSlice = createSlice({
     setExpandedComments: (state, action: { payload: string[] }) => {
       state.expandedComments = action.payload
     },
-    setActiveTaskAssignees: (state, action: { payload: IAssigneeCombined[] }) => {
-      state.activeTaskAssignees = action.payload
-    },
   },
 })
 
@@ -67,7 +62,6 @@ export const {
   toggleShowConfirmAssignModal,
   setOpenImage,
   setExpandedComments,
-  setActiveTaskAssignees,
 } = taskDetailsSlice.actions
 
 export default taskDetailsSlice.reducer

--- a/src/services/users.ts
+++ b/src/services/users.ts
@@ -13,15 +13,13 @@ export async function getAssigneeList(
   limit?: number,
   nextToken?: string,
   filterOptions?: string,
-  clientCompanyId?: string,
 ): Promise<IAssignee> {
   const reqUrl =
     `/api/users?token=${token}` +
     buildOptionalSearchParam('search', keyword) +
     buildOptionalSearchParam('limit', limit) +
     buildOptionalSearchParam('nextToken', nextToken) +
-    buildOptionalSearchParam('userType', filterOptions) +
-    buildOptionalSearchParam('clientCompanyId', clientCompanyId)
+    buildOptionalSearchParam('userType', filterOptions)
 
   const res = await fetch(reqUrl, {
     next: { tags: ['getAssigneeList'] },


### PR DESCRIPTION
## Changes

- [x] Removed clientCompanyId filters in users api. This was previously used to return assignee by filtering limited access IU so that parent task assigned to inaccesible clients cannot have subtasks assigned to limited access IU. This was one hacky way to limit the feature to prevent using filtering for disjoint tasks for limited access IU which was VERY expensive before. But the introduction of userIds replacing assigneeIds in tasks has made this optimization and we can use that now.
- [x] added the disjoint tasks filtering for limited access IU.
- [x] removed useless states used in previous selectors like activeTaskAssignees.

## Testing Criteria

- [LOOM](https://www.loom.com/share/adb64f5fe0dd4b3e9581cfcfe52cffd3)

