### PR TITLE
OUT-2204 | OUT-2205 | OUT-2206 | OUT-2208 | OUT-2212 | OUT-2216 | OUT-2217 Tooltips should disappear once the cursor leaves hover area

### DIFF
--- a/src/app/detail/ui/TaskCardList.tsx
+++ b/src/app/detail/ui/TaskCardList.tsx
@@ -186,9 +186,6 @@ export const TaskCardList = ({ task, variant, workflowState, mode, handleUpdate,
           size={Sizes.MEDIUM}
           padding={'2px 4px'}
           hoverColor={200}
-          tooltipProps={{
-            placement: variant !== 'subtask-board' ? 'right' : 'center',
-          }}
         />
 
         {isTemp || variant === 'subtask-board' ? (
@@ -287,8 +284,6 @@ export const TaskCardList = ({ task, variant, workflowState, mode, handleUpdate,
               isShort
               hoverColor={200}
               tooltipProps={{
-                placement: variant !== 'subtask-board' ? 'left' : 'center',
-
                 disabled: mode === UserRole.Client && !previewMode,
               }}
             />
@@ -307,7 +302,7 @@ export const TaskCardList = ({ task, variant, workflowState, mode, handleUpdate,
             variant="icon"
             tooltipProps={{
               content: assigneeValue === NoAssignee ? 'Set assignee' : 'Change assignee',
-              placement: variant !== 'subtask-board' ? 'left' : 'center',
+
               disabled: mode === UserRole.Client && !previewMode,
             }}
             buttonContent={

--- a/src/app/detail/ui/TaskCardList.tsx
+++ b/src/app/detail/ui/TaskCardList.tsx
@@ -6,6 +6,7 @@ import { clientUpdateTask, updateAssignee, updateTaskDetail } from '@/app/detail
 import { StyledModal } from '@/app/detail/ui/styledComponent'
 import { CopilotAvatar } from '@/components/atoms/CopilotAvatar'
 import { TaskMetaItems } from '@/components/atoms/TaskMetaItems'
+import TaskTitle from '@/components/atoms/TaskTitle'
 import { CopilotPopSelector } from '@/components/inputs/CopilotSelector'
 import { DatePickerComponent } from '@/components/inputs/DatePickerComponent'
 import { SelectorType } from '@/components/inputs/Selector'
@@ -263,21 +264,7 @@ export const TaskCardList = ({ task, variant, workflowState, mode, handleUpdate,
                 flexShrink: 1,
               }}
             >
-              <Typography
-                variant="bodySm"
-                sx={{
-                  lineHeight: variant == 'task' ? '22px' : '21px',
-                  fontSize: variant == 'task' ? '14px' : '13px',
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                  whiteSpace: 'nowrap',
-                  flexShrink: 1,
-                  flexGrow: 0,
-                  minWidth: 0,
-                }}
-              >
-                {task.title}
-              </Typography>
+              <TaskTitle variant="list" title={task.title} />
               {(task.subtaskCount > 0 || task.isArchived) && (
                 <Stack direction="row" sx={{ display: 'flex', gap: '12px', flexShrink: 0, alignItems: 'center' }}>
                   <TaskMetaItems task={task} lineHeight="21px" />

--- a/src/app/detail/ui/TaskCardList.tsx
+++ b/src/app/detail/ui/TaskCardList.tsx
@@ -128,7 +128,6 @@ export const TaskCardList = ({ task, variant, workflowState, mode, handleUpdate,
     return assigneeCache[task.id]
   }) //Omitting type for NoAssignee
 
-  const tooltipDisabled = variant == 'subtask' || variant == 'subtask-board'
   return (
     <Stack
       tabIndex={0}
@@ -188,8 +187,7 @@ export const TaskCardList = ({ task, variant, workflowState, mode, handleUpdate,
           padding={'2px 4px'}
           hoverColor={200}
           tooltipProps={{
-            disabled: tooltipDisabled,
-            placement: 'right',
+            placement: variant !== 'subtask-board' ? 'right' : 'center',
           }}
         />
 
@@ -246,9 +244,7 @@ export const TaskCardList = ({ task, variant, workflowState, mode, handleUpdate,
             style={{
               display: 'flex',
               gap: '2px',
-              minWidth: 0,
-              flexGrow: 0,
-              flexShrink: 1,
+
               width: '100%',
             }}
           >
@@ -258,10 +254,6 @@ export const TaskCardList = ({ task, variant, workflowState, mode, handleUpdate,
                 gap: '8px',
                 display: 'flex',
                 alignItems: 'center',
-                marginRight: 'auto',
-                minWidth: 0,
-                flexGrow: 1,
-                flexShrink: 1,
               }}
             >
               <TaskTitle variant="list" title={task.title} />
@@ -308,7 +300,9 @@ export const TaskCardList = ({ task, variant, workflowState, mode, handleUpdate,
               isShort
               hoverColor={200}
               tooltipProps={{
-                disabled: (mode === UserRole.Client && !previewMode) || tooltipDisabled,
+                placement: variant !== 'subtask-board' ? 'left' : 'center',
+
+                disabled: mode === UserRole.Client && !previewMode,
               }}
             />
           </Box>
@@ -326,8 +320,8 @@ export const TaskCardList = ({ task, variant, workflowState, mode, handleUpdate,
             variant="icon"
             tooltipProps={{
               content: assigneeValue === NoAssignee ? 'Set assignee' : 'Change assignee',
-              placement: 'left',
-              disabled: (mode === UserRole.Client && !previewMode) || tooltipDisabled,
+              placement: variant !== 'subtask-board' ? 'left' : 'center',
+              disabled: mode === UserRole.Client && !previewMode,
             }}
             buttonContent={
               <Box

--- a/src/app/detail/ui/TaskCardList.tsx
+++ b/src/app/detail/ui/TaskCardList.tsx
@@ -198,7 +198,7 @@ export const TaskCardList = ({ task, variant, workflowState, mode, handleUpdate,
               display: 'flex',
               gap: '2px',
               minWidth: 0,
-              flexGrow: 0,
+              flexGrow: 1,
               flexShrink: 1,
               width: '100%',
             }}
@@ -215,21 +215,8 @@ export const TaskCardList = ({ task, variant, workflowState, mode, handleUpdate,
                 flexShrink: 1,
               }}
             >
-              <Typography
-                variant="bodySm"
-                sx={{
-                  lineHeight: variant == 'task' ? '22px' : '21px',
-                  fontSize: variant == 'task' ? '14px' : '13px',
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                  whiteSpace: 'nowrap',
-                  flexShrink: 1,
-                  flexGrow: 0,
-                  minWidth: 0,
-                }}
-              >
-                {task.title}
-              </Typography>
+              <TaskTitle variant={variant == 'task' ? 'list' : 'subtasks'} title={task.title} />
+
               {(task.subtaskCount > 0 || task.isArchived) && (
                 <Stack direction="row" sx={{ display: 'flex', gap: '12px', flexShrink: 0, alignItems: 'center' }}>
                   <TaskMetaItems task={task} lineHeight="21px" />
@@ -278,7 +265,7 @@ export const TaskCardList = ({ task, variant, workflowState, mode, handleUpdate,
         }}
       >
         {task.dueDate && (
-          <Box sx={{ minWidth: '105px', display: 'flex', justifyContent: 'flex-end' }}>
+          <Box sx={{ minWidth: '55px', display: 'flex', justifyContent: 'flex-end' }}>
             <DatePickerComponent
               getDate={(date) => {
                 const isoDate = DateStringSchema.parse(formatDate(date))

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -76,7 +76,12 @@ a {
   gap: 16px;
   min-height: 29px;
   min-width: 109px;
+  max-width: 350px;
   font-size: 13px;
   font-weight: 400;
   line-height: 21px;
+}
+
+.displayoff {
+  display: none;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -70,16 +70,18 @@ a {
   display: inline-flex;
   border: 1px solid #dfe1e4;
   box-shadow: 0px 8px 16px 0px rgba(0, 0, 0, 0.14);
-  padding: 8px;
+  padding: 4px 8px;
   align-items: center;
   justify-content: center;
   gap: 16px;
-  min-height: 29px;
-  min-width: 109px;
-  max-width: 350px;
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 400;
-  line-height: 21px;
+  line-height: 22px;
+  white-space: nowrap;
+}
+.tooltip-max {
+  max-width: 350px;
+  white-space: normal;
 }
 
 .displayoff {

--- a/src/components/atoms/CopilotTooltip.tsx
+++ b/src/components/atoms/CopilotTooltip.tsx
@@ -1,5 +1,5 @@
 import { Tooltip } from 'copilot-design-system'
-import React from 'react'
+import React, { useRef, useState } from 'react'
 
 export interface CopilotTooltipProps {
   content: React.ReactNode
@@ -16,15 +16,32 @@ export const CopilotTooltip = ({
   placement = 'center',
   disabled = false,
 }: CopilotTooltipProps) => {
+  const [open, setOpen] = useState(false)
+  const timer = useRef<NodeJS.Timeout | null>(null)
+
   return (
     <Tooltip
       content={content}
       position={position}
-      tooltipClassname="tooltip"
+      tooltipClassname={open ? 'tooltip' : 'displayoff'}
       offset={{ x: placement == 'right' ? 50 : placement == 'left' ? -50 : 5, y: -10 }}
       disabled={disabled}
     >
-      {children}
+      <span
+        onMouseEnter={() => {
+          timer.current = setTimeout(() => setOpen(true), 500)
+        }}
+        onMouseLeave={() => {
+          if (timer.current) clearTimeout(timer.current)
+          setOpen(false)
+        }}
+        onMouseDown={() => {
+          if (timer.current) clearTimeout(timer.current)
+          setOpen(false)
+        }}
+      >
+        {children}
+      </span>
     </Tooltip>
   )
 }

--- a/src/components/atoms/CopilotTooltip.tsx
+++ b/src/components/atoms/CopilotTooltip.tsx
@@ -1,3 +1,4 @@
+import { Box, useMediaQuery } from '@mui/material'
 import { Tooltip } from 'copilot-design-system'
 import React, { useRef, useState } from 'react'
 
@@ -5,30 +6,47 @@ export interface CopilotTooltipProps {
   content: React.ReactNode
   children: React.ReactElement
   position?: 'top' | 'bottom' | 'left' | 'right'
-  placement?: 'left' | 'right' | 'center'
   disabled?: boolean
+  allowMaxWidth?: boolean
 }
 
 export const CopilotTooltip = ({
   content,
   children,
   position = 'bottom',
-  placement = 'center',
   disabled = false,
+  allowMaxWidth = false,
 }: CopilotTooltipProps) => {
   const [open, setOpen] = useState(false)
   const timer = useRef<NodeJS.Timeout | null>(null)
+  const isMobileScreen = useMediaQuery('(max-width:600px)')
+  const [dynamicPlacement, setDynamicPlacement] = useState<'left' | 'right' | 'center'>('center')
+
+  const handlePosition = (el: HTMLElement) => {
+    const rect = el.getBoundingClientRect()
+    const tooltipWidth = 100
+    const viewportWidth = window.innerWidth
+
+    if (rect.right + tooltipWidth > viewportWidth) {
+      setDynamicPlacement('left')
+    } else if (rect.left - tooltipWidth < 0) {
+      setDynamicPlacement('right')
+    } else {
+      setDynamicPlacement('center')
+    }
+  }
 
   return (
     <Tooltip
       content={content}
       position={position}
-      tooltipClassname={open ? 'tooltip' : 'displayoff'}
-      offset={{ x: placement == 'right' ? 50 : placement == 'left' ? -50 : 5, y: -10 }}
-      disabled={disabled}
+      tooltipClassname={open ? `tooltip${allowMaxWidth ? ' tooltip-max' : ''}` : 'displayoff'}
+      offset={{ x: dynamicPlacement == 'right' ? 40 : dynamicPlacement == 'left' ? -55 : 7, y: -5 }}
+      disabled={disabled || isMobileScreen}
     >
       <span
-        onMouseEnter={() => {
+        onMouseEnter={(e) => {
+          handlePosition(e.currentTarget)
           timer.current = setTimeout(() => setOpen(true), 500)
         }}
         onMouseLeave={() => {

--- a/src/components/atoms/TaskMetaItems.tsx
+++ b/src/components/atoms/TaskMetaItems.tsx
@@ -2,8 +2,9 @@ import { useSubtaskCount } from '@/hooks/useSubtaskCount'
 import { ArchiveBoxIcon, SubtaskIcon } from '@/icons'
 import { selectTaskBoard } from '@/redux/features/taskBoardSlice'
 import { TaskResponse } from '@/types/dto/tasks.dto'
-import { Box, Stack, Typography } from '@mui/material'
+import { Box, Stack, Typography, useMediaQuery } from '@mui/material'
 import { useSelector } from 'react-redux'
+import { CopilotTooltip } from './CopilotTooltip'
 
 export const TaskMetaItems = ({ task, lineHeight }: { task: TaskResponse; lineHeight: string }) => {
   const subtaskCount = useSubtaskCount(task.id)
@@ -19,19 +20,21 @@ export const TaskMetaItems = ({ task, lineHeight }: { task: TaskResponse; lineHe
         </Stack>
       )}
       {subtaskCount > 0 && !showSubtasks && (
-        <Stack direction="row" alignItems={'center'} columnGap={'4px'}>
-          <Typography
-            variant="bodySm"
-            sx={{
-              fontSize: '12px',
-              color: (theme) => theme.color.text.textSecondary,
-              lineHeight: lineHeight ?? '21px',
-            }}
-          >
-            {subtaskCount}
-          </Typography>
-          <SubtaskIcon />
-        </Stack>
+        <CopilotTooltip content={`${subtaskCount} task${subtaskCount === 1 ? '' : 's'}`}>
+          <Stack direction="row" alignItems={'center'} columnGap={'4px'}>
+            <Typography
+              variant="bodySm"
+              sx={{
+                fontSize: '12px',
+                color: (theme) => theme.color.text.textSecondary,
+                lineHeight: lineHeight ?? '21px',
+              }}
+            >
+              {subtaskCount}
+            </Typography>
+            <SubtaskIcon />
+          </Stack>
+        </CopilotTooltip>
       )}
     </>
   )

--- a/src/components/atoms/TaskTitle.tsx
+++ b/src/components/atoms/TaskTitle.tsx
@@ -14,8 +14,7 @@ const TaskTitle = ({ title, variant = 'board' }: TaskTitleProps) => {
   useEffect(() => {
     const element = textRef.current
     if (element) {
-      const isTextOverflowing =
-        variant == 'board' ? element.scrollHeight > element.clientHeight : element.scrollWidth > element.clientWidth
+      const isTextOverflowing = element.scrollHeight > element.clientHeight || element.scrollWidth > element.clientWidth
       setIsOverflowing(isTextOverflowing)
     }
   }, [title])

--- a/src/components/atoms/TaskTitle.tsx
+++ b/src/components/atoms/TaskTitle.tsx
@@ -38,17 +38,17 @@ const TaskTitle = ({ title, variant = 'board' }: TaskTitleProps) => {
       </Typography>
     ) : (
       <Typography
-        // ref={textRef}
+        ref={textRef}
         variant="bodySm"
         sx={{
           lineHeight: variant == 'list' ? '22px' : '21px',
           fontSize: variant == 'list' ? '14px' : '13px',
+          display: '-webkit-box',
+          WebkitBoxOrient: 'vertical',
+          WebkitLineClamp: 1,
           overflow: 'hidden',
           textOverflow: 'ellipsis',
-          whiteSpace: 'nowrap',
-          flexShrink: 1,
-          flexGrow: 0,
-          minWidth: 0,
+          width: '100%',
         }}
       >
         {title}

--- a/src/components/atoms/TaskTitle.tsx
+++ b/src/components/atoms/TaskTitle.tsx
@@ -1,0 +1,61 @@
+import React, { useRef, useEffect, useState } from 'react'
+import { Typography } from '@mui/material'
+import { CopilotTooltip } from './CopilotTooltip'
+
+interface TaskTitleProps {
+  title?: string
+  variant?: 'board' | 'list' | 'subtasks'
+}
+
+const TaskTitle = ({ title, variant = 'board' }: TaskTitleProps) => {
+  const textRef = useRef<HTMLElement>(null)
+  const [isOverflowing, setIsOverflowing] = useState(false)
+
+  useEffect(() => {
+    const element = textRef.current
+    if (element) {
+      const isTextOverflowing =
+        variant == 'board' ? element.scrollHeight > element.clientHeight : element.scrollWidth > element.clientWidth
+      setIsOverflowing(isTextOverflowing)
+    }
+  }, [title])
+
+  const typographyComponent =
+    variant == 'board' ? (
+      <Typography
+        ref={textRef}
+        variant="bodyMd"
+        sx={{
+          color: (theme) => theme.color.gray[600],
+          display: '-webkit-box',
+          WebkitBoxOrient: 'vertical',
+          WebkitLineClamp: 2,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+        }}
+      >
+        {title}
+      </Typography>
+    ) : (
+      <Typography
+        // ref={textRef}
+        variant="bodySm"
+        sx={{
+          lineHeight: variant == 'list' ? '22px' : '21px',
+          fontSize: variant == 'list' ? '14px' : '13px',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+          flexShrink: 1,
+          flexGrow: 0,
+          minWidth: 0,
+        }}
+      >
+        {title}
+      </Typography>
+    )
+
+  return isOverflowing ? <CopilotTooltip content={title}>{typographyComponent}</CopilotTooltip> : typographyComponent
+}
+
+export default TaskTitle

--- a/src/components/atoms/TaskTitle.tsx
+++ b/src/components/atoms/TaskTitle.tsx
@@ -54,7 +54,13 @@ const TaskTitle = ({ title, variant = 'board' }: TaskTitleProps) => {
       </Typography>
     )
 
-  return isOverflowing ? <CopilotTooltip content={title}>{typographyComponent}</CopilotTooltip> : typographyComponent
+  return isOverflowing ? (
+    <CopilotTooltip content={title} allowMaxWidth={true}>
+      {typographyComponent}
+    </CopilotTooltip>
+  ) : (
+    typographyComponent
+  )
 }
 
 export default TaskTitle

--- a/src/components/cards/TaskCard.tsx
+++ b/src/components/cards/TaskCard.tsx
@@ -19,26 +19,25 @@ import { IAssigneeCombined, InputValue, Sizes } from '@/types/interfaces'
 import { getAssigneeId, getUserIds, UserIdsType } from '@/utils/assignee'
 import { isTaskCompleted } from '@/utils/isTaskCompleted'
 import { NoAssignee } from '@/utils/noAssignee'
-import { Box, Skeleton, Stack, styled, Typography } from '@mui/material'
+import { Box, Skeleton, Stack, styled } from '@mui/material'
 import { useEffect, useState } from 'react'
 import { useSelector } from 'react-redux'
 import { UrlObject } from 'url'
 
 import { updateTask } from '@/app/(home)/actions'
 import { clientUpdateTask, updateAssignee, updateTaskDetail } from '@/app/detail/[task_id]/[user_type]/actions'
-import { CopilotTooltip } from '@/components/atoms/CopilotTooltip'
+import { TaskCardList } from '@/app/detail/ui/TaskCardList'
 import { TaskMetaItems } from '@/components/atoms/TaskMetaItems'
+import TaskTitle from '@/components/atoms/TaskTitle'
 import { CopilotPopSelector } from '@/components/inputs/CopilotSelector'
 import { DatePickerComponent } from '@/components/inputs/DatePickerComponent'
+import { CustomLink } from '@/hoc/CustomLink'
 import { DateStringSchema } from '@/types/date'
 import { createDateFromFormattedDateString, formatDate } from '@/utils/dateHelper'
+import { getCardHref } from '@/utils/getCardHref'
 import { getSelectedUserIds, getSelectorAssignee, getSelectorAssigneeFromTask } from '@/utils/selector'
 import { shouldConfirmBeforeReassignment } from '@/utils/shouldConfirmBeforeReassign'
 import z from 'zod'
-import { TaskCardList } from '@/app/detail/ui/TaskCardList'
-import { CustomLink } from '@/hoc/CustomLink'
-import { getCardHref } from '@/utils/getCardHref'
-import { sortTaskByDescendingOrder } from '@/utils/sortTask'
 
 const TaskCardContainer = styled(Stack)(({ theme }) => ({
   border: `1px solid ${theme.color.borders.border}`,
@@ -151,19 +150,7 @@ export const TaskCard = ({ task, href, workflowState, mode, subtasks }: TaskCard
           </Box>
           <Stack direction="column" justifyContent="center" rowGap={'5px'} sx={{ width: '100%' }}>
             <Stack direction={'row'} columnGap={'10px'} justifyContent={'space-between'}>
-              <Typography
-                variant="bodyMd"
-                sx={{
-                  color: (theme) => theme.color.gray[600],
-                  display: '-webkit-box',
-                  WebkitLineClamp: 2,
-                  WebkitBoxOrient: 'vertical',
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                }}
-              >
-                {task.title}
-              </Typography>
+              <TaskTitle title={task.title ?? ''} variant="board" />
 
               {assigneeValue ? (
                 <CopilotPopSelector

--- a/src/components/inputs/CopilotSelector.tsx
+++ b/src/components/inputs/CopilotSelector.tsx
@@ -144,7 +144,6 @@ export const CopilotPopSelector = ({
           <CopilotTooltip
             content={tooltipProps?.content ?? 'Change assignee'}
             disabled={tooltipProps?.disabled || variant == 'normal'}
-            placement={tooltipProps?.placement}
             position={tooltipProps?.position}
           >
             <>{buttonContent}</>

--- a/src/components/inputs/DatePickerComponent.tsx
+++ b/src/components/inputs/DatePickerComponent.tsx
@@ -143,12 +143,7 @@ export const DatePickerComponent = ({
           </>
         ) : (
           // Right now Tooltip support is applied to the icon variant only
-          <CopilotTooltip
-            content={'Change due date'}
-            disabled={tooltipProps?.disabled}
-            placement={tooltipProps?.placement}
-            position={tooltipProps?.position}
-          >
+          <CopilotTooltip content={'Change due date'} disabled={tooltipProps?.disabled} position={tooltipProps?.position}>
             <Box
               sx={{
                 padding: padding,

--- a/src/components/inputs/Selector-WorkflowState.tsx
+++ b/src/components/inputs/Selector-WorkflowState.tsx
@@ -121,12 +121,7 @@ export const WorkflowStateSelector = ({
             />
           ) : (
             // Right now Tooltip support is applied to the icon variant only
-            <CopilotTooltip
-              content={'Change status'}
-              disabled={tooltipProps?.disabled}
-              placement={tooltipProps?.placement}
-              position={tooltipProps?.position}
-            >
+            <CopilotTooltip content={'Change status'} disabled={tooltipProps?.disabled} position={tooltipProps?.position}>
               <Box
                 sx={{
                   padding: padding,


### PR DESCRIPTION
## Changes

- [x] Added a mechanism not to show tooltips instantly. After 500 ms on hover, tooltips will be shown.
- [x] Added a mechanism to instantly remove tooltip if hovered out.
- [x] Added tooltips on hover for tasks with long name.
- [x] Tooltips on subtasks components.
- [x] tooltips disabled on mobile.
- [x] added tootltip when hovering over task count to show the number of tasks
- [x] added design changes fix on tooltip

## Testing Criteria

-[LOOM](https://www.loom.com/share/618d323f2c954256ad26d8dcdf4052d6)

<img width="305" height="154" alt="image" src="https://github.com/user-attachments/assets/001c4543-3159-4a5c-acc6-05b8b1561a11" />
<img width="406" height="188" alt="image" src="https://github.com/user-attachments/assets/cbe4626e-72ce-431a-b9f5-f62d2b9af543" />
<img width="386" height="134" alt="image" src="https://github.com/user-attachments/assets/70a635fa-a665-45af-ab04-6a1dfb10dd9d" />



