### PR TITLE
OUT-2022 | Investigate and apply Activity Log Optimization

### DIFF
--- a/src/app/api/activity-logs/schemas/CommentAddedSchema.ts
+++ b/src/app/api/activity-logs/schemas/CommentAddedSchema.ts
@@ -22,7 +22,6 @@ export const commentAddedResponseSchema = z.object({
       parentId: z.string().uuid(),
       initiatorId: z.string().uuid(),
       workspaceId: z.string(),
-      initiator: z.union([InternalUsersSchema, ClientResponseSchema]),
       createdAt: z.string().datetime(),
       updatedAt: z.string().datetime(),
     }),

--- a/src/app/api/activity-logs/schemas/LogResponseSchema.ts
+++ b/src/app/api/activity-logs/schemas/LogResponseSchema.ts
@@ -11,7 +11,6 @@ export const LogResponseSchema = z.object({
   userId: z.string().uuid(),
   userRole: z.nativeEnum(AssigneeType),
   workspaceId: z.string(),
-  initiator: z.union([InternalUsersSchema, ClientResponseSchema]).nullable(),
   createdAt: z.string().datetime(),
 })
 

--- a/src/app/detail/ui/ActivityLog.tsx
+++ b/src/app/detail/ui/ActivityLog.tsx
@@ -137,7 +137,7 @@ export const ActivityLog = ({ log }: Prop) => {
     [ActivityType.COMMENT_ADDED]: () => null,
   }
 
