### PR TITLE
OUT-2317: fill up the task creation form even if no client Id and show error message (deeplink)

### DIFF
--- a/src/app/ui/NewTaskForm.tsx
+++ b/src/app/ui/NewTaskForm.tsx
@@ -129,23 +129,23 @@ export const NewTaskForm = ({ handleCreate, handleClose }: NewTaskFormProps) => 
 
         if (!assigneeVal) {
           setErrorMessage('Assignee not found')
-          return
-        }
-
-        if (Array.isArray(assigneeVal.companyIds) && assigneeVal.companyIds.length === 1) {
-          payload.companyId = assigneeVal.companyIds[0]
-        } else if (
-          assigneeVal.companyId &&
-          (!assigneeVal.companyIds || (Array.isArray(assigneeVal.companyIds) && !assigneeVal.companyIds.length))
-        ) {
-          payload.companyId = assigneeVal.companyId
-        } else if (Array.isArray(assigneeVal?.companyIds)) {
-          // If client has multiple companies, set error
           delete payload.clientId
-          setErrorMessage('companyId must be provided for clients with more than one company')
         } else {
-          delete payload.clientId
-          setErrorMessage('companyId must be provided when clientId is provided')
+          if (Array.isArray(assigneeVal.companyIds) && assigneeVal.companyIds.length === 1) {
+            payload.companyId = assigneeVal.companyIds[0]
+          } else if (
+            assigneeVal.companyId &&
+            (!assigneeVal.companyIds || (Array.isArray(assigneeVal.companyIds) && !assigneeVal.companyIds.length))
+          ) {
+            payload.companyId = assigneeVal.companyId
+          } else if (Array.isArray(assigneeVal?.companyIds)) {
+            // If client has multiple companies, set error
+            delete payload.clientId
+            setErrorMessage('companyId must be provided for clients with more than one company')
+          } else {
+            delete payload.clientId
+            setErrorMessage('companyId must be provided when clientId is provided')
+          }
         }
       }
       const parsedPayload = await publicTaskCreateDtoSchemaFactory(token, true).parseAsync({


### PR DESCRIPTION
## Changes

- [X] check if clientId matches assignee list and if not, show error message
- [X] task create form will still be prefilled

## Testing Criteria

<img width="785" height="528" alt="image" src="https://github.com/user-attachments/assets/76c8f453-1e33-41ef-9090-3bf9bd4578ab" />
