### PR TITLE
OUT-2020 | Tasks App errors out (autosave feature on viewSettings) 

### DIFF
--- a/src/hoc/ClientSideStateUpdate.tsx
+++ b/src/hoc/ClientSideStateUpdate.tsx
@@ -82,8 +82,9 @@ export const ClientSideStateUpdate = ({
     }
 
     if (viewSettings) {
-      store.dispatch(setViewSettings(viewSettings))
-      const view = viewSettingsTemp ? viewSettingsTemp.filterOptions : viewSettings.filterOptions
+      const viewSettingsCopy = structuredClone(viewSettings) //deep cloning for immutability and prevent the reducer mutating the original object.
+      store.dispatch(setViewSettings(viewSettingsCopy))
+      const view = viewSettingsTemp ? viewSettingsTemp.filterOptions : viewSettingsCopy.filterOptions
       store.dispatch(setFilteredAssgineeList({ filteredType: filterOptionsMap[view?.type] || filterOptionsMap.default }))
     }
 


### PR DESCRIPTION
## Changes

- [x] prevent viewsettings to mutate from reducers. Provided  a deep copy of viewsettings instead of actual reference to the reducer because viewsettings has nested object for filterOptions. 


## Testing Criteria

- [LOOM]()
