### PR TITLE
OUT-1964 | Subtasks are not showing for CU

### DIFF
--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -544,18 +544,26 @@ export class TasksService extends BaseService {
           {
             ...this.getClientOrCompanyAssigneeFilter(), // Prevent overwriting of OR statement
             parent: {
-              NOT: {
-                OR: [
-                  {
-                    clientId: this.user.clientId,
-                    companyId: this.user.companyId,
+              OR: [
+                {
+                  clientId: null,
+                  companyId: null,
+                },
+                {
+                  NOT: {
+                    OR: [
+                      {
+                        clientId: this.user.clientId,
+                        companyId: this.user.companyId,
+                      },
+                      {
+                        clientId: null,
+                        companyId: this.user.companyId,
+                      },
+                    ],
                   },
-                  {
-                    clientId: null,
-                    companyId: this.user.companyId,
-                  },
-                ],
-              },
+                },
+              ],
             },
           },
           // Task is a parent / standalone task


### PR DESCRIPTION
## Changes

- [x] explicitly allowed subtasks whose parents clientId and companyId are null to solve some subtasks not being seen for CU.

## Testing Criteria

- [LOOM](https://www.loom.com/share/ecfc996b7f244895bbbdbe0c893a75d9)


