### PR TITLE
OUT-2061 | Notifications for other companies are removed when tasks app opens in another company

### DIFF
--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -218,6 +218,7 @@ export const NotificationCreatedResponseSchema = z.object({
   createdAt: z.string().datetime(),
   event: z.string().optional(),
   object: z.string().optional(),
+  companyId: z.string().optional(),
   recipientInternalUserId: z.string().optional(),
   recipientClientId: z.string().optional(),
   recipientCompanyId: z.string().optional(),


### PR DESCRIPTION
## Changes

- [x] For some reason, `companyId` is still being used instead of `recipientCompanyId` for notification response, even for multi-company flagged resources. Added a filter block that is compatible with both `companyId` and `recipientCompanyId` to filter notifications for a particular company of a client.

## Testing Criteria:
- [x] Screencast


https://github.com/user-attachments/assets/e7a4f982-1867-493c-9dc7-3b3d3ab4e95e

