### PR TITLE
OUT-2055 | Realtime subtask count and subtasks list issues.

### DIFF
--- a/prisma/migrations/20250723060707_add_last_subtask_updated_timestamp/migration.sql
+++ b/prisma/migrations/20250723060707_add_last_subtask_updated_timestamp/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Tasks" ADD COLUMN     "lastSubtaskUpdated" TIMESTAMP(3);

--- a/prisma/schema/task.prisma
+++ b/prisma/schema/task.prisma
@@ -32,6 +32,7 @@ model Task {
   completedAt              DateTime?
   dueDate                  String?                    @db.VarChar(10)
   lastActivityLogUpdated   DateTime?
+  lastSubtaskUpdated       DateTime?
   createdAt                DateTime                   @default(now())
   deletedAt                DateTime?
   ClientNotification       ClientNotification[]

--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -775,6 +775,7 @@ export class TasksService extends BaseService {
       const activityLogger = new TasksActivityLogger(this.user, updatedTask)
       await Promise.all([
         activityLogger.logTaskUpdated(prevTask),
+        this.setNewLastSubtaskUpdated(updatedTask.parentId),
         dispatchUpdatedWebhookEvent(this.user, prevTask, updatedTask, false),
       ])
     }

--- a/src/app/detail/ui/ActivityWrapper.tsx
+++ b/src/app/detail/ui/ActivityWrapper.tsx
@@ -116,7 +116,7 @@ export const ActivityWrapper = ({
         {
           optimisticData: { data: optimisticData },
           rollbackOnError: true,
-          revalidate: false, // Make sure to revalidate after mutation
+          revalidate: false,
         },
       )
     } catch (error) {

--- a/src/cmd/load-testing/load-testing.service.ts
+++ b/src/cmd/load-testing/load-testing.service.ts
@@ -107,6 +107,7 @@ class LoadTester {
         | 'internalUserId'
         | 'clientId'
         | 'companyId'
+        | 'lastSubtaskUpdated'
       >[] = []
       const currentUser = await authenticateWithToken(this.token, this.apiKey)
       const labelsService = new LabelMappingService(currentUser, this.apiKey)

--- a/src/hoc/ClientSideStateUpdate.tsx
+++ b/src/hoc/ClientSideStateUpdate.tsx
@@ -61,7 +61,7 @@ export const ClientSideStateUpdate = ({
   accesibleTaskIds?: string[]
   accessibleTasks?: TaskResponse[]
 }) => {
-  const { tasks: tasksInStore, viewSettingsTemp } = useSelector(selectTaskBoard)
+  const { tasks: tasksInStore, viewSettingsTemp, accessibleTasks: accessibleTaskInStore } = useSelector(selectTaskBoard)
   useEffect(() => {
     if (workflowStates) {
       store.dispatch(setWorkflowStates(workflowStates))
@@ -121,7 +121,8 @@ export const ClientSideStateUpdate = ({
     }
 
     if (accessibleTasks) {
-      store.dispatch(setAccessibleTasks(accessibleTasks))
+      const accessibleTaskData = accessibleTaskInStore.length ? accessibleTaskInStore : accessibleTasks
+      store.dispatch(setAccessibleTasks(accessibleTaskData))
     }
 
     return () => {

--- a/src/lib/realtime.ts
+++ b/src/lib/realtime.ts
@@ -36,6 +36,7 @@ export class RealtimeHandler {
       createdAt: newTask.createdAt && new Date(newTask.createdAt + 'Z').toISOString(),
       updatedAt: newTask.updatedAt && new Date(newTask.updatedAt + 'Z').toISOString(),
       lastActivityLogUpdated: newTask.lastActivityLogUpdated && new Date(newTask.lastActivityLogUpdated + 'Z').toISOString(),
+      lastSubtaskUpdated: newTask.lastSubtaskUpdated && new Date(newTask.lastSubtaskUpdated + 'Z').toISOString(),
     }
   }
 

--- a/src/types/dto/tasks.dto.ts
+++ b/src/types/dto/tasks.dto.ts
@@ -78,6 +78,7 @@ export const TaskResponseSchema = z.object({
   updatedAt: z.string().datetime().nullish(),
   assignee: z.union([ClientResponseSchema, InternalUsersSchema, CompanyResponseSchema]).optional(),
   lastActivityLogUpdated: z.string().datetime().nullish(),
+  lastSubtaskUpdated: z.string().datetime().nullish(),
   isArchived: z.boolean().optional(),
   lastArchivedDate: z.string().datetime(),
   parentId: z.string().nullish(),


### PR DESCRIPTION
## Changes

- [x] subtasks count cache issue : accessibleTask was use to calculate subtask count component for task card and task list. only implemented accessibleTask to be update from server on the first laod, rest of the time, its updated from realtime.
- [x] subtasks list update issue : subtasks list were only refetched when no of subtasks in parent task was change, but while updating it doesnt change :
	- created a migration adding lastSubtaskUpdated timestamp in task schema.
	- formatted the timestamp for lastSubtaskUpdated in realtime response.
	- refetched subtasks according to the change in lastSubtaskUpdated.
	- updated lastSubtaskUpdated while creating, updating and deleted a sub task.
	- made sure we dont compromise on previously applied optimization by adding refetching check on mount and optimistic updates.

## Testing Criteria

- [LOOM](https://www.loom.com/share/3ec47e64132041d8a8c32fbf6a79b67a)
