### PR TITLE
OUT-1783 | Backfill companyId in ClientNotifications table

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "cmd:backfill-archived-by": "tsx ./src/cmd/backfill-archived-by",
     "cmd:backfill-completed-tasks": "tsx ./src/cmd/backfill-completed-tasks",
     "cmd:backfill-new-user-ids": "tsx ./src/cmd/backfill-new-user-ids",
-    "cmd:normalize-filterOptions-assignee": "tsx ./src/cmd/normalize-filterOptions-assignee"
+    "cmd:normalize-filterOptions-assignee": "tsx ./src/cmd/normalize-filterOptions-assignee",
+    "cmd:backfill-company-id-in-client-notifications": "tsx ./src/cmd/backfill-company-id-in-client-notifications"
   },
   "dependencies": {
     "@cyntler/react-doc-viewer": "^1.17.0",

--- a/prisma/migrations/20250701102047_add_company_id_column_in_client_notifications_table/migration.sql
+++ b/prisma/migrations/20250701102047_add_company_id_column_in_client_notifications_table/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "ClientNotifications" ADD COLUMN     "companyId" UUID;

--- a/prisma/schema/clientNotification.prisma
+++ b/prisma/schema/clientNotification.prisma
@@ -3,8 +3,10 @@ model ClientNotification {
 
   /// Client ID on Copilot for the assigned client user
   clientId       String    @db.Uuid
+  /// Company ID on Copilot for the assigned client user -> update after copilot supporting multiple companies for a client
+  companyId      String?    @db.Uuid
   /// Notification ID for triggered notification on Copilot
-  notificationId String    @db.Uuid
+  notificationId  String    @db.Uuid
   /// Related task
   task           Task      @relation(fields: [taskId], references: [id])
   taskId         String    @db.Uuid

--- a/src/cmd/backfill-company-id-in-client-notifications/index.ts
+++ b/src/cmd/backfill-company-id-in-client-notifications/index.ts
@@ -1,0 +1,115 @@
+import { API_DOMAIN } from '@/constants/domains'
+import DBClient from '@/lib/db'
+import { ClientNotification } from '@prisma/client'
+import Bottleneck from 'bottleneck'
+import { z } from 'zod'
+
+interface Clientable {
+  id: string
+  companyId: string
+}
+
+const copilotAPIKey = process.env.COPILOT_API_KEY
+const COPILOT_CLIENTS_ENDPOINT = `${API_DOMAIN}/v1/clients?limit=10000`
+
+const getCompanyMap = async (uniqueWorkspaceIds: Array<string>) => {
+  const workspaceClientCompanyIdMap: Record<string, Record<string, string>> = {}
+  const failedWorkspaces: Array<string> = []
+
+  // Fetch and set workspaceId + client-company id mapping
+  for (let workspaceId of uniqueWorkspaceIds) {
+    console.info(`backfill-company-id#run | Running backfill for clientNotifications under workspace id ${workspaceId}`)
+    const resp = await fetch(COPILOT_CLIENTS_ENDPOINT, {
+      headers: {
+        'Content-Type': 'application/json',
+        'X-API-KEY': `${workspaceId}/${copilotAPIKey}`,
+      },
+    })
+    const clients: Clientable[] = (await resp.json())?.data
+    if (!clients) {
+      console.error(`backfill-company-id#run | Failed to fetch client data for ${workspaceId}`)
+      failedWorkspaces.push(workspaceId)
+      continue
+    }
+    workspaceClientCompanyIdMap[workspaceId] = clients.reduce(
+      (acc, client) => {
+        if (client.id && client.companyId) {
+          acc[client.id] = client.companyId
+        }
+        return acc
+      },
+      {} as Record<string, string>,
+    )
+  }
+  return { workspaceClientCompanyIdMap, failedWorkspaces }
+}
+
+const updateClientNotifications = async (
+  clientNotifications: (ClientNotification & {
+    task: {
+      workspaceId: string
+    }
+  })[],
+  workspaceClientCompanyIdMap: Record<string, Record<string, string>>,
+  failedWorkspaces: Array<string>,
+) => {
+  const db = DBClient.getInstance()
+  const dbBottleneck = new Bottleneck({ minTime: 200, maxConcurrent: 50 })
+
+  const failedClientNotifications: Array<string> = []
+  const updatePromises = []
+
+  for (let clientNotification of clientNotifications) {
+    if (failedWorkspaces.includes(clientNotification.task.workspaceId)) {
+      failedClientNotifications.push(clientNotification.id)
+      continue
+    }
+
+    const companyId =
+      workspaceClientCompanyIdMap[clientNotification.task.workspaceId][z.string().uuid().parse(clientNotification.clientId)]
+    updatePromises.push(
+      db.clientNotification.update({
+        where: { id: clientNotification.id },
+        data: { companyId },
+      }),
+    )
+  }
+
+  await Promise.all(updatePromises.map((promise) => dbBottleneck.schedule(() => promise)))
+
+  return { failedClientNotifications }
+}
+
+const run = async () => {
+  console.info(`backfill-company-id#run | Using clients endpoint:`, COPILOT_CLIENTS_ENDPOINT)
+
+  const db = DBClient.getInstance()
+  const clientNotifications = await db.clientNotification.findMany({
+    where: { companyId: null },
+    include: {
+      task: {
+        select: {
+          workspaceId: true,
+        },
+      },
+    },
+  })
+
+  const uniqueWorkspaceIds = [...new Set(clientNotifications.map((el) => el.task.workspaceId))]
+
+  console.info(`backfill-company-id#run | All workspace ids (${uniqueWorkspaceIds.length})`, uniqueWorkspaceIds)
+  // Map with workspaceId -> clientId -> companyId
+  const { workspaceClientCompanyIdMap, failedWorkspaces } = await getCompanyMap(uniqueWorkspaceIds)
+
+  // Update client notifications in db
+  const { failedClientNotifications } = await updateClientNotifications(
+    clientNotifications,
+    workspaceClientCompanyIdMap,
+    failedWorkspaces,
+  )
+
+  console.info(`Failed workspaces (${failedWorkspaces.length})`, failedWorkspaces)
+  console.info(`Failed update on clientNotifications (${failedClientNotifications.length})`, failedClientNotifications)
+}
+
+run()


### PR DESCRIPTION
## Changes

- [x] created a new column companyId on clientNotifications table with a new migration.
- [x] created a script to populate companyId for each clientNotifications entry which is not yet deleted.
- [x] added the script command on package.json.

## Testing Criteria

Out of 668 client notifications : 
<img width="427" alt="image" src="https://github.com/user-attachments/assets/ee9d622c-f7e8-4b78-a8ab-c362b2f32256" />

21 are failed, because the workspaces use another api key, probably the outside multi companies workspace : 
<img width="480" alt="image" src="https://github.com/user-attachments/assets/24823c54-f033-4d67-a781-024f7e2a8f4d" />

