### PR TITLE
fix: catch failed view settings re

### DIFF
--- a/src/app/ui/TaskBoard.tsx
+++ b/src/app/ui/TaskBoard.tsx
@@ -118,7 +118,11 @@ export const TaskBoard = ({ mode, workspace, token }: TaskBoardProps) => {
       <FilterBar
         mode={mode}
         updateViewModeSetting={async (payload: CreateViewSettingsDTO) => {
-          await updateViewModeSettings(z.string().parse(token), payload)
+          try {
+            await updateViewModeSettings(z.string().parse(token), payload)
+          } catch (error) {
+            console.error('view settings update error', error)
+          }
         }}
       />
 


### PR DESCRIPTION
## Changes

- [X] add try/catch around update view settings 

## Testing Criteria

- [ ] skipped for simple error catching

## Re from https://github.com/copilot-platforms/tasks-app/pull/949

## Notes

- we observed intermittent errors on the tasks app right after onboarding. The logs in vercel show a 200 for the server response but a failed on view-settings being created. This likely throws a client side unresolved exception which caused this error.

![Screenshot 2025-09-03 at 2.11.20 PM.png](https://app.graphite.dev/user-attachments/assets/39cc381d-a793-427c-81a2-54bd8dfac7b4.png)

UTC timestamp: `Sep 3, 2025, 5:52:52.196 PM`

Error Log:
```
PrismaClientKnownRequestError: 
Invalid `prisma.viewSetting.create()` invocation:


Unique constraint failed on the fields: (`userId`,`workspaceId`)
    at $n.handleRequestError (/var/task/node_modules/@prisma/client/runtime/library.js:121:7315)
    at $n.handleAndLogRequestError (/var/task/node_modules/@prisma/client/runtime/library.js:121:6623)
    at $n.request (/var/task/node_modules/@prisma/client/runtime/library.js:121:6307)
    at async l (/var/task/node_modules/@prisma/client/runtime/library.js:130:9633)
    at async z.createInitialViewSettings (/var/task/.next/server/app/api/view-settings/route.js:1:3462)
    at async z.getViewSettingsForUser (/var/task/.next/server/app/api/view-settings/route.js:1:2961)
    at async v (/var/task/.next/server/app/api/view-settings/route.js:1:4312)
    at async /var/task/.next/server/app/api/notification/validate-count/route.js:11:3543
    at async /var/task/.next/server/chunks/7839.js:20:60899
    at async /var/task/node_modules/next/dist/compiled/next-server/app-route.runtime.prod.js:6:38411 {
  code: 'P2002',
  clientVersion: '5.22.0',
  meta: { modelName: 'ViewSetting', target: [ 'userId', 'workspaceId' ] }
}
```

## Impact & Surface Area of Change

- N/A
