### PR TITLE
OUT-2036 | OUT-2037 | Enforce strict no-duplication mechanism for notification dispatch

### DIFF
--- a/prisma/migrations/20250716135445_prevent_duplicate_client_notifications/migration.sql
+++ b/prisma/migrations/20250716135445_prevent_duplicate_client_notifications/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[clientId,companyId,notificationId,deletedAt]` on the table `ClientNotifications` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "ClientNotifications_clientId_companyId_notificationId_delet_key" ON "ClientNotifications"("clientId", "companyId", "notificationId", "deletedAt");

--- a/prisma/migrations/20250716135445_prevent_duplicate_client_notifications/migration.sql
+++ b/prisma/migrations/20250716135445_prevent_duplicate_client_notifications/migration.sql
@@ -1,8 +1,0 @@
-/*
-  Warnings:
-
-  - A unique constraint covering the columns `[clientId,companyId,notificationId,deletedAt]` on the table `ClientNotifications` will be added. If there are existing duplicate values, this will fail.
-
-*/
--- CreateIndex
-CREATE UNIQUE INDEX "ClientNotifications_clientId_companyId_notificationId_delet_key" ON "ClientNotifications"("clientId", "companyId", "notificationId", "deletedAt");

--- a/prisma/migrations/20250717103934_prevent_duplicate_migrations/migration.sql
+++ b/prisma/migrations/20250717103934_prevent_duplicate_migrations/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[taskId,clientId,companyId,deletedAt]` on the table `ClientNotifications` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "ClientNotifications_taskId_clientId_companyId_deletedAt_key" ON "ClientNotifications"("taskId", "clientId", "companyId", "deletedAt");

--- a/prisma/schema/clientNotification.prisma
+++ b/prisma/schema/clientNotification.prisma
@@ -18,7 +18,7 @@ model ClientNotification {
   // WARNING: This is going to make it so that we cannot bulk soft-delete multiple duplicate client notifications at once
   // since there is "deletedAt" in the unique constraint.
   // Either way, soft deleting client notifications (not IU ones) is not very useful in the first place
-  @@unique([clientId, companyId, notificationId, deletedAt], name: "UQ_ClientNotifications_clientId_companyId_notificationId_deletedAt")
+  @@unique([taskId, clientId, companyId, deletedAt], name: "UQ_ClientNotifications_taskId_clientId_companyId_deletedAt")
   @@index([notificationId], name: "IX_ClientNotifications_notificationId")
   @@map("ClientNotifications")
 }

--- a/prisma/schema/clientNotification.prisma
+++ b/prisma/schema/clientNotification.prisma
@@ -15,6 +15,10 @@ model ClientNotification {
   deletedAt      DateTime?
 
   @@unique([notificationId], name: "UQ_ClientNotifications_notificationId")
+  // WARNING: This is going to make it so that we cannot bulk soft-delete multiple duplicate client notifications at once
+  // since there is "deletedAt" in the unique constraint.
+  // Either way, soft deleting client notifications (not IU ones) is not very useful in the first place
+  @@unique([clientId, companyId, notificationId, deletedAt], name: "UQ_ClientNotifications_clientId_companyId_notificationId_deletedAt")
   @@index([notificationId], name: "IX_ClientNotifications_notificationId")
   @@map("ClientNotifications")
 }

--- a/src/app/api/notification/notification.service.ts
+++ b/src/app/api/notification/notification.service.ts
@@ -35,7 +35,7 @@ export class NotificationService extends BaseService {
             where: { taskId: task.id, clientId: task.clientId, companyId: task.companyId },
           })
         : null
