### PR TITLE
OUT-2076 | Optimizations to the User's API

### DIFF
--- a/src/app/api/users/users.service.ts
+++ b/src/app/api/users/users.service.ts
@@ -1,97 +1,82 @@
+import { MAX_FETCH_ASSIGNEE_COUNT } from '@/constants/users'
+import { ClientResponse, CompanyResponse, FilterableUser, InternalUsers } from '@/types/common'
+import { FilterOptionsKeywords } from '@/types/interfaces'
 import { CopilotAPI } from '@/utils/CopilotAPI'
-import { BaseService } from '@api/core/services/base.service'
+import { orderByRecentlyCreatedAt } from '@/utils/ordering'
+import { filterUsersByKeyword } from '@/utils/users'
+import APIError from '@api/core/exceptions/api'
 import User from '@api/core/models/User.model'
+import { BaseService } from '@api/core/services/base.service'
 import { PoliciesService } from '@api/core/services/policies.service'
 import { Resource } from '@api/core/types/api'
 import { UserAction, UserRole } from '@api/core/types/user'
-import APIError from '@api/core/exceptions/api'
 import httpStatus from 'http-status'
-import { CompanyResponse, CopilotListArgs, FilterableUser } from '@/types/common'
-import { filterUsersByKeyword } from '@/utils/users'
-import { z } from 'zod'
-import { FilterOptionsKeywords } from '@/types/interfaces'
-import { orderByRecentlyCreatedAt } from '@/utils/ordering'
-import { MAX_FETCH_ASSIGNEE_COUNT } from '@/constants/users'
 
 class UsersService extends BaseService {
   private copilot: CopilotAPI
-  private DEFAULT_USERS_LIMIT = 10
 
   constructor(user: User) {
     super(user)
     this.copilot = new CopilotAPI(this.user.token)
   }
 
-  async getGroupedUsers(limit: number = this.DEFAULT_USERS_LIMIT, nextToken?: string) {
+  private limitUsers<T>(users: T[], limit?: number): T[] {
+    if (!limit) return users
+
+    // Do not slice array unless limit is present - minor optimization
+    return users.slice(0, limit)
+  }
+
+  async getGroupedUsers(limit?: number, nextToken?: string) {
     const user = this.user
     new PoliciesService(user).authorize(UserAction.Read, Resource.Users)
 
-    const listArgs: CopilotListArgs = { limit, nextToken }
+    // NOTE: Get currentInternalUser with a separate CopilotAPI call. This adds a
+    // Copilot call, but saves us from having to `.find` in a potentially large array
 
-    const [ius, clients, companies, currentWorkspace] = await Promise.all([
-      this.copilot.getInternalUsers(listArgs),
+    const [currentInternalUser, ius, clients, companies, currentWorkspace] = await Promise.all([
+      this.copilot.getInternalUser(user.internalUserId!),
+      this.copilot.getInternalUsers({ limit: MAX_FETCH_ASSIGNEE_COUNT, nextToken }),
       this.copilot.getClients({ limit: MAX_FETCH_ASSIGNEE_COUNT, nextToken }),
-      this.copilot.getCompanies({ limit: MAX_FETCH_ASSIGNEE_COUNT, nextToken }),
+      this.copilot.getCompanies({ limit: MAX_FETCH_ASSIGNEE_COUNT, nextToken, isPlaceholder: false }),
       this.copilot.getWorkspace(),
     ])
 
-    // Get current internal user as only IUs are authenticated to access this route
-    const currentInternalUser = ius.data.find((iu) => iu.id === user.internalUserId)
     if (!currentInternalUser) {
       throw new APIError(httpStatus.UNAUTHORIZED, 'Only internal users are allowed to access this resource')
     }
-    // Filter out companies where isPlaceholder is true if companies.data is not null
-    // Also filter out just companies which are accessible to this IU, since copilot doesn't do that
-    // If current workspace setting does not have companies enabled, don't return any companies
-    let filteredCompanies: CompanyResponse[] = []
-    if (currentWorkspace.isCompaniesEnabled && companies.data) {
-      filteredCompanies = companies.data
-        .filter((company) => !company.isPlaceholder)
-        .filter((company) =>
-          currentInternalUser.isClientAccessLimited ? currentInternalUser.companyAccessList?.includes(company.id) : true,
-        )
-        .slice(0, limit)
+
+    const processIus = (ius: InternalUsers[]) => {
+      return [currentInternalUser, ...orderByRecentlyCreatedAt(ius.filter((user) => user.id !== currentInternalUser.id))]
     }
 
-    // Same for clients
-    const clientsWithCompanyData = clients.data || []
-    const accessibleClients = (
-      currentInternalUser.isClientAccessLimited
-        ? clientsWithCompanyData
-            ?.map((client) => {
-              const matchingCompanyIds = client.companyIds?.filter((id) =>
-                currentInternalUser.companyAccessList?.includes(id),
-              )
+    const processClients = (clients: ClientResponse[]) => {
+      if (!currentInternalUser.isClientAccessLimited) return clients
 
-              if (matchingCompanyIds?.length) {
-                return {
-                  ...client,
-                  companyIds: matchingCompanyIds,
-                }
-              }
-              return null
-            })
-            .filter((c) => c !== null)
-        : clientsWithCompanyData
-    )?.slice(0, limit)
-
-    const internalUsers = [
-      currentInternalUser,
-      ...orderByRecentlyCreatedAt(ius.data.filter((user) => user.id !== currentInternalUser.id)),
-    ] //Always keeping the current user at the first of the list.
-    let companyId
-    let filteredIUs = internalUsers
-    if (companyId) {
-      filteredIUs = filteredIUs.filter((iu) => {
-        !iu.isClientAccessLimited || iu.companyAccessList?.includes(companyId)
-      })
+      return clients.reduce((acc, client) => {
+        const allowedCompanyIds = client.companyIds?.filter((id) => currentInternalUser.companyAccessList?.includes(id))
+        if (allowedCompanyIds?.length) {
+          acc.push({ ...client, companyIds: allowedCompanyIds })
+        }
+        return acc
+      }, [] as ClientResponse[])
     }
+
+    const processCompanies = (companies: CompanyResponse[]) => {
+      if (!currentWorkspace.isCompaniesEnabled) return []
+      if (!currentInternalUser.isClientAccessLimited) return companies
+
+      return companies.filter((company) => currentInternalUser.companyAccessList?.includes(company.id))
+    }
+
+    const processedIus = processIus(ius.data)
+    const processedClients = processClients(clients.data || [])
+    const processedCompanies = processCompanies(companies.data || [])
 
     return {
-      // CopilotAPI doesn't currently support sorting data, so manually sort them before returning a response
-      internalUsers: filteredIUs,
-      clients: orderByRecentlyCreatedAt(accessibleClients),
-      companies: orderByRecentlyCreatedAt(filteredCompanies),
+      internalUsers: this.limitUsers(processedIus, limit),
+      clients: this.limitUsers(processedClients, limit),
+      companies: this.limitUsers(processedCompanies, limit),
     }
   }
 
@@ -127,7 +112,7 @@ class UsersService extends BaseService {
     }
   }
 
-  async getUsersForClients(limit: number = this.DEFAULT_USERS_LIMIT) {
+  async getUsersForClients(limit?: number) {
     const user = this.user
     //Apply custom authorization here. Policy service is not used because this api is for client's task-assignee match function to get clients from same organizations only. Only clients can use this.
     if (user.role !== UserRole.Client) {
@@ -135,14 +120,11 @@ class UsersService extends BaseService {
     }
     const [clients, companies, internalUsers] = await Promise.all([
       this.copilot.getClients({ limit }),
-      this.copilot.getCompanies({ limit }),
+      this.copilot.getCompanies({ limit, isPlaceholder: false }),
       this.copilot.getInternalUsers({ limit }),
     ])
 
-    // Filter out companies where isPlaceholder is true if companies.data is not null
-    const filteredCompanies = companies.data ? companies.data.filter((company) => !company.isPlaceholder) : []
-
-    return { clients: clients.data, companies: filteredCompanies, internalUsers: internalUsers.data }
+    return { clients: clients.data, companies: companies.data, internalUsers: internalUsers.data }
   }
 }
 

--- a/src/constants/users.ts
+++ b/src/constants/users.ts
@@ -1,1 +1,1 @@
-export const MAX_FETCH_ASSIGNEE_COUNT = 10_000
+export const MAX_FETCH_ASSIGNEE_COUNT = 15_000

--- a/src/utils/CopilotAPI.ts
+++ b/src/utils/CopilotAPI.ts
@@ -150,7 +150,7 @@ export class CopilotAPI {
     return CompanyResponseSchema.parse(await this.copilot.retrieveCompany({ id }))
   }
 
-  async _getCompanies(args: CopilotListArgs = {}): Promise<CompaniesResponse> {
+  async _getCompanies(args: CopilotListArgs & { isPlaceholder?: boolean } = {}): Promise<CompaniesResponse> {
     console.info('CopilotAPI#_getCompanies', this.token)
     return CompaniesResponseSchema.parse(await this.copilot.listCompanies(args))
   }


### PR DESCRIPTION
## Changes

- [x] Optimize the flow of `getGroupedUsers` function to avoid unnecessary filters
- [x] Slice array only when `limit` is provided (saves us from 3 slices, minor optimization)
- [x] Apply Copilot API's new `isPlaceholder` filter instead of filtering placeholder companies manually

## Testing Criteria:

Response time improvement in my local machine with a production build across 10 requests averaged on OUT-2076 vs `feature/M15`: **13.5% response time improvement**

<img width="1034" height="268" alt="image" src="https://github.com/user-attachments/assets/ca1a632c-ed2e-4a59-9ea5-6177e6927fc8" />

 …ng clients (you can never be too safe)