### PR TITLE
OUT-1952 | Company avatar missing from selected assignee

### DIFF
--- a/src/app/detail/ui/NewTaskCard.tsx
+++ b/src/app/detail/ui/NewTaskCard.tsx
@@ -21,7 +21,7 @@ import { WorkflowStateResponse } from '@/types/dto/workflowStates.dto'
 import { IAssigneeCombined, ITemplate, UserIds } from '@/types/interfaces'
 import { getAssigneeName, UserIdsType } from '@/utils/assignee'
 import { deleteEditorAttachmentsHandler, uploadImageHandler } from '@/utils/inlineImage'
-import { getSelectedUserIds } from '@/utils/selector'
+import { getSelectedUserIds, updateCompanyIdOfSelectedAssignee } from '@/utils/selector'
 import { trimAllTags } from '@/utils/trimTags'
 import { Box, Stack, Typography } from '@mui/material'
 import dayjs from 'dayjs'
@@ -336,7 +336,10 @@ export const NewTaskCard = ({
             name="Set assignee"
             onChange={(inputValue) => {
               const newUserIds = getSelectedUserIds(inputValue)
-              const selectedAssignee = assignee.find((assignee) => assignee.id === inputValue[0]?.id)
+              const selectedAssignee = updateCompanyIdOfSelectedAssignee(
+                assignee.find((assignee) => assignee.id === inputValue[0]?.id),
+                newUserIds.companyId,
+              )
               setAssigneeValue(selectedAssignee || null)
               handleFieldChange('userIds', newUserIds)
             }}

--- a/src/app/detail/ui/Sidebar.tsx
+++ b/src/app/detail/ui/Sidebar.tsx
@@ -21,7 +21,7 @@ import { WorkflowStateResponse } from '@/types/dto/workflowStates.dto'
 import { IAssigneeCombined, InputValue, Sizes } from '@/types/interfaces'
 import { getAssigneeId, getAssigneeName, getUserIds, UserIdsType } from '@/utils/assignee'
 import { createDateFromFormattedDateString, formatDate } from '@/utils/dateHelper'
-import { getSelectedUserIds } from '@/utils/selector'
+import { getSelectedUserIds, updateCompanyIdOfSelectedAssignee } from '@/utils/selector'
 import { NoAssignee } from '@/utils/noAssignee'
 import { shouldConfirmBeforeReassignment } from '@/utils/shouldConfirmBeforeReassign'
 import { Box, Skeleton, Stack, styled, Typography } from '@mui/material'
@@ -75,8 +75,11 @@ export const Sidebar = ({
       updateStatusValue(currentWorkflowState)
       //UPDATE THE VALUE OF ASSIGNEE IN COPILOT SELECTOR after it supports value prop. (REALTIME)
       setDueDate(currentTask?.dueDate)
-      const currentAssignee = assignee.find((assignee) => assignee.id == activeTask?.assigneeId)
-      setAssigneeValue(currentAssignee)
+      const currentAssignee = updateCompanyIdOfSelectedAssignee(
+        assignee.find((assignee) => assignee.id == activeTask?.assigneeId),
+        activeTask.companyId ?? null,
+      )
+      setAssigneeValue(currentAssignee || undefined)
     }
   }, [activeTask, workflowStates, assignee])
 
@@ -85,7 +88,9 @@ export const Sidebar = ({
 
   const handleConfirmAssigneeChange = (userIds: UserIdsType) => {
     updateAssignee(userIds)
-    setAssigneeValue(getAssigneeValue(userIds) as IAssigneeCombined)
+    setAssigneeValue(
+      updateCompanyIdOfSelectedAssignee(getAssigneeValue(userIds) as IAssigneeCombined, userIds.companyId) ?? undefined,
+    )
     store.dispatch(toggleShowConfirmAssignModal())
   }
 
@@ -115,7 +120,10 @@ export const Sidebar = ({
       setSelectedAssignee(newUserIds)
       store.dispatch(toggleShowConfirmAssignModal())
     } else {
-      setAssigneeValue(getAssigneeValue(newUserIds) as IAssigneeCombined)
+      setAssigneeValue(
+        updateCompanyIdOfSelectedAssignee(getAssigneeValue(newUserIds) as IAssigneeCombined, newUserIds.companyId) ??
+          undefined,
+      )
       updateAssignee(newUserIds)
     }
   }

--- a/src/app/detail/ui/TaskCardList.tsx
+++ b/src/app/detail/ui/TaskCardList.tsx
@@ -29,7 +29,7 @@ import { createDateFromFormattedDateString, formatDate } from '@/utils/dateHelpe
 import { getCardHref } from '@/utils/getCardHref'
 import { isTaskCompleted } from '@/utils/isTaskCompleted'
 import { NoAssignee } from '@/utils/noAssignee'
-import { getSelectedUserIds } from '@/utils/selector'
+import { getSelectedUserIds, updateCompanyIdOfSelectedAssignee } from '@/utils/selector'
 import { shouldConfirmBeforeReassignment } from '@/utils/shouldConfirmBeforeReassign'
 import { Box, Skeleton, Stack, Typography } from '@mui/material'
 import { useCallback, useEffect, useState } from 'react'
@@ -54,8 +54,7 @@ export const TaskCardList = ({ task, variant, workflowState, mode, handleUpdate 
   useEffect(() => {
     if (assignee.length > 0) {
       const currentAssignee = assignee.find((el) => el.id === task.assigneeId)
-      const finalAssignee = currentAssignee ?? NoAssignee
-      // @ts-expect-error  "type" property has mismatching types in between NoAssignee and IAssigneeCombined
+      const finalAssignee = updateCompanyIdOfSelectedAssignee(currentAssignee, task.companyId ?? null) ?? NoAssignee
       store.dispatch(setAssigneeCache({ key: task.id, value: finalAssignee }))
       setAssigneeValue(finalAssignee)
     }
@@ -104,7 +103,12 @@ export const TaskCardList = ({ task, variant, workflowState, mode, handleUpdate 
       } else {
         token && updateAssignee(token, task.id, internalUserId, clientId, companyId)
       }
-      setAssigneeValue(assignee.find((assignee) => assignee.id === nextAssignee?.id) ?? NoAssignee)
+      setAssigneeValue(
+        updateCompanyIdOfSelectedAssignee(
+          assignee.find((assignee) => assignee.id === nextAssignee?.id),
+          companyId,
+        ) ?? NoAssignee,
+      )
     }
   }
 
@@ -119,6 +123,8 @@ export const TaskCardList = ({ task, variant, workflowState, mode, handleUpdate 
 
   const [assigneeValue, setAssigneeValue] = useState<IAssigneeCombined | Omit<IAssigneeCombined, 'type'> | undefined>(() => {
     return assigneeCache[task.id]
+      ? (updateCompanyIdOfSelectedAssignee(assigneeCache[task.id], task.companyId ?? null) ?? undefined)
+      : undefined
   }) //Omitting type for NoAssignee
 
   return (

--- a/src/app/ui/NewTaskForm.tsx
+++ b/src/app/ui/NewTaskForm.tsx
@@ -29,7 +29,7 @@ import { CreateTaskErrors, FilterOptions, IAssigneeCombined, ITemplate, UserIds 
 import { checkEmptyAssignee, emptyAssignee, getAssigneeName } from '@/utils/assignee'
 import { getAssigneeTypeCorrected } from '@/utils/getAssigneeTypeCorrected'
 import { deleteEditorAttachmentsHandler, uploadImageHandler } from '@/utils/inlineImage'
-import { getSelectedUserIds } from '@/utils/selector'
+import { getSelectedUserIds, updateCompanyIdOfSelectedAssignee } from '@/utils/selector'
 import { trimAllTags } from '@/utils/trimTags'
 import { Box, Stack, Typography, styled } from '@mui/material'
 import { Dispatch, SetStateAction, useCallback, useEffect, useState } from 'react'
@@ -65,12 +65,15 @@ export const NewTaskForm = ({ handleCreate, handleClose }: NewTaskFormProps) => 
   const [isEditorReadonly, setIsEditorReadonly] = useState(false)
 
   const [assigneeValue, setAssigneeValue] = useState<IAssigneeCombined | null>(
-    assignee.find(
-      (item) =>
-        item.id == filterOptions[FilterOptions.ASSIGNEE][UserIds.INTERNAL_USER_ID] ||
-        item.id == filterOptions[FilterOptions.ASSIGNEE][UserIds.CLIENT_ID] ||
-        item.id == filterOptions[FilterOptions.ASSIGNEE][UserIds.COMPANY_ID] ||
-        item.id == filterOptions[FilterOptions.TYPE],
+    updateCompanyIdOfSelectedAssignee(
+      assignee.find(
+        (item) =>
+          item.id == filterOptions[FilterOptions.ASSIGNEE][UserIds.INTERNAL_USER_ID] ||
+          item.id == filterOptions[FilterOptions.ASSIGNEE][UserIds.CLIENT_ID] ||
+          item.id == filterOptions[FilterOptions.ASSIGNEE][UserIds.COMPANY_ID] ||
+          item.id == filterOptions[FilterOptions.TYPE],
+      ),
+      filterOptions[FilterOptions.ASSIGNEE][UserIds.COMPANY_ID],
     ) ?? null,
   )
   useEffect(() => {
@@ -159,7 +162,7 @@ export const NewTaskForm = ({ handleCreate, handleClose }: NewTaskFormProps) => 
               onChange={(inputValue) => {
                 const newUserIds = getSelectedUserIds(inputValue)
                 const selectedAssignee = assignee.find((assignee) => assignee.id === inputValue[0]?.id)
-                setAssigneeValue(selectedAssignee || null)
+                setAssigneeValue(updateCompanyIdOfSelectedAssignee(selectedAssignee, newUserIds.companyId) || null)
                 store.dispatch(setCreateTaskFields({ targetField: 'userIds', value: newUserIds }))
               }}
               buttonContent={

--- a/src/components/buttons/FilterByAssigneeBtn.tsx
+++ b/src/components/buttons/FilterByAssigneeBtn.tsx
@@ -5,7 +5,7 @@ import { Avatar, IconButton, Stack, Typography } from '@mui/material'
 import { CopilotAvatar } from '../atoms/CopilotAvatar'
 import { getAssigneeName } from '@/utils/assignee'
 
-export const FilterByAssigneeBtn = ({ assigneeValue }: { assigneeValue: IAssigneeCombined }) => {
+export const FilterByAssigneeBtn = ({ assigneeValue }: { assigneeValue: IAssigneeCombined | null }) => {
   return (
     <Stack direction="row" alignItems="center" columnGap={1}>
       <Typography

--- a/src/components/cards/TaskCard.tsx
+++ b/src/components/cards/TaskCard.tsx
@@ -48,9 +48,7 @@ export const TaskCard = ({ task, href }: TaskCardProps) => {
     if (assignee.length > 0) {
       const currentAssignee = assignee.find((el) => el.id === task.assigneeId)
       const finalAssignee = currentAssignee ?? NoAssignee
-      //@ts-expect-error  "type" property has mismatching types in between NoAssignee and IAssigneeCombined
       store.dispatch(setAssigneeCache({ key: task.id, value: finalAssignee }))
-      //@ts-expect-error  "type" property has mismatching types in between NoAssignee and IAssigneeCombined
       setCurrentAssignee(finalAssignee)
     }
   }, [assignee, task.id, task.assigneeId])

--- a/src/utils/noAssignee.ts
+++ b/src/utils/noAssignee.ts
@@ -1,12 +1,12 @@
 import { IAssigneeCombined, IExtraOption } from '@/types/interfaces'
 
-export const NoAssignee = {
+export const NoAssignee: IAssigneeCombined = {
   id: '01',
   name: 'No assignee',
   avatarImageUrl: '',
   iconImageUrl: '',
   givenName: 'No assignee',
-  type: '',
+  type: 'internalUsers', //mitigate type error by specifying a type. doesnt do any effect.
 }
 
 export const NoAssigneeExtraOptions: IExtraOption = {

--- a/src/utils/selector.ts
+++ b/src/utils/selector.ts
@@ -2,7 +2,7 @@
  * All utils related to the Copilot selector component
  */
 
-import { InputValue, ISelectorOption, UserIds } from '@/types/interfaces'
+import { IAssigneeCombined, InputValue, ISelectorAssignee, ISelectorOption, UserIds } from '@/types/interfaces'
 import { userIdFieldMap } from '@/types/objectMaps'
 import { UserIdsType } from './assignee'
 
@@ -37,3 +37,8 @@ export const selectorOptionsToInputValue = (options: ISelectorOption[]): InputVa
     object: option.type,
     companyId: option.companyId,
   }))
+
+export const updateCompanyIdOfSelectedAssignee = (value: IAssigneeCombined | undefined, companyId: string | null) => {
+  if (!value) return null
+  return { ...value, companyId: companyId ?? undefined }
+} //util to update companyId for the selected assignee for copilot selector


### PR DESCRIPTION
## Changes

- [x] created updateCompanyIdOfSelectedAssginee util to overwrite companyId value in IAssigneeCombined assignee value with the selected companyId for clients.
- [x] applied the util to all assigneeValues on new task form, filter by assignee, side bar, task card list and new task card components.

## Testing Criteria

- [LOOM](https://www.loom.com/share/37e5194965294274870417151fda25ad)

