### PR TITLE
OUT-2166 | Add a toggle to display settings to show subtasks (UI + API)

### DIFF
--- a/prisma/migrations/20250814072051_add_show_subtasks_field_to_view_settings/migration.sql
+++ b/prisma/migrations/20250814072051_add_show_subtasks_field_to_view_settings/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "ViewSettings" ADD COLUMN     "showSubtasks" BOOLEAN NOT NULL DEFAULT true;

--- a/prisma/schema/viewSetting.prisma
+++ b/prisma/schema/viewSetting.prisma
@@ -13,6 +13,7 @@ model ViewSetting {
   filterOptions  Json      @db.JsonB
   showUnarchived Boolean   @default(true)
   showArchived   Boolean   @default(false)
+  showSubtasks   Boolean  @default(true)
 
   @@unique([userId, workspaceId], name: "UQ_ViewSettings_userId_workspaceId")
   @@index([userId, workspaceId], name: "IX_ViewSettings_userId_workspaceId")

--- a/src/app/_fetchers/TaskDataFetcher.tsx
+++ b/src/app/_fetchers/TaskDataFetcher.tsx
@@ -1,6 +1,6 @@
 import { selectTaskBoard, setIsTasksLoading, setTasks } from '@/redux/features/taskBoardSlice'
 import store from '@/redux/store'
-import { ArchivedOptionsType } from '@/types/dto/viewSettings.dto'
+import { DisplayOptions } from '@/types/dto/viewSettings.dto'
 import { PropsWithToken } from '@/types/interfaces'
 import { fetcher } from '@/utils/fetcher'
 import { useEffect } from 'react'
@@ -8,20 +8,29 @@ import { useSelector } from 'react-redux'
 import useSWR from 'swr'
 
 export const TaskDataFetcher = ({ token }: PropsWithToken) => {
-  const { showArchived, showUnarchived, tasks } = useSelector(selectTaskBoard)
+  const { showArchived, showUnarchived, showSubtasks, tasks } = useSelector(selectTaskBoard)
 
-  const buildQueryString = (token: string, archivedOptions?: ArchivedOptionsType) => {
+  const buildQueryString = (token: string, displayOptions?: DisplayOptions) => {
     const queryParams = new URLSearchParams({ token })
-    if (archivedOptions?.showArchived !== undefined) {
-      queryParams.append('showArchived', archivedOptions.showArchived.toString())
+    if (displayOptions?.showArchived !== undefined) {
+      queryParams.append('showArchived', displayOptions.showArchived.toString())
     }
-    if (archivedOptions?.showUnarchived !== undefined) {
-      queryParams.append('showUnarchived', archivedOptions.showUnarchived.toString())
+    if (displayOptions?.showUnarchived !== undefined) {
+      queryParams.append('showUnarchived', displayOptions.showUnarchived.toString())
     }
+
+    // NOTE: We don't need to send showSubtasks as a param to `getTasks` since we
+    // are currently implementing showSubtasks in UI only. Uncomment and proceed with handling
+    // showSubtasks in GET /api/tasks if we handle from the backend
+
+    // if (displayOptions?.showSubtasks !== undefined) {
+    //   queryParams.append('showSubtasks', displayOptions.showSubtasks.toString())
+    // }
+
     return queryParams.toString()
   }
 
-  const queryString = token ? buildQueryString(token, { showArchived, showUnarchived }) : null
+  const queryString = token ? buildQueryString(token, { showArchived, showUnarchived, showSubtasks }) : null
 
   const { data, isLoading } = useSWR(queryString ? `/api/tasks/?${queryString}` : null, fetcher, {
     fallbackData: { tasks },

--- a/src/app/api/view-settings/viewSettings.service.ts
+++ b/src/app/api/view-settings/viewSettings.service.ts
@@ -69,6 +69,7 @@ export class ViewSettingsService extends BaseService {
         },
         showUnarchived: true,
         showArchived: false,
+        showSubtasks: true, // If we DO need to default to false for IUs, we can add a condition here after confirmation
       },
     })
   }

--- a/src/components/inputs/DisplaySelector.tsx
+++ b/src/components/inputs/DisplaySelector.tsx
@@ -4,21 +4,21 @@ import { ViewMode } from '@prisma/client'
 import { SecondaryBtn } from '@/components/buttons/SecondaryBtn'
 import { useState } from 'react'
 import { StyledSwitch } from '@/components/inputs/StyledSwitch'
-import { ArchivedOptionsType } from '@/types/dto/viewSettings.dto'
+import { DisplayOptions } from '@/types/dto/viewSettings.dto'
 
 interface DisplaySelectorProps {
   handleModeChange: (mode: ViewMode) => void
   selectedMode: ViewMode
-  archivedOptions: ArchivedOptionsType
-  handleArchivedOptionsChange: (archivedOptions: ArchivedOptionsType) => void
+  displayOptions: DisplayOptions
+  handleDisplayOptionsChange: (displayOptions: DisplayOptions) => void
   mobileView?: boolean
 }
 
 export const DisplaySelector = ({
   handleModeChange,
   selectedMode,
-  archivedOptions,
-  handleArchivedOptionsChange,
+  displayOptions,
+  handleDisplayOptionsChange,
   mobileView,
 }: DisplaySelectorProps) => {
   const [anchorEl, setAnchorEl] = useState<null | Element>(null)
@@ -118,6 +118,30 @@ export const DisplaySelector = ({
             </Typography>
           </IconContainer>
         </Stack>
+
+        <Stack
+          direction="row"
+          columnGap={'8px'}
+          sx={{
+            display: 'flex',
+            alignSelf: 'stretch',
+            alignItems: 'center',
+            padding: '4px 0px',
+            justifyContent: 'space-between',
+          }}
+        >
+          <Typography variant="bodyMd"> Show subtasks</Typography>
+          <StyledSwitch
+            checked={displayOptions.showSubtasks}
+            onChange={(e) =>
+              handleDisplayOptionsChange({
+                ...displayOptions,
+                showSubtasks: e.target.checked,
+              })
+            }
+          />
+        </Stack>
+
         <Stack
           direction="row"
           columnGap={'8px'}
@@ -131,12 +155,16 @@ export const DisplaySelector = ({
         >
           <Typography variant="bodyMd"> Show unarchived tasks</Typography>
           <StyledSwitch
-            checked={archivedOptions.showUnarchived}
+            checked={displayOptions.showUnarchived}
             onChange={(e) =>
-              handleArchivedOptionsChange({ showArchived: archivedOptions.showArchived, showUnarchived: e.target.checked })
+              handleDisplayOptionsChange({
+                ...displayOptions,
+                showUnarchived: e.target.checked,
+              })
             }
           />
         </Stack>
+
         <Stack
           direction="row"
           columnGap={'8px'}
@@ -150,9 +178,12 @@ export const DisplaySelector = ({
         >
           <Typography variant="bodyMd"> Show archived tasks</Typography>
           <StyledSwitch
-            checked={archivedOptions.showArchived}
+            checked={displayOptions.showArchived}
             onChange={(e) =>
-              handleArchivedOptionsChange({ showArchived: e.target.checked, showUnarchived: archivedOptions.showUnarchived })
+              handleDisplayOptionsChange({
+                ...displayOptions,
+                showArchived: e.target.checked,
+              })
             }
           />
         </Stack>

--- a/src/components/layouts/FilterBar.tsx
+++ b/src/components/layouts/FilterBar.tsx
@@ -18,7 +18,7 @@ import {
 } from '@/redux/features/taskBoardSlice'
 import store from '@/redux/store'
 import { IUTokenSchema } from '@/types/common'
-import { CreateViewSettingsDTO } from '@/types/dto/viewSettings.dto'
+import { CreateViewSettingsDTO, DisplayOptions } from '@/types/dto/viewSettings.dto'
 import { FilterOptions, FilterOptionsKeywords, IFilterOptions, UserIds } from '@/types/interfaces'
 import { filterTypeToButtonIndexMap } from '@/types/objectMaps'
 import { checkAssignee, emptyAssignee, getAssigneeId, UserIdsType } from '@/utils/assignee'
@@ -32,14 +32,16 @@ interface FilterBarProps {
   mode: UserRole
   updateViewModeSetting: (payload: CreateViewSettingsDTO) => void
 }
+
 export const FilterBar = ({ mode, updateViewModeSetting }: FilterBarProps) => {
-  const { view, filterOptions, assignee, token, viewSettingsTemp, showArchived, showUnarchived } =
+  const { view, filterOptions, assignee, viewSettingsTemp, showArchived, showUnarchived, showSubtasks } =
     useSelector(selectTaskBoard)
 
   const viewMode = viewSettingsTemp ? viewSettingsTemp.viewMode : view
-  const archivedOptions = {
+  const displayOptions = {
     showArchived: viewSettingsTemp ? viewSettingsTemp.showArchived : showArchived,
     showUnarchived: viewSettingsTemp ? viewSettingsTemp.showUnarchived : showUnarchived,
+    showSubtasks: viewSettingsTemp ? viewSettingsTemp.showSubtasks : showSubtasks,
   }
 
   const viewModeFilterOptions = viewSettingsTemp ? (viewSettingsTemp.filterOptions as IFilterOptions) : filterOptions //ViewSettingsTemp used to apply temp values of viewSettings in filterOptions and viewMode because clientSideUpdate applies outdated cached values to original view and filterOptions if navigated
@@ -81,6 +83,18 @@ export const FilterBar = ({ mode, updateViewModeSetting }: FilterBarProps) => {
       ? NoAssignee
       : getSelectorAssigneeFromFilterOptions(assignee, viewModeFilterOptions.assignee),
   )
+
+  const handleDisplayOptionsChange = (displayOptions: DisplayOptions) => {
+    store.dispatch(setIsTasksLoading(true))
+    const newViewSettings = {
+      viewMode,
+      filterOptions,
+      ...displayOptions,
+    }
+    store.dispatch(setViewSettings(newViewSettings))
+    updateViewModeSetting(newViewSettings)
+    store.dispatch(setViewSettingsTemp(newViewSettings))
+  }
 
   const filterButtons = [
     {
@@ -239,32 +253,8 @@ export const FilterBar = ({ mode, updateViewModeSetting }: FilterBarProps) => {
                   }),
                 )
               }}
-              archivedOptions={archivedOptions}
-              handleArchivedOptionsChange={(archivedOptions) => {
-                store.dispatch(setIsTasksLoading(true))
-                store.dispatch(
-                  setViewSettings({
-                    viewMode: viewMode,
-                    filterOptions: filterOptions,
-                    showArchived: archivedOptions.showArchived,
-                    showUnarchived: archivedOptions.showUnarchived,
-                  }),
-                )
-                updateViewModeSetting({
-                  viewMode: viewMode,
-                  filterOptions: filterOptions,
-                  showArchived: archivedOptions.showArchived,
-                  showUnarchived: archivedOptions.showUnarchived,
-                })
-                store.dispatch(
-                  setViewSettingsTemp({
-                    viewMode: viewMode,
-                    filterOptions: filterOptions,
-                    showArchived: archivedOptions.showArchived,
-                    showUnarchived: archivedOptions.showUnarchived,
-                  }),
-                )
-              }}
+              displayOptions={displayOptions}
+              handleDisplayOptionsChange={handleDisplayOptionsChange}
             />
           </Stack>
         </Stack>
@@ -376,32 +366,8 @@ export const FilterBar = ({ mode, updateViewModeSetting }: FilterBarProps) => {
                     }),
                   )
                 }}
-                archivedOptions={archivedOptions}
-                handleArchivedOptionsChange={(archivedOptions) => {
-                  store.dispatch(setIsTasksLoading(true))
-                  store.dispatch(
-                    setViewSettings({
-                      viewMode: viewMode,
-                      filterOptions: filterOptions,
-                      showArchived: archivedOptions.showArchived,
-                      showUnarchived: archivedOptions.showUnarchived,
-                    }),
-                  )
-                  updateViewModeSetting({
-                    viewMode: viewMode,
-                    filterOptions: filterOptions,
-                    showArchived: archivedOptions.showArchived,
-                    showUnarchived: archivedOptions.showUnarchived,
-                  })
-                  store.dispatch(
-                    setViewSettingsTemp({
-                      viewMode: viewMode,
-                      filterOptions: filterOptions,
-                      showArchived: archivedOptions.showArchived,
-                      showUnarchived: archivedOptions.showUnarchived,
-                    }),
-                  )
-                }}
+                displayOptions={displayOptions}
+                handleDisplayOptionsChange={handleDisplayOptionsChange}
               />
             </Stack>
           </Stack>

--- a/src/redux/features/taskBoardSlice.tsx
+++ b/src/redux/features/taskBoardSlice.tsx
@@ -3,14 +3,7 @@ import { PreviewMode } from '@/types/common'
 import { TaskResponse } from '@/types/dto/tasks.dto'
 import { CreateViewSettingsDTO, FilterOptionsType } from '@/types/dto/viewSettings.dto'
 import { WorkflowStateResponse } from '@/types/dto/workflowStates.dto'
-import {
-  FilterByOptions,
-  FilterOptions,
-  IAssigneeCombined,
-  IFilterOptions,
-  ISelectorAssignee,
-  UserIds,
-} from '@/types/interfaces'
+import { FilterByOptions, FilterOptions, IAssigneeCombined, IFilterOptions, UserIds } from '@/types/interfaces'
 import { emptyAssignee, UserIdsType } from '@/utils/assignee'
 import { ViewMode } from '@prisma/client'
 import { createSlice } from '@reduxjs/toolkit'
@@ -26,6 +19,7 @@ interface IInitialState {
   filteredAssigneeList: IAssigneeCombined[]
   showArchived: boolean | undefined
   showUnarchived: boolean | undefined
+  showSubtasks: boolean | undefined
   viewSettingsTemp: CreateViewSettingsDTO | undefined
   isTasksLoading: boolean
   activeTask: TaskResponse | undefined
@@ -51,6 +45,7 @@ const initialState: IInitialState = {
   filteredAssigneeList: [],
   showArchived: undefined,
   showUnarchived: undefined,
+  showSubtasks: undefined,
   viewSettingsTemp: undefined,
   // Use this state as a global loading flag for tasks
   isTasksLoading: true,
@@ -101,10 +96,11 @@ const taskBoardSlice = createSlice({
       state.filteredAssigneeList = action.payload
     },
     setViewSettings: (state, action: { payload: CreateViewSettingsDTO }) => {
-      const { viewMode, filterOptions, showArchived, showUnarchived } = action.payload
+      const { viewMode, filterOptions, showArchived, showUnarchived, showSubtasks } = action.payload
       state.view = viewMode
       state.showArchived = showArchived
       state.showUnarchived = showUnarchived
+      state.showSubtasks = showSubtasks
       taskBoardSlice.caseReducers.updateFilterOption(state, { payload: { filterOptions } })
     },
     setViewSettingsTemp: (state, action: { payload: CreateViewSettingsDTO }) => {

--- a/src/types/dto/viewSettings.dto.ts
+++ b/src/types/dto/viewSettings.dto.ts
@@ -8,19 +8,21 @@ export const FilterOptionsSchema = z.object({
   type: z.string(),
 })
 
-export const ArchivedOptionsSchema = z.object({
+export const DisplayOptionsSchema = z.object({
   showArchived: z.boolean().optional(),
   showUnarchived: z.boolean().optional(),
+  showSubtasks: z.boolean().optional(),
 })
 
 export type FilterOptionsType = z.infer<typeof FilterOptionsSchema>
 
-export type ArchivedOptionsType = z.infer<typeof ArchivedOptionsSchema>
+export type DisplayOptions = z.infer<typeof DisplayOptionsSchema>
 
 export const CreateViewSettingsSchema = z.object({
   viewMode: z.nativeEnum(ViewMode),
   filterOptions: FilterOptionsSchema,
   showUnarchived: z.boolean().optional(),
   showArchived: z.boolean().optional(),
+  showSubtasks: z.boolean().optional(),
 })
 export type CreateViewSettingsDTO = z.infer<typeof CreateViewSettingsSchema>


### PR DESCRIPTION
## Changes

- [x] Add `showSubtasks` field in ViewSettings table
- [x] Implement `showSubtasks` and default `showSubtasks` value (true) in API
- [x] Add support for field in redux slice (taskBoardSlice)
- [x] Add functional toggle in display drawer   

## Testing Criteria

- [x] Screencast:

https://github.com/user-attachments/assets/06956a92-34d8-440a-906a-b7aef7c7ebd6

