### PR TITLE
OUT-2318 | OUT-2323: revoke permission to change task status by viewer 

### DIFF
--- a/src/app/detail/[task_id]/[user_type]/page.tsx
+++ b/src/app/detail/[task_id]/[user_type]/page.tsx
@@ -109,6 +109,15 @@ export default async function TaskDetailPage({
     href: `/detail/${id}/${user_type}?token=${token}`,
   }))
 
+  // flag that determines if the current user is the task viewer
+  const isViewer =
+    Array.isArray(task.viewers) &&
+    task.viewers.length > 0 &&
+    (!task.viewers[0].clientId || task.viewers[0].clientId === tokenPayload.clientId) &&
+    task.viewers[0].companyId === tokenPayload.companyId
+      ? true
+      : false
+
   return (
     <DetailStateUpdate
       isRedirect={!!searchParams.isRedirect}
@@ -227,6 +236,7 @@ export default async function TaskDetailPage({
                 await updateTaskDetail({ token, taskId: task_id, payload })
               }}
               disabled={params.user_type === UserType.CLIENT_USER}
+              workflowDisabled={isViewer}
             />
           </Box>
         </ResponsiveStack>

--- a/src/app/detail/ui/Sidebar.tsx
+++ b/src/app/detail/ui/Sidebar.tsx
@@ -47,7 +47,7 @@ export const Sidebar = ({
   updateAssignee,
   updateTask,
   disabled,
-  workflowDisabled,
+  workflowDisabled = false,
   userType,
   portalUrl,
 }: {
@@ -58,7 +58,7 @@ export const Sidebar = ({
   updateAssignee: (userIds: UserIdsWithViewersType) => void
   updateTask: (payload: UpdateTaskRequest) => void
   disabled: boolean
-  workflowDisabled?: false
+  workflowDisabled?: boolean
   userType: UserType
   portalUrl?: string
 }) => {
@@ -368,7 +368,7 @@ export const Sidebar = ({
             <Box
               sx={{
                 ':hover': {
-                  bgcolor: (theme) => theme.color.background.bgCallout,
+                  bgcolor: (theme) => (!!workflowDisabled ? '' : theme.color.background.bgCallout),
                 },
                 padding: '4px',
                 borderRadius: '4px',

--- a/src/components/buttons/SelectorButton.tsx
+++ b/src/components/buttons/SelectorButton.tsx
@@ -64,6 +64,7 @@ export const SelectorButton = ({
           marginRight: '6px',
         },
         height: height ?? '32px',
+        minWidth: 'auto',
       })}
       onClick={handleClick}
       disableRipple

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -150,6 +150,7 @@ export interface IAssigneeCombined {
   email?: string
   type: AssigneeType
   companyId?: string
+  companyIds?: string[]
   status?: string
   avatarImageUrl?: string
   customFields?: unknown

--- a/src/utils/selector.ts
+++ b/src/utils/selector.ts
@@ -60,7 +60,11 @@ export const getSelectorAssigneeFromTask = (assignee: IAssigneeCombined[], task:
 
 export const getSelectorViewerFromTask = (assignee: IAssigneeCombined[], task: TaskResponse) => {
   if (!task) return undefined
-  return assignee.find((assignee) => task?.viewers?.[0]?.clientId == assignee.id)
+  return assignee.find(
+    (assignee) =>
+      (task.viewers?.[0]?.clientId == assignee.id && task.viewers?.[0]?.companyId == assignee.companyId) ||
+      task.viewers?.[0]?.companyId == assignee.id,
+  )
 }
 
 export const getSelectorAssigneeFromFilterOptions = (
@@ -78,7 +82,10 @@ export const getSelectorAssigneeFromFilterOptions = (
 } //util to get initial assignee from filterOptions for selector.
 
 export const getSelectedViewerIds = (inputValue: InputValue[]): Viewers => {
-  if (!inputValue?.length || inputValue[0].object !== UserRole.Client) return [] // when no user is selected.
+  if (!inputValue?.length || inputValue[0].object === UserRole.IU) return [] // when no user is selected.
 
-  return [{ clientId: inputValue[0].id, companyId: z.string().parse(inputValue[0].companyId) }] // currently id of single client id
+  if (inputValue[0].object === UserRole.Client)
+    return [{ clientId: inputValue[0].id, companyId: z.string().parse(inputValue[0].companyId) }] // currently id of single client id
+
+  return [{ companyId: inputValue[0].id }]
 }


### PR DESCRIPTION
## Changes

- [X] FE implement to disable workflow status dropdown
- [X] fix: allow company as viewer
- [X] minor UI fix for sidebar client visibility
- [X] flag is passed to control viewers filter. We dont want to retrieve task for update when the current user is viewer
- [X] fix: make tasks visible to client when the client's company is provided with visibility

## Testing Criteria

[Loom](https://www.loom.com/share/cad71f05e2de40f8a7b48305c816c709?sid=80013a08-cf75-4cee-986d-88176e9aaf4f)