### PR TITLE
OUT-1995: Change activity log for when task is unassigned

### DIFF
--- a/src/app/detail/ui/ActivityLog.tsx
+++ b/src/app/detail/ui/ActivityLog.tsx
@@ -51,11 +51,6 @@ export const ActivityLog = ({ log }: Prop) => {
           const taskAssignees = TaskAssignedResponseSchema.parse(log.details)
           return getAssignedToName(taskAssignees)
 
-        case ActivityType.TASK_UNASSIGNED:
-          const { oldValue: oldId } = TaskUnassignedSchema.parse(log.details)
-          const oldAssignee = assignee.find((el) => el.id === oldId)
-          return [getAssigneeName(oldAssignee, 'Deleted User')]
-
         case ActivityType.TITLE_UPDATED:
           const titles = TitleUpdatedSchema.parse(log.details)
           return [titles.oldValue, titles.newValue]
@@ -97,10 +92,9 @@ export const ActivityLog = ({ log }: Prop) => {
         <DotSeparator />
       </>
     ),
-    [ActivityType.TASK_UNASSIGNED]: (from: string) => (
+    [ActivityType.TASK_UNASSIGNED]: () => (
       <>
-        <StyledTypography>unassigned the task {from && `from `}</StyledTypography>
-        {from && <BoldTypography>{from}</BoldTypography>}
+        <StyledTypography>removed assignee</StyledTypography>
         <DotSeparator />
       </>
     ),


### PR DESCRIPTION
## Changes

- [X] When a task is unassigned, the activity log reads "{unassigner} removed assignee."

## Testing Criteria

<img width="656" height="59" alt="image" src="https://github.com/user-attachments/assets/6b0d30ba-88f4-4877-9fa1-d93a39787238" />

