### PR TITLE
OUT-2075: Fix nested fetchers for Assignee & WorkflowState in Task Description

### DIFF
--- a/src/app/detail/[task_id]/[user_type]/page.tsx
+++ b/src/app/detail/[task_id]/[user_type]/page.tsx
@@ -190,36 +190,33 @@ export default async function TaskDetailPage({
             </CustomScrollBar>
           </ToggleController>
           <Box>
-            <Suspense fallback={<SidebarSkeleton />}>
-              <WorkflowStateFetcher token={token} task={task}>
-                <AssigneeFetcher
-                  token={token}
-                  userType={params.user_type}
-                  isPreview={!!getPreviewMode(tokenPayload)}
-                  task={task}
-                />
-                <Sidebar
-                  task_id={task_id}
-                  selectedAssigneeId={task?.assigneeId}
-                  selectedWorkflowState={task?.workflowState}
-                  updateWorkflowState={async (workflowState) => {
-                    'use server'
-                    params.user_type === UserType.CLIENT_USER && !getPreviewMode(tokenPayload)
-                      ? await clientUpdateTask(token, task_id, workflowState.id)
-                      : await updateWorkflowStateIdOfTask(token, task_id, workflowState?.id)
-                  }}
-                  updateAssignee={async ({ internalUserId, clientId, companyId }: UserIdsType) => {
-                    'use server'
-                    await updateAssignee(token, task_id, internalUserId, clientId, companyId)
-                  }}
-                  updateTask={async (payload) => {
-                    'use server'
-                    await updateTaskDetail({ token, taskId: task_id, payload })
-                  }}
-                  disabled={params.user_type === UserType.CLIENT_USER}
-                />
-              </WorkflowStateFetcher>
-            </Suspense>
+            <AssigneeFetcher
+              token={token}
+              userType={params.user_type}
+              isPreview={!!getPreviewMode(tokenPayload)}
+              task={task}
+            />
+            <WorkflowStateFetcher token={token} task={task} />
+            <Sidebar
+              task_id={task_id}
+              selectedAssigneeId={task?.assigneeId}
+              selectedWorkflowState={task?.workflowState}
+              updateWorkflowState={async (workflowState) => {
+                'use server'
+                params.user_type === UserType.CLIENT_USER && !getPreviewMode(tokenPayload)
+                  ? await clientUpdateTask(token, task_id, workflowState.id)
+                  : await updateWorkflowStateIdOfTask(token, task_id, workflowState?.id)
+              }}
+              updateAssignee={async ({ internalUserId, clientId, companyId }: UserIdsType) => {
+                'use server'
+                await updateAssignee(token, task_id, internalUserId, clientId, companyId)
+              }}
+              updateTask={async (payload) => {
+                'use server'
+                await updateTaskDetail({ token, taskId: task_id, payload })
+              }}
+              disabled={params.user_type === UserType.CLIENT_USER}
+            />
           </Box>
         </ResponsiveStack>
       </RealTime>

--- a/src/app/detail/ui/Sidebar.tsx
+++ b/src/app/detail/ui/Sidebar.tsx
@@ -112,7 +112,7 @@ export const Sidebar = ({
     return match ?? undefined
   }
 
-  if (!activeTask) return <SidebarSkeleton />
+  if (!activeTask || !isHydrated) return <SidebarSkeleton />
 
   const handleAssigneeChange = (inputValue: InputValue[]) => {
     const newUserIds = getSelectedUserIds(inputValue)
@@ -127,8 +127,6 @@ export const Sidebar = ({
       updateAssignee(newUserIds)
     }
   }
-
-  if (!activeTask || !isHydrated) return <SidebarSkeleton />
 
   if (!showSidebar) {
     return (


### PR DESCRIPTION
## Changes

- removed suspense wrapper from sidebar component

## Testing Criteria

[Loom](https://www.loom.com/share/035f165739ec4f79820cf7cdf6ceb96e?sid=eca71878-d523-4f3f-8813-f4bc6c5d89d1)

## Notes

- Adding suspense is actually delaying the `workflowState` render, so I removed the suspense from the `AssigneeFetcher` and `WorkflowStateFetcher`. I didn't see a need for this, as those fetchers are invoked outside the component that is being rendered (i.e. Sidebar component).