### PR TITLE
OUT-2250 | ViewSettings, display drawer is buggy

### DIFF
--- a/src/components/layouts/FilterBar.tsx
+++ b/src/components/layouts/FilterBar.tsx
@@ -59,6 +59,7 @@ export const FilterBar = ({ mode, updateViewModeSetting }: FilterBarProps) => {
         filterOptions: { ...updatedFilterOptions, [optionType]: newValue },
         showArchived: showArchived,
         showUnarchived: showUnarchived,
+        showSubtasks: showSubtasks,
       }),
     )
     updateViewModeSetting({
@@ -69,6 +70,7 @@ export const FilterBar = ({ mode, updateViewModeSetting }: FilterBarProps) => {
       },
       showArchived: showArchived,
       showUnarchived: showUnarchived,
+      showSubtasks: showSubtasks,
     })
   }
 
@@ -352,6 +354,7 @@ export const FilterBar = ({ mode, updateViewModeSetting }: FilterBarProps) => {
                       filterOptions: filterOptions,
                       showArchived: showArchived,
                       showUnarchived: showUnarchived,
+                      showSubtasks: showSubtasks,
                     }),
                   )
                   updateViewModeSetting({
@@ -359,6 +362,7 @@ export const FilterBar = ({ mode, updateViewModeSetting }: FilterBarProps) => {
                     filterOptions: filterOptions,
                     showArchived: showArchived,
                     showUnarchived: showUnarchived,
+                    showSubtasks: showSubtasks,
                   })
                   store.dispatch(
                     setViewSettingsTemp({
@@ -366,6 +370,7 @@ export const FilterBar = ({ mode, updateViewModeSetting }: FilterBarProps) => {
                       filterOptions: viewModeFilterOptions,
                       showArchived: showArchived,
                       showUnarchived: showUnarchived,
+                      showSubtasks: showSubtasks,
                     }),
                   )
                 }}

--- a/src/hoc/ClientSideStateUpdate.tsx
+++ b/src/hoc/ClientSideStateUpdate.tsx
@@ -80,7 +80,7 @@ export const ClientSideStateUpdate = ({
     }
 
     if (viewSettings) {
-      const viewSettingsCopy = structuredClone(viewSettings) //deep cloning for immutability and prevent the reducer mutating the original object.
+      const viewSettingsCopy = viewSettingsTemp ? structuredClone(viewSettingsTemp) : structuredClone(viewSettings) //deep cloning for immutability and prevent the reducer mutating the original object.
       store.dispatch(setViewSettings(viewSettingsCopy))
       const view = viewSettingsTemp ? viewSettingsTemp.filterOptions : viewSettingsCopy.filterOptions
       store.dispatch(setFilteredAssigneeList({ filteredType: filterOptionsMap[view?.type] || filterOptionsMap.default }))


### PR DESCRIPTION
## Changes

- [x] viewSetting resetting on route change due to cached response. need to investigate more on this but this solves the problem for now.

## Testing Criteria

- [LOOM](https://www.loom.com/share/8aa577ef993241ac9416f327512e30a0)


