### PR TITLE
OUT-2263 | Change GET endpoints on tasks allowing clients to access visible tasks.

### DIFF
--- a/src/app/client/page.tsx
+++ b/src/app/client/page.tsx
@@ -37,10 +37,7 @@ async function getAllWorkflowStates(token: string): Promise<WorkflowStateRespons
 }
 
 async function getAllTasks(token: string): Promise<TaskResponse[]> {
-  const res = await fetch(`${apiUrl}/api/tasks?token=${token}`, {
-    next: { tags: ['getAllTasks-client'] },
-  })
-
+  const res = await fetch(`${apiUrl}/api/tasks?token=${token}`)
   const data = await res.json()
   return data.tasks
 }


### PR DESCRIPTION
## Changes

- in getAllTasks service for clients, we have 2 filters : getDisjointTaskFilters and getClientOrCompanyAssigneeFilter.
- [x] changed the logic in getClientOrCompanyAssigneeFilter to let client access tasks which mark them as a viewer in viewer property of in the task row. Before only those tasks assigned to the clientId and their companyId was allowed for clients.
- [x] changed the logic in getDisjointTasksFilter to show subtasks in client board if parent task is not accessible. Also, to hide the subtasks from client board if the parent task is accessible through assignment or client visibility.

## Testing Criteria

- Coming soon...


