### PR TITLE
OUT-2004 | Write a postdeploy script for M15

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "cmd:backfill-completed-tasks": "tsx ./src/cmd/backfill-completed-tasks",
     "cmd:backfill-new-user-ids": "tsx ./src/cmd/backfill-new-user-ids",
     "cmd:normalize-filterOptions-assignee": "tsx ./src/cmd/normalize-filterOptions-assignee",
-    "cmd:backfill-company-id-in-client-notifications": "tsx ./src/cmd/backfill-company-id-in-client-notifications"
+    "cmd:backfill-company-id-in-client-notifications": "tsx ./src/cmd/backfill-company-id-in-client-notifications",
+    "cmd:post-deploy-m15": "tsx ./src/cmd/post-deploy-m15"
   },
   "dependencies": {
     "@cyntler/react-doc-viewer": "^1.17.0",

--- a/src/cmd/backfill-company-id-in-client-notifications/index.ts
+++ b/src/cmd/backfill-company-id-in-client-notifications/index.ts
@@ -80,7 +80,7 @@ const updateClientNotifications = async (
   return { failedClientNotifications }
 }
 
-const run = async () => {
+export const backfillCompanyIdInClientNotifications = async () => {
   console.info(`backfill-company-id#run | Using clients endpoint:`, COPILOT_CLIENTS_ENDPOINT)
 
   const db = DBClient.getInstance()
@@ -112,4 +112,4 @@ const run = async () => {
   console.info(`Failed update on clientNotifications (${failedClientNotifications.length})`, failedClientNotifications)
 }
 
-run()
+backfillCompanyIdInClientNotifications()

--- a/src/cmd/post-deploy-m15/index.ts
+++ b/src/cmd/post-deploy-m15/index.ts
@@ -8,6 +8,8 @@ const run = async () => {
   console.info('⚒️ Running script to backfill companyId in ClientNotifications')
   await backfillCompanyIdInClientNotifications()
   console.info('🔥 Completed : backfill companyId in ClientNotifications')
+
+  //DO NOT FORGET to run trigger deploy action once milestone 15 has been promoted to production
 }
 
 run()

--- a/src/cmd/post-deploy-m15/index.ts
+++ b/src/cmd/post-deploy-m15/index.ts
@@ -1,0 +1,13 @@
+import { backfillCompanyIdInClientNotifications } from '../backfill-company-id-in-client-notifications'
+import { normalizeStringAssigneeToObject } from '../normalize-filterOptions-assignee'
+
+const run = async () => {
+  console.info('⚒️ Running normalize-filter-options script')
+  await normalizeStringAssigneeToObject()
+  console.info('🔥 Completed : normalize-filter-options script')
+  console.info('⚒️ Running script to backfill companyId in ClientNotifications')
+  await backfillCompanyIdInClientNotifications()
+  console.info('🔥 Completed : backfill companyId in ClientNotifications')
+}
+
+run()


### PR DESCRIPTION
## Changes

- [x] created a postdeploy script consisting of 2 backfill scripts for milestone 15.
- [x] ran backfill user ids script in production database and deleted contraint violating data consisting of 2864 tasks, 653 internalUserNotifications and 1051 clientNotifications.
- [x] saved the deleted data in csv format in production storage.


