### PR TITLE
OUT-2053 | Client users are able to see activity logs of users out of their scope

### DIFF
--- a/prisma/migrations/20250728055550_add_user_company_id_field_to_activity_logs/migration.sql
+++ b/prisma/migrations/20250728055550_add_user_company_id_field_to_activity_logs/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "ActivityLogs" ADD COLUMN     "userCompanyId" UUID;
+
+-- CreateIndex
+CREATE INDEX "IX_ActivityLogs_userId_userCompanyId" ON "ActivityLogs"("userId", "userCompanyId");

--- a/prisma/schema/activityLog.prisma
+++ b/prisma/schema/activityLog.prisma
@@ -10,20 +10,23 @@ enum ActivityType {
 }
 
 model ActivityLog {
-  id          String       @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  taskId      String       @db.Uuid
-  task        Task         @relation(fields: [taskId], references: [id], onDelete: Cascade)
-  workspaceId String       @db.VarChar(32)
-  type        ActivityType
-  details     Json         @db.JsonB
-  userId      String       @db.Uuid
-  userRole    AssigneeType
-  createdAt   DateTime     @default(now()) @db.Timestamptz()
-  updatedAt   DateTime     @updatedAt @ignore @db.Timestamptz()
-  deletedAt   DateTime?
+  id            String       @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  taskId        String       @db.Uuid
+  task          Task         @relation(fields: [taskId], references: [id], onDelete: Cascade)
+  workspaceId   String       @db.VarChar(32)
+  type          ActivityType
+  details       Json         @db.JsonB
+  userId        String       @db.Uuid
+  userCompanyId String?      @db.Uuid
+  userRole      AssigneeType
+  createdAt     DateTime     @default(now()) @db.Timestamptz()
+  updatedAt     DateTime     @updatedAt @ignore @db.Timestamptz()
+  deletedAt     DateTime?
 
   @@index([createdAt])
   @@index([taskId], name: "IX_ActivityLogs_taskId")
+  // Single + composite index on userId for IU + Client initiated activities
   @@index([userId], name: "IX_ActivityLogs_userId")
+  @@index([userId, userCompanyId], name: "IX_ActivityLogs_userId_userCompanyId")
   @@map("ActivityLogs")
 }

--- a/src/app/api/activity-logs/const.ts
+++ b/src/app/api/activity-logs/const.ts
@@ -27,6 +27,7 @@ export const DBActivityLogSchema = z.object({
   details: DBActivityLogDetailsSchema,
   taskId: z.string().uuid(),
   userId: z.string().uuid(),
+  userCompanyId: z.string().uuid().nullable(),
   userRole: z.nativeEnum(AssigneeType),
   workspaceId: z.string(),
   createdAt: z.date(),

--- a/src/app/api/activity-logs/services/activity-log.service.ts
+++ b/src/app/api/activity-logs/services/activity-log.service.ts
@@ -183,10 +183,6 @@ export class ActivityLogService extends BaseService {
     if (!task.clientId && task.companyId) {
       const companyClients = (await copilot.getClients({ companyId: task.companyId }))?.data || []
       return parsedActivityLogs.filter((log) => {
-        console.log('\n\n\n\n\n\n')
-        console.log(log)
-        console.log(isIuLog(log), isCurrentCompanysClientLog(log), isCompanyMemberLog(companyClients, log))
-        console.log('\n\n\n\n\n\n')
         return isIuLog(log) || isCurrentCompanysClientLog(log) || isCompanyMemberLog(companyClients, log)
       })
     }

--- a/src/app/api/activity-logs/services/activity-logger.service.ts
+++ b/src/app/api/activity-logs/services/activity-logger.service.ts
@@ -16,8 +16,10 @@ export class ActivityLogger extends BaseService {
   async log<ActivityLog extends keyof typeof SchemaByActivityType = keyof typeof SchemaByActivityType>(
     activityType: ActivityLog,
     payload: NonNullable<z.input<(typeof SchemaByActivityType)[ActivityLog]>>,
+    // Overrides inferring createdBy data from the user's token payload
     createdBy?: {
       userId: string
+      userCompanyId?: string
       role: AssigneeType
     },
   ) {
@@ -27,6 +29,7 @@ export class ActivityLogger extends BaseService {
         workspaceId: this.user.workspaceId,
         type: activityType,
         userId: createdBy?.userId ?? z.string().parse(this.user.internalUserId || this.user.clientId),
+        userCompanyId: createdBy?.userCompanyId || this.user.companyId,
         userRole: createdBy?.role ?? this.user.role,
         details: payload,
       },

--- a/src/app/api/tasks/tasks.logger.ts
+++ b/src/app/api/tasks/tasks.logger.ts
@@ -29,7 +29,13 @@ export class TasksActivityLogger extends BaseService {
     this.activityLogger = new ActivityLogger({ taskId: this.task.id, user })
   }
 
-  async logNewTask(createdBy?: { userId: string; role: AssigneeType }) {
+  async logNewTask(createdBy?: {
+    userId: string
+    // We don't need to pass userCompanyId here because Clients currently cannot create tasks
+    // Remove this commented code if this feature is implemented in the future
+    // userCompanyId?: string
+    role: AssigneeType
+  }) {
     await this.logTaskCreated(createdBy)
   }
 

--- a/src/lib/patch-jsdom-xhr.cjs
+++ b/src/lib/patch-jsdom-xhr.cjs
@@ -20,7 +20,7 @@ fs.readFile(filePath, 'utf8', (err, data) => {
   const newLine = `const syncWorkerFile = "${resolvedPath}";`
 
   if (!oldLine.test(data)) {
-    console.log('⚠️ Patch not applied: Pattern not found.')
+    console.info('⚠️ Patch not applied: Pattern not found.')
     return
   }
 
@@ -28,6 +28,6 @@ fs.readFile(filePath, 'utf8', (err, data) => {
 
   fs.writeFile(filePath, updated, 'utf8', (err) => {
     if (err) throw err
-    console.log('✅ Patched XMLHttpRequest-impl.js with resolved syncWorker path.')
+    console.info('✅ Patched XMLHttpRequest-impl.js with resolved syncWorker path.')
   })
 })


### PR DESCRIPTION
## Changes

- [x] Fix activity log to check for client's access scope and filter out unintended activity logs
- [x] Add support for `userCompanyId` in activity logs 

## Testing Criteria

- [x] Screencast:

https://github.com/user-attachments/assets/9be92b7b-1fee-41c7-bcda-15d956242805


