### PR TITLE
OUT-2213, OUT-2214, OUT-2215 | Increase width of cards from 304px to 336px

### DIFF
--- a/src/app/detail/ui/TaskCardList.tsx
+++ b/src/app/detail/ui/TaskCardList.tsx
@@ -228,7 +228,8 @@ export const TaskCardList = ({ task, variant, workflowState, mode, handleUpdate,
             style={{
               display: 'flex',
               gap: '2px',
-
+              minWidth: 0,
+              flexShrink: 1,
               width: '100%',
             }}
           >
@@ -238,6 +239,8 @@ export const TaskCardList = ({ task, variant, workflowState, mode, handleUpdate,
                 gap: '8px',
                 display: 'flex',
                 alignItems: 'center',
+                minWidth: 0,
+                flexShrink: 1,
               }}
             >
               <TaskTitle variant="list" title={task.title} />

--- a/src/components/atoms/CopilotTooltip.tsx
+++ b/src/components/atoms/CopilotTooltip.tsx
@@ -45,6 +45,9 @@ export const CopilotTooltip = ({
       disabled={disabled || isMobileScreen}
     >
       <span
+        style={{
+          display: 'flex',
+        }}
         onMouseEnter={(e) => {
           handlePosition(e.currentTarget)
           timer.current = setTimeout(() => setOpen(true), 500)

--- a/src/components/atoms/TaskTitle.tsx
+++ b/src/components/atoms/TaskTitle.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useEffect, useState } from 'react'
-import { Typography } from '@mui/material'
+import { Box, Typography } from '@mui/material'
 import { CopilotTooltip } from './CopilotTooltip'
 
 interface TaskTitleProps {
@@ -42,12 +42,12 @@ const TaskTitle = ({ title, variant = 'board' }: TaskTitleProps) => {
         sx={{
           lineHeight: variant == 'list' ? '22px' : '21px',
           fontSize: variant == 'list' ? '14px' : '13px',
-          display: '-webkit-box',
-          WebkitBoxOrient: 'vertical',
-          WebkitLineClamp: 1,
           overflow: 'hidden',
           textOverflow: 'ellipsis',
-          width: '100%',
+          whiteSpace: 'nowrap',
+          flexShrink: 1,
+          flexGrow: 0,
+          minWidth: 0,
         }}
       >
         {title}
@@ -55,9 +55,11 @@ const TaskTitle = ({ title, variant = 'board' }: TaskTitleProps) => {
     )
 
   return isOverflowing ? (
-    <CopilotTooltip content={title} allowMaxWidth={true}>
-      {typographyComponent}
-    </CopilotTooltip>
+    <Box sx={{ flexShrink: 1, minWidth: 0, overflow: 'hidden' }}>
+      <CopilotTooltip content={title} allowMaxWidth={true}>
+        {typographyComponent}
+      </CopilotTooltip>
+    </Box>
   ) : (
     typographyComponent
   )

--- a/src/components/cards/TaskCard.tsx
+++ b/src/components/cards/TaskCard.tsx
@@ -55,7 +55,7 @@ const TaskCardContainer = styled(Stack)(({ theme }) => ({
     outline: 'none',
   },
   cursor: 'pointer',
-  width: '304px',
+  width: '336px',
 }))
 
 interface TaskCardProps {

--- a/src/components/cards/TaskColumn.tsx
+++ b/src/components/cards/TaskColumn.tsx
@@ -11,11 +11,11 @@ const TaskColumnHeader = styled(Stack)({
   justifyContent: 'space-between',
   alignItems: 'center',
   paddingBottom: '8px',
-  width: '304px',
+  width: '336px',
 })
 
 const TaskColumnContainer = styled(Stack)<{ showHeader?: boolean }>(({ showHeader }) => ({
-  width: '316px',
+  width: '348px',
   height: `calc(100vh - ${showHeader ? '195px' : '145px'})`,
   marginTop: '6px',
   justifyContent: 'space-between',

--- a/src/components/layouts/DueDateLayout.tsx
+++ b/src/components/layouts/DueDateLayout.tsx
@@ -28,7 +28,10 @@ export const DueDateLayout = ({ dateString, isDone, variant = 'long', isClient =
 
   const isPast = now.isAfter(dateString)
   return (
-    <Typography variant="bodySm" sx={{ color: (theme) => (isPast && !isDone ? theme.color.error : theme.color.gray[500]) }}>
+    <Typography
+      variant="bodySm"
+      sx={{ color: (theme) => (isPast && !isDone ? theme.color.red[200] : theme.color.gray[500]) }}
+    >
       {formattedDueDate}
     </Typography>
   )

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -88,6 +88,9 @@ export const theme = createTheme({
       bgCommentDrag: '#E6F0FF',
       avatarBackground: '#E8EBF1',
     },
+    red: {
+      200: '#991A00',
+    },
     error: '#CC0000',
     muiError: '#D32F2F',
   },

--- a/src/types/theme.d.ts
+++ b/src/types/theme.d.ts
@@ -86,6 +86,9 @@ export declare module '@mui/material/styles' {
         bgCommentDrag: string
         avatarBackground: string
       }
+      red: {
+        200: string
+      }
       error: string
       muiError: string
     }
@@ -174,6 +177,9 @@ export declare module '@mui/material/styles' {
         bgHover: React.CSSProperties['color']
         bgCommentDrag: React.CSSProperties['color']
         avatarBackground: React.CSSProperties['color']
+      }
+      red: {
+        200: React.CSSProperties['color']
       }
       error: React.CSSProperties['color']
       muiError: React.CSSProperties['color']


### PR DESCRIPTION
## Changes

- [x] updated the color for overdue task from error to red-200.
- [x] task card in board's width increased to 336px. Likewise, task column width increased to 348px to maintain padding.
- [x] Solved issue of task name getting cut of way too early. ellipsis design change for list view cards. Maintained proper flex shrink, padding between task title, meta items, due date and assignee in task card list.

## Testing Criteria
<img width="354" height="569" alt="image" src="https://github.com/user-attachments/assets/e7d7be48-bf83-4f90-b392-30acc99aa76f" />
<img width="403" height="306" alt="image" src="https://github.com/user-attachments/assets/8a21f07d-1aee-44f0-8480-cc01a71a92cc" />
<img width="447" height="388" alt="image" src="https://github.com/user-attachments/assets/0e38f568-bd81-41e9-81ae-75e18de7ae9b" />