-      if (existingNotification) {
+      if (task.clientId && existingNotification) {
         console.error(`NotificationService#create | Found existing notification for ${task.clientId}`, existingNotification)
         return
       }

--- a/src/app/api/notification/notification.service.ts
+++ b/src/app/api/notification/notification.service.ts
@@ -264,7 +264,8 @@ export class NotificationService extends BaseService {
       // Due to race conditions, we are forced to allow multiple client notifications for a single notification as well
       const relatedNotifications = await this.db.clientNotification.findMany({
         where: {
-          clientId: Uuid.parse(task.clientId),
+          // Accomodate company task lookups where clientId is null
+          clientId: Uuid.nullable().parse(task.clientId) || undefined,
           companyId: Uuid.parse(task.companyId),
           taskId: task.id,
         },

--- a/src/app/api/notification/notification.service.ts
+++ b/src/app/api/notification/notification.service.ts
@@ -63,6 +63,7 @@ export class NotificationService extends BaseService {
       console.info('NotificationService#create | Creating single notification:', notificationDetails)
 
       const notification = await copilot.createNotification(notificationDetails)
+      console.info('NotificationService#create | Created single notification:', notification)
 
       // 3. Save notification to ClientNotification or InternalUserNotification table
       if (task.assigneeType === AssigneeType.client) {
@@ -158,6 +159,7 @@ export class NotificationService extends BaseService {
           )
           console.info('NotificationService#bulkCreate | Creating single notification:', notificationDetails)
           const notification = await copilot.createNotification(notificationDetails)
+          console.info('NotificationService#bulkCreate | Created single notification:', notification)
           if (!notification) {
             console.error(`NotificationService#bulkCreate | Failed to send notifications to ${recipientId}:`)
             continue

--- a/src/app/api/notification/notification.service.ts
+++ b/src/app/api/notification/notification.service.ts
@@ -157,6 +157,13 @@ export class NotificationService extends BaseService {
     `
   }
 
+  deleteClientNotificationForTask = async (id: string) => {
+    await this.db.$executeRaw`
+      DELETE FROM "ClientNotifications"
+      WHERE "taskId" = ${id}::uuid
+    `
+  }
+
   /**
    * Marks a client notification in Copilot Notifications service as read
    * @param id Notification ID for object as exists in Copilot

--- a/src/app/api/notification/validate-count/validateCount.service.ts
+++ b/src/app/api/notification/validate-count/validateCount.service.ts
@@ -1,5 +1,4 @@
 import { DuplicateNotificationsQuerySchema } from '@/types/client-notifications'
-import { NotificationCreatedResponse } from '@/types/common'
 import { getArrayDifference } from '@/utils/array'
 import { bottleneck } from '@/utils/bottleneck'
 import { CopilotAPI } from '@/utils/CopilotAPI'

--- a/src/app/api/tasks/subtasks.service.ts
+++ b/src/app/api/tasks/subtasks.service.ts
@@ -4,7 +4,6 @@ import { buildLtreeNodeString } from '@/utils/ltree'
 import APIError from '@api/core/exceptions/api'
 import { BaseService } from '@api/core/services/base.service'
 import { UserRole } from '@api/core/types/user'
-import { AssigneeType } from '@prisma/client'
 import httpStatus from 'http-status'
 import { z } from 'zod'
 

--- a/src/app/api/tasks/task-notifications.service.ts
+++ b/src/app/api/tasks/task-notifications.service.ts
@@ -1,4 +1,4 @@
-import { NotificationCreatedResponseSchema, Uuid } from '@/types/common'
+import { Uuid } from '@/types/common'
 import { TaskWithWorkflowState } from '@/types/db'
 import { CopilotAPI } from '@/utils/CopilotAPI'
 import User from '@api/core/models/User.model'

--- a/src/app/api/tasks/task-notifications.service.ts
+++ b/src/app/api/tasks/task-notifications.service.ts
@@ -313,7 +313,6 @@ export class TaskNotificationsService extends BaseService {
     // behalf of client later
     if (!notification) {
       console.error('Notification failed to trigger for task:', task)
-    } else {
     }
   }
 

--- a/src/cmd/queries/remove-duplicate-notifications.sql
+++ b/src/cmd/queries/remove-duplicate-notifications.sql
@@ -1,0 +1,11 @@
+DELETE FROM "ClientNotifications" AS cn
+    WHERE cn."deletedAt" IS NULL
+    AND EXISTS (
+        SELECT 1
+        FROM "ClientNotifications" AS sub
+        WHERE sub."taskId" = cn."taskId"
+            AND sub."clientId" = cn."clientId"
+            AND sub."deletedAt" IS NULL
+        GROUP BY sub."taskId", sub."clientId"
+        HAVING COUNT(sub.id) > 1
+    );


### PR DESCRIPTION
## Changes

- [x] Implement no-duplication for Validate Task Count job
- [x] Implement no-duplication for Notification create 
- [x] Implement no-duplication for Notification bulk create

## Testing Criteria

Previously these use cases were causing multiple duplicate notifications to be dispatched for a single task operation

https://github.com/user-attachments/assets/9df154dd-f99f-40fb-9ac1-58453b155d39

https://github.com/user-attachments/assets/07b04a07-4368-4afc-a84f-de15af9283ef