-  const activityUser = log.initiator as unknown as IAssigneeCombined
+  const activityUser = assignee.find((assignee) => assignee.id == log.userId)
 
   return (
     <Stack direction="row" columnGap={4} position="relative">

--- a/src/app/detail/ui/ActivityWrapper.tsx
+++ b/src/app/detail/ui/ActivityWrapper.tsx
@@ -47,7 +47,7 @@ export const ActivityWrapper = ({
   const cacheKey = `/api/tasks/${task_id}/activity-logs?token=${token}`
   const { data: activities, isLoading } = useSWR(`/api/tasks/${task_id}/activity-logs?token=${token}`, fetcher, {
     refreshInterval: 0,
-    dedupingInterval: 10000, // avoid duplicate requests within 10 seconds
+    dedupingInterval: 5000, // avoid duplicate requests within 5 seconds
   })
   const { mutate } = useSWRConfig()
   useScrollToElement('commentId')

--- a/src/app/detail/ui/ActivityWrapper.tsx
+++ b/src/app/detail/ui/ActivityWrapper.tsx
@@ -38,7 +38,7 @@ export const ActivityWrapper = ({
   task_id: string
   tokenPayload: Token
 }) => {
-  const { activeTask } = useSelector(selectTaskBoard)
+  const { activeTask, assignee } = useSelector(selectTaskBoard)
   const { expandedComments } = useSelector(selectTaskDetails)
   const task = activeTask
   const [lastUpdated, setLastUpdated] = useState(task?.lastActivityLogUpdated)
@@ -47,8 +47,8 @@ export const ActivityWrapper = ({
   const cacheKey = `/api/tasks/${task_id}/activity-logs?token=${token}`
   const { data: activities, isLoading } = useSWR(`/api/tasks/${task_id}/activity-logs?token=${token}`, fetcher, {
     refreshInterval: 0,
+    dedupingInterval: 10000, // avoid duplicate requests within 10 seconds
   })
-  const { assignee } = useSelector(selectTaskBoard)
   const { mutate } = useSWRConfig()
   useScrollToElement('commentId')
   useEffect(() => {

--- a/src/app/detail/ui/Comments.tsx
+++ b/src/app/detail/ui/Comments.tsx
@@ -7,6 +7,8 @@ import { Stack } from '@mui/material'
 import { VerticalLine } from './styledComponent'
 import { OptimisticUpdate } from '@/utils/optimisticCommentUtils'
 import { TrashIcon2 } from '@/icons'
+import { useSelector } from 'react-redux'
+import { selectTaskBoard } from '@/redux/features/taskBoardSlice'
 
 interface Prop {
   comment: LogResponse
@@ -18,6 +20,8 @@ interface Prop {
 }
 
 export const Comments = ({ comment, createComment, deleteComment, task_id, stableId, optimisticUpdates }: Prop) => {
+  const { assignee } = useSelector(selectTaskBoard)
+  const commentInitiator = assignee.find((assignee) => assignee.id == comment.userId)
   return (
     <Stack id={stableId} direction="row" columnGap={2} position="relative">
       <VerticalLine />
@@ -26,7 +30,7 @@ export const Comments = ({ comment, createComment, deleteComment, task_id, stabl
           width="22px"
           height="22px"
           fontSize="12px"
-          currentAssignee={comment.initiator as unknown as IAssigneeCombined}
+          currentAssignee={commentInitiator}
           sx={{
             border: (theme) => `1.1px solid ${theme.color.gray[200]}`,
             marginTop: '8px',
@@ -41,6 +45,7 @@ export const Comments = ({ comment, createComment, deleteComment, task_id, stabl
           deleteComment={deleteComment}
           task_id={task_id}
           optimisticUpdates={optimisticUpdates}
+          commentInitiator={commentInitiator}
         />
       </Stack>
     </Stack>

--- a/src/app/detail/ui/Subtasks.tsx
+++ b/src/app/detail/ui/Subtasks.tsx
@@ -51,7 +51,7 @@ export const Subtasks = ({
   const { data: subTasks } = useSWR(cacheKey, fetcher, {
     refreshInterval: 0,
     revalidateOnMount: false,
-    dedupingInterval: 10000, // avoid duplicate requests within 10 seconds
+    dedupingInterval: 5000, // avoid duplicate requests within 5 seconds
   })
 
   const { mutate } = useSWRConfig()

--- a/src/app/detail/ui/Subtasks.tsx
+++ b/src/app/detail/ui/Subtasks.tsx
@@ -48,7 +48,11 @@ export const Subtasks = ({
 
   const cacheKey = `/api/tasks/?token=${token}&showArchived=1&showUnarchived=1&parentId=${task_id}`
 
-  const { data: subTasks } = useSWR(cacheKey, fetcher, { refreshInterval: 0 })
+  const { data: subTasks } = useSWR(cacheKey, fetcher, {
+    refreshInterval: 0,
+    revalidateOnMount: false,
+    dedupingInterval: 10000, // avoid duplicate requests within 10 seconds
+  })
 
   const { mutate } = useSWRConfig()
 

--- a/src/components/atoms/OverlappingAvatars.tsx
+++ b/src/components/atoms/OverlappingAvatars.tsx
@@ -5,7 +5,7 @@ import { getAssigneeName } from '@/utils/assignee'
 import { Avatar, SxProps, Theme } from '@mui/material'
 
 type OverlappingAvatarsProps = {
-  assignees: (IAssigneeCombined | null)[]
+  assignees: (IAssigneeCombined | undefined)[]
   width?: string
   height?: string
   fontSize?: string
@@ -40,7 +40,7 @@ export const OverlappingAvatars: React.FC<OverlappingAvatarsProps> = ({
     },
   }
 
-  const renderAvatar = (assignee: IAssigneeCombined | null, index: number) => {
+  const renderAvatar = (assignee: IAssigneeCombined | undefined, index: number) => {
     const avatarVariant: 'circular' | 'rounded' | 'square' = assignee?.type === 'companies' ? 'rounded' : 'circular'
 
     if (!assignee || assignee?.name || assignee?.givenName === 'No assignee') {

--- a/src/components/cards/CollapsibleReplyCard.tsx
+++ b/src/components/cards/CollapsibleReplyCard.tsx
@@ -7,7 +7,7 @@ import { Box, Stack, Typography } from '@mui/material'
 interface CollapsibleReplyCardProps {
   replyCount: number
   fetchCommentsWithFullReplies: () => void
-  lastAssignees: IAssigneeCombined[]
+  lastAssignees: (IAssigneeCombined | undefined)[]
 }
 
 export const CollapsibleReplyCard = ({

--- a/src/components/cards/CommentCard.tsx
+++ b/src/components/cards/CommentCard.tsx
@@ -93,6 +93,10 @@ export const CommentCard = ({
   const [editedContent, setEditedContent] = useState(content)
   const [isListOrMenuActive, setIsListOrMenuActive] = useState(false)
 
+  const firstInitiators = (comment?.details?.firstInitiators as string[])?.map((initiator) => {
+    return assignee.find((assignee) => assignee.id == initiator)
+  })
+
   useEffect(() => {
     const updateTimeAgo = () => setTimeAgo(getTimeDifference(comment.createdAt))
     const intervalId = setInterval(updateTimeAgo, 60 * 1000)
@@ -339,7 +343,7 @@ export const CommentCard = ({
           showReply) && <CustomDivider />}
         {replyCount > 3 && !expandedComments.includes(z.string().parse(comment.details.id)) && (
           <CollapsibleReplyCard
-            lastAssignees={comment.details.firstInitiators as IAssigneeCombined[]}
+            lastAssignees={firstInitiators}
             fetchCommentsWithFullReplies={fetchCommentsWithFullReplies}
             replyCount={replyCount}
           />

--- a/src/components/cards/CommentCard.tsx
+++ b/src/components/cards/CommentCard.tsx
@@ -49,12 +49,14 @@ export const CommentCard = ({
   deleteComment,
   task_id,
   optimisticUpdates,
+  commentInitiator,
 }: {
   comment: LogResponse
   createComment: (postCommentPayload: CreateComment) => void
   deleteComment: (id: string, replyId?: string, softDelete?: boolean) => void
   task_id: string
   optimisticUpdates: OptimisticUpdate[]
+  commentInitiator: IAssigneeCombined | undefined
 }) => {
   const [showReply, setShowReply] = useState(false)
   const [isHovered, setIsHovered] = useState(false)
@@ -66,8 +68,8 @@ export const CommentCard = ({
 
   const [showConfirmDeleteModal, setShowConfirmDeleteModal] = useState(false)
   const { tokenPayload } = useSelector(selectAuthDetails)
-  const canEdit = tokenPayload?.internalUserId == comment?.initiator?.id || tokenPayload?.clientId == comment?.initiator?.id
-  const canDelete = tokenPayload?.internalUserId == comment?.initiator?.id
+  const canEdit = tokenPayload?.internalUserId == comment?.userId || tokenPayload?.clientId == comment?.userId
+  const canDelete = tokenPayload?.internalUserId == comment?.userId
   const { assignee, activeTask, token } = useSelector(selectTaskBoard)
   const { expandedComments } = useSelector(selectTaskDetails)
   const [isMenuOpen, setIsMenuOpen] = useState(false)
@@ -148,7 +150,6 @@ export const CommentCard = ({
     }
   }, [editedContent, isListOrMenuActive, isFocused, isMobile])
 
-  const commentUser = comment.initiator as unknown as IAssigneeCombined
   const replyCount = (comment.details as CommentResponse).replyCount
 
   const cacheKey = `/api/comment/?token=${token}&parentId=${comment.details.id}`
@@ -213,7 +214,7 @@ export const CommentCard = ({
             {isReadOnly && (
               <Stack direction="row" justifyContent={'space-between'} alignItems="flex-end">
                 <Stack direction="row" columnGap={1} alignItems="center" sx={{ display: 'flex', flexWrap: 'wrap' }}>
-                  {commentUser ? (
+                  {commentInitiator ? (
                     <BoldTypography
                       sx={{
                         maxWidth: { xs: isXxs ? '100px' : '225px', sm: '300px', sd: '380px', md: '520px' },
@@ -222,7 +223,7 @@ export const CommentCard = ({
                         whiteSpace: 'nowrap',
                       }}
                     >
-                      {getAssigneeName(commentUser, '')}
+                      {getAssigneeName(commentInitiator, '')}
                     </BoldTypography>
                   ) : (
                     <Typography
@@ -346,6 +347,7 @@ export const CommentCard = ({
         <TransitionGroup>
           {Array.isArray((comment as LogResponse).details?.replies) &&
             replies.map((item: ReplyResponse) => {
+              const replyInitiator = assignee.find((assignee) => assignee.id == item.initiatorId)
               return (
                 <Collapse key={checkOptimisticStableId(item, optimisticUpdates)}>
                   <ReplyCard
@@ -355,6 +357,7 @@ export const CommentCard = ({
                     handleImagePreview={handleImagePreview}
                     deleteReply={deleteComment}
                     setDeletedReplies={setDeletedReplies}
+                    replyInitiator={replyInitiator}
                   />
                 </Collapse>
               )

--- a/src/components/cards/ReplyCard.tsx
+++ b/src/components/cards/ReplyCard.tsx
@@ -34,6 +34,7 @@ export const ReplyCard = ({
   handleImagePreview,
   deleteReply,
   setDeletedReplies,
+  replyInitiator,
 }: {
   item: ReplyResponse
   uploadFn: ((file: File) => Promise<string | undefined>) | undefined
@@ -41,6 +42,7 @@ export const ReplyCard = ({
   handleImagePreview: (e: React.MouseEvent<unknown>) => void
   deleteReply: (id: string, replyId: string) => void
   setDeletedReplies: Dispatch<SetStateAction<string[]>>
+  replyInitiator: IAssigneeCombined | undefined
 }) => {
   const [isReadOnly, setIsReadOnly] = useState<boolean>(true)
   const [isMenuOpen, setIsMenuOpen] = useState(false)
@@ -55,7 +57,7 @@ export const ReplyCard = ({
   const [isFocused, setIsFocused] = useState(false)
   const editRef = useRef<HTMLDivElement>(null)
 
-  const canEdit = tokenPayload?.internalUserId == item?.initiator?.id || tokenPayload?.clientId == item?.initiator?.id
+  const canEdit = tokenPayload?.internalUserId == item?.initiatorId || tokenPayload?.clientId == item?.initiatorId
 
   const isMobile = () => {
     return /Mobi|Android|iPhone|iPad|iPod/i.test(navigator.userAgent) || windowWidth < 600
@@ -71,7 +73,7 @@ export const ReplyCard = ({
     setEditedContent(content)
   }
 
-  const canDelete = tokenPayload?.internalUserId == item?.initiator?.id
+  const canDelete = tokenPayload?.internalUserId == item?.initiatorId
 
   const handleEdit = async () => {
     if (isTapwriteContentEmpty(editedContent)) {
@@ -111,8 +113,6 @@ export const ReplyCard = ({
     }
   }, [editedContent, isListOrMenuActive, isFocused, isMobile])
 
-  const replyUser = item.initiator as unknown as IAssigneeCombined
-
   return (
     <>
       <Stack
@@ -130,7 +130,7 @@ export const ReplyCard = ({
           width="20px"
           height="20px"
           fontSize="10px"
-          currentAssignee={replyUser}
+          currentAssignee={replyInitiator}
           sx={{
             border: (theme) => `1.1px solid ${theme.color.gray[200]}`,
             marginTop: '1px',
@@ -158,7 +158,7 @@ export const ReplyCard = ({
                   whiteSpace: 'nowrap',
                 }}
               >
-                {replyUser ? getAssigneeName(replyUser) : 'Deleted User'}
+                {replyInitiator ? getAssigneeName(replyInitiator) : 'Deleted User'}
               </BoldTypography>
               <Stack direction="row" columnGap={1} alignItems={'center'}>
                 <DotSeparator />


### PR DESCRIPTION
## Changes

- [x] removed the functionality of attaching initiator property, full objects of users on activityLogs (incl comments) response.
- [x] applied relevant changes on the client side, removed initiator from response schema. Looked up initiator from the global assignee state using userId from the logs.
- [x] removed copilotAPI for user fetching for internal users. And only clients and companies are fetched for limited access user and clients for filtering activity logs for limited access.
- [x] returnerd only ids from api instead of whole user objects for firstInitiators in a comment.
- [x] added relevent changes to lookup users objects from global assignee state in the client side.
- [x] added duduping interval of 5 seconds for activity log and subtasks api call from swr to prevent double fetching of these apis on component mount. 

## Testing Criteria

- coming soon...
