### PR TITLE
OUT-2298 | Comment notifications on email not working

### DIFF
--- a/src/app/api/notification/notification.service.ts
+++ b/src/app/api/notification/notification.service.ts
@@ -17,8 +17,16 @@ import { AssigneeType, ClientNotification, Task } from '@prisma/client'
 import Bottleneck from 'bottleneck'
 import httpStatus from 'http-status'
 import { z } from 'zod'
+import User from '@api/core/models/User.model'
 
 export class NotificationService extends BaseService {
+  public isComment: boolean
+
+  constructor(user: User, isComment: boolean = false) {
+    super(user)
+    this.isComment = isComment
+  }
+
   async create(
     action: NotificationTaskActions,
     task: Task,
@@ -36,7 +44,7 @@ export class NotificationService extends BaseService {
             where: { taskId: task.id, clientId: task.clientId, companyId: task.companyId },
           })
         : null
-      if (task.clientId && existingNotification) {
+      if (task.clientId && existingNotification && !this.isComment) {
         console.error(`NotificationService#create | Found existing notification for ${task.clientId}`, existingNotification)
         return
       }
@@ -153,7 +161,7 @@ export class NotificationService extends BaseService {
         try {
           // 1.Check for existing notification. Skip if duplicate
           const existingNotification = existingNotifications.find((notification) => notification.clientId === recipientId)
-          if (existingNotification) {
+          if (existingNotification && !this.isComment) {
             console.error(
               `NotificationService#bulkCreate | Found existing notification for ${recipientId}`,
               existingNotification,

--- a/src/app/api/notification/notification.service.ts
+++ b/src/app/api/notification/notification.service.ts
@@ -17,16 +17,8 @@ import { AssigneeType, ClientNotification, Task } from '@prisma/client'
 import Bottleneck from 'bottleneck'
 import httpStatus from 'http-status'
 import { z } from 'zod'
-import User from '@api/core/models/User.model'
 
 export class NotificationService extends BaseService {
-  public isComment: boolean
-
-  constructor(user: User, isComment: boolean = false) {
-    super(user)
-    this.isComment = isComment
-  }
-
   async create(
     action: NotificationTaskActions,
     task: Task,
@@ -44,7 +36,7 @@ export class NotificationService extends BaseService {
             where: { taskId: task.id, clientId: task.clientId, companyId: task.companyId },
           })
         : null
-      if (task.clientId && existingNotification && !this.isComment) {
+      if (task.clientId && existingNotification && !opts.commentId) {
         console.error(`NotificationService#create | Found existing notification for ${task.clientId}`, existingNotification)
         return
       }
@@ -161,7 +153,7 @@ export class NotificationService extends BaseService {
         try {
           // 1.Check for existing notification. Skip if duplicate
           const existingNotification = existingNotifications.find((notification) => notification.clientId === recipientId)
-          if (existingNotification && !this.isComment) {
+          if (existingNotification && !opts?.commentId) {
             console.error(
               `NotificationService#bulkCreate | Found existing notification for ${recipientId}`,
               existingNotification,

--- a/src/jobs/notifications/send-comment-create-notifications.ts
+++ b/src/jobs/notifications/send-comment-create-notifications.ts
@@ -26,7 +26,7 @@ export const sendCommentCreateNotifications = task({
     // If task is unassigned, there's nobody to send notifications to
     if (!task.assigneeId || !task.assigneeType) return
 
-    const commentNotificationService = new NotificationService(user)
+    const commentNotificationService = new NotificationService(user, true)
     const copilot = new CopilotAPI(user.token)
     const { recipientIds: clientRecipientIds } = await commentNotificationService.getNotificationParties(
       copilot,

--- a/src/jobs/notifications/send-comment-create-notifications.ts
+++ b/src/jobs/notifications/send-comment-create-notifications.ts
@@ -26,7 +26,7 @@ export const sendCommentCreateNotifications = task({
     // If task is unassigned, there's nobody to send notifications to
     if (!task.assigneeId || !task.assigneeType) return
 
-    const commentNotificationService = new NotificationService(user, true)
+    const commentNotificationService = new NotificationService(user)
     const copilot = new CopilotAPI(user.token)
     const { recipientIds: clientRecipientIds } = await commentNotificationService.getNotificationParties(
       copilot,


### PR DESCRIPTION
## Changes

- a check for preventing duplicate notifications on clientNotificationsTable which is not at all associated with commentId was preventing sending the notifications.
- [x] added a isComment property while construction NotificationService with default false and prevented the check if the value of isComment is true. Passed isComment true from comment notification service.

## Testing Criteria

<img width="1046" height="670" alt="image" src="https://github.com/user-attachments/assets/15d8512a-d2bd-4ee2-8e0c-ed2e8a782429" />

