### PR TITLE
OUT-2139: ZodError - isClientAccessLimited is not parsable in response body

### DIFF
--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -147,7 +147,7 @@ export const InternalUsersSchema = z.object({
   familyName: z.string(),
   email: z.string().email(),
   avatarImageUrl: z.string().optional(),
-  isClientAccessLimited: z.boolean(),
+  isClientAccessLimited: z.boolean().default(false),
   companyAccessList: z.array(z.string()).nullable(),
   fallbackColor: z.string().nullish(),
   createdAt: z.string().datetime(),


### PR DESCRIPTION
## Changes

- [x] Add 'false' as a default value for `isClientAccessLimited` when the field is not provided. Confirmed that the field is provided in response when the value is true
