### PR TITLE
OUT-1987: Cache & Revalidate assignee data in browser cache

### DIFF
--- a/src/app/detail/[task_id]/[user_type]/page.tsx
+++ b/src/app/detail/[task_id]/[user_type]/page.tsx
@@ -33,7 +33,7 @@ import { RealTime } from '@/hoc/RealTime'
 import { WorkspaceResponse } from '@/types/common'
 import { AncestorTaskResponse, SubTaskStatusResponse, TaskResponse } from '@/types/dto/tasks.dto'
 import { UserType } from '@/types/interfaces'
-import { UserIdsType } from '@/utils/assignee'
+import { getAssigneeCacheLookupKey, UserIdsType } from '@/utils/assignee'
 import { CopilotAPI } from '@/utils/CopilotAPI'
 import EscapeHandler from '@/utils/escapeHandler'
 import { getPreviewMode } from '@/utils/previewMode'
@@ -190,13 +190,7 @@ export default async function TaskDetailPage({
             </CustomScrollBar>
           </ToggleController>
           <Box>
-            <AssigneeCacheGetter
-              lookupKey={
-                user_type === UserType.INTERNAL_USER
-                  ? tokenPayload.internalUserId!
-                  : `${tokenPayload.clientId}.${tokenPayload.companyId}`
-              }
-            />
+            <AssigneeCacheGetter lookupKey={getAssigneeCacheLookupKey(user_type, tokenPayload)} />
             <AssigneeFetcher
               token={token}
               userType={params.user_type}

--- a/src/app/detail/[task_id]/[user_type]/page.tsx
+++ b/src/app/detail/[task_id]/[user_type]/page.tsx
@@ -38,9 +38,9 @@ import { CopilotAPI } from '@/utils/CopilotAPI'
 import EscapeHandler from '@/utils/escapeHandler'
 import { getPreviewMode } from '@/utils/previewMode'
 import { Box, Stack } from '@mui/material'
-import { Suspense } from 'react'
 import { z } from 'zod'
 import { fetchWithErrorHandler } from '@/app/_fetchers/fetchWithErrorHandler'
+import { AssigneeCacheGetter } from '@/app/_cache/AssigneeCacheGetter'
 
 async function getOneTask(token: string, taskId: string): Promise<TaskResponse> {
   const data = await fetchWithErrorHandler<{ task: TaskResponse }>(`${apiUrl}/api/tasks/${taskId}?token=${token}`, {
@@ -190,11 +190,19 @@ export default async function TaskDetailPage({
             </CustomScrollBar>
           </ToggleController>
           <Box>
+            <AssigneeCacheGetter
+              lookupKey={
+                user_type === UserType.INTERNAL_USER
+                  ? tokenPayload.internalUserId!
+                  : `${tokenPayload.clientId}.${tokenPayload.companyId}`
+              }
+            />
             <AssigneeFetcher
               token={token}
               userType={params.user_type}
               isPreview={!!getPreviewMode(tokenPayload)}
               task={task}
+              tokenPayload={tokenPayload}
             />
             <WorkflowStateFetcher token={token} task={task} />
             <Sidebar

--- a/src/app/detail/ui/Sidebar.tsx
+++ b/src/app/detail/ui/Sidebar.tsx
@@ -275,73 +275,81 @@ export const Sidebar = ({
           <StyledText variant="md" minWidth="80px">
             Status
           </StyledText>
-          <Box
-            sx={{
-              ':hover': {
-                bgcolor: (theme) => theme.color.background.bgCallout,
-              },
-              padding: '4px',
-              borderRadius: '4px',
-              width: 'fit-content',
-            }}
-          >
-            <WorkflowStateSelector
-              option={workflowStates}
-              value={statusValue}
-              getValue={(value) => {
-                updateStatusValue(value)
-                updateWorkflowState(value)
+          {workflowStates.length > 0 && statusValue ? ( // show skelete if statusValue and workflow state list is empty
+            <Box
+              sx={{
+                ':hover': {
+                  bgcolor: (theme) => theme.color.background.bgCallout,
+                },
+                padding: '4px',
+                borderRadius: '4px',
+                width: 'fit-content',
               }}
-              disabled={workflowDisabled}
-              variant={'normal'}
-              responsiveNoHide
-            />
-          </Box>
+            >
+              <WorkflowStateSelector
+                option={workflowStates}
+                value={statusValue}
+                getValue={(value) => {
+                  updateStatusValue(value)
+                  updateWorkflowState(value)
+                }}
+                disabled={workflowDisabled}
+                variant={'normal'}
+                responsiveNoHide
+              />
+            </Box>
+          ) : (
+            <SidebarElementSkeleton />
+          )}
         </Stack>
         <Stack direction="row" m="8px 0px" alignItems="center" columnGap="10px">
           <StyledText variant="md" minWidth="80px">
             Assignee
           </StyledText>
-          <Box
-            sx={{
-              ':hover': {
-                bgcolor: (theme) => (disabled ? 'none' : theme.color.background.bgCallout),
-              },
-              padding: '4px',
-              borderRadius: '4px',
-              width: 'fit-content',
-            }}
-          >
-            <CopilotPopSelector
-              name="Set assignee"
-              onChange={handleAssigneeChange}
-              disabled={disabled}
-              initialValue={assigneeValue}
-              buttonContent={
-                <SelectorButton
-                  disabled={disabled}
-                  padding="4px 8px"
-                  startIcon={<CopilotAvatar currentAssignee={assigneeValue} />}
-                  outlined={true}
-                  buttonContent={
-                    <Typography
-                      variant="md"
-                      lineHeight="22px"
-                      sx={{
-                        color: (theme) => theme.color.gray[600],
-                        textOverflow: 'ellipsis',
-                        whiteSpace: 'nowrap',
-                        overflow: 'hidden',
-                        maxWidth: '150px',
-                      }}
-                    >
-                      {assigneeValue?.name == 'No assignee' ? 'Unassigned' : getAssigneeName(assigneeValue, 'Unassigned')}
-                    </Typography>
-                  }
-                />
-              }
-            />
-          </Box>
+          {assignee.length > 0 ? ( // show skeleton if assignee list is empty
+            <Box
+              sx={{
+                ':hover': {
+                  bgcolor: (theme) => (disabled ? 'none' : theme.color.background.bgCallout),
+                },
+                padding: '4px',
+                borderRadius: '4px',
+                width: 'fit-content',
+              }}
+            >
+              <CopilotPopSelector
+                name="Set assignee"
+                onChange={handleAssigneeChange}
+                disabled={disabled}
+                initialValue={assigneeValue}
+                buttonContent={
+                  <SelectorButton
+                    disabled={disabled}
+                    padding="4px 8px"
+                    startIcon={<CopilotAvatar currentAssignee={assigneeValue} />}
+                    outlined={true}
+                    buttonContent={
+                      <Typography
+                        variant="md"
+                        lineHeight="22px"
+                        sx={{
+                          color: (theme) => theme.color.gray[600],
+                          textOverflow: 'ellipsis',
+                          whiteSpace: 'nowrap',
+                          overflow: 'hidden',
+                          maxWidth: '150px',
+                        }}
+                      >
+                        {assigneeValue?.name == 'No assignee' ? 'Unassigned' : getAssigneeName(assigneeValue, 'Unassigned')}
+                      </Typography>
+                    }
+                  />
+                }
+              />
+            </Box>
+          ) : (
+            <SidebarElementSkeleton />
+          )}
         </Stack>
         <Stack direction="row" m="8px 0px" alignItems="center" columnGap="10px" minWidth="fit-content">
           <StyledText variant="md" minWidth="80px">
@@ -482,6 +490,25 @@ export const SidebarSkeleton = () => {
           </Box>
         </Stack>
       </AppMargin>
+    </Box>
+  )
+}
+
+export const SidebarElementSkeleton = () => {
+  const windowWidth = useWindowWidth()
+  const isMobile = windowWidth < 600 && windowWidth !== 0
+
+  return (
+    <Box
+      sx={{
+        height: `${isMobile ? '30px' : '38px'}`,
+        alignItems: 'center',
+        justifyContent: 'center',
+        display: 'flex',
+        width: 'fit-content',
+      }}
+    >
+      <Skeleton variant="rectangular" width={`${isMobile ? '140px' : '120px'}`} height={15} />
     </Box>
   )
 }

--- a/src/utils/assignee.ts
+++ b/src/utils/assignee.ts
@@ -1,6 +1,7 @@
+import { Token } from '@/types/common'
 import { TruncateMaxNumber } from '@/types/constants'
 import { TaskResponse } from '@/types/dto/tasks.dto'
-import { IAssigneeCombined, ISelectorOption } from '@/types/interfaces'
+import { IAssigneeCombined, ISelectorOption, UserType } from '@/types/interfaces'
 import { getAssigneeTypeCorrected } from '@/utils/getAssigneeTypeCorrected'
 import { truncateText } from '@/utils/truncateText'
 import { AssigneeType } from '@prisma/client'
@@ -72,4 +73,11 @@ export const emptyAssignee: UserIdsType = {
 
 export const checkEmptyAssignee = (userIds: UserIdsType) => {
   return deepEqual(emptyAssignee, userIds)
+}
+
+export const getAssigneeCacheLookupKey = (userType: string, tokenPayload: Token): string => {
+  if (userType === UserType.INTERNAL_USER) {
+    return tokenPayload.internalUserId!
+  }
+  return `${tokenPayload.clientId}.${tokenPayload.companyId}`
 }


### PR DESCRIPTION
## Changes

- [X] Assignee cache getter and assignee cache setter in task detail page
- [X] Show skeleton for workflow state and assignee dropdown when values are not loaded yet

## Testing Criteria

[Loom](https://www.loom.com/share/a9ca1da577b746e69daca4bfa434c24a?sid=0d17129e-8006-465d-a036-aa12f1352d87)