### PR TITLE
OUT-2233 | Removing/switching assignee requires too many clicks

### DIFF
--- a/src/components/inputs/CopilotSelector.tsx
+++ b/src/components/inputs/CopilotSelector.tsx
@@ -36,6 +36,7 @@ export const CopilotSelector = ({
     <>
       <StyledUserCompanySelector
         openMenuOnFocus
+        menuIsOpen={true}
         autoFocus
         placeholder={'Set assignee'}
         initialValue={initialAssignee}


### PR DESCRIPTION
## Changes

- [x] Use `menuIsOpen` prop to pin the menu to always be open while popper is open in all instances where the selector is used

## Testing Criteria

- [x] Screencast

https://github.com/user-attachments/assets/a258522b-ddb9-4492-b03c-782f61202a95

