### PR TITLE
OUT-2219, OUT-2220 | Update copy on Task Details to match "Set Assignee"

### DIFF
--- a/src/app/detail/ui/Sidebar.tsx
+++ b/src/app/detail/ui/Sidebar.tsx
@@ -204,7 +204,7 @@ export const Sidebar = ({
                       maxWidth: '150px',
                     }}
                   >
-                    {assigneeValue?.name == 'No assignee' ? 'Unassigned' : getAssigneeName(assigneeValue, 'Unassigned')}
+                    {assigneeValue?.name == 'No assignee' ? 'Set assignee' : getAssigneeName(assigneeValue, 'Set assignee')}
                   </Typography>
                 }
               />
@@ -349,7 +349,9 @@ export const Sidebar = ({
                           maxWidth: '150px',
                         }}
                       >
-                        {assigneeValue?.name == 'No assignee' ? 'Unassigned' : getAssigneeName(assigneeValue, 'Unassigned')}
+                        {assigneeValue?.name == 'No assignee'
+                          ? 'Set assignee'
+                          : getAssigneeName(assigneeValue, 'Set assignee')}
                       </Typography>
                     }
                   />

--- a/src/app/detail/ui/TaskCardList.tsx
+++ b/src/app/detail/ui/TaskCardList.tsx
@@ -184,7 +184,7 @@ export const TaskCardList = ({ task, variant, workflowState, mode, handleUpdate,
           }}
           responsiveNoHide
           size={Sizes.MEDIUM}
-          padding={'2px 4px'}
+          padding={'4px'}
           hoverColor={200}
           tooltipProps={{
             disabled: tooltipDisabled,


### PR DESCRIPTION
## Changes

- [x] button size of workflowselector buttons on list view task card fixed.
- [x] unassigned keyword changed to Set Assignee on sidebar in the details page.

## Testing Criteria

<img width="515" height="295" alt="image" src="https://github.com/user-attachments/assets/426a133e-3ed4-48ee-9677-04b843c587e4" />
<img width="349" height="279" alt="image" src="https://github.com/user-attachments/assets/06fd5375-b8a9-4a56-b0db-d80ac61392ae" />
<img width="405" height="220" alt="image" src="https://github.com/user-attachments/assets/0eb3ff88-d937-4765-ad97-667d71e3ff6b" />
