### PR TITLE
OUT-2331: Filter by type changes in CU view

### DIFF
--- a/src/components/buttonsGroup/FilterButtonsGroup.tsx
+++ b/src/components/buttonsGroup/FilterButtonsGroup.tsx
@@ -1,6 +1,4 @@
 import { Stack, Typography } from '@mui/material'
-import { SecondaryBtn } from '@/components/buttons/SecondaryBtn'
-import { ReactNode } from 'react'
 import { TertiaryBtn } from '../buttons/TertiaryBtn'
 
 export type FilterButtons = {
@@ -9,13 +7,12 @@ export type FilterButtons = {
   onClick: (index: number) => void
 }
 
-const FilterButtonGroup = ({
-  filterButtons,
-  activeButtonIndex,
-}: {
+type FilterButtonGroupProps = {
   filterButtons: FilterButtons[]
   activeButtonIndex: number | undefined
-}) => {
+}
+
+const FilterButtonGroup = ({ filterButtons, activeButtonIndex }: FilterButtonGroupProps) => {
   return (
     <Stack
       sx={(theme) => ({

--- a/src/components/layouts/FilterBar.tsx
+++ b/src/components/layouts/FilterBar.tsx
@@ -80,8 +80,6 @@ export const FilterBar = ({ mode, updateViewModeSetting }: FilterBarProps) => {
       ? (filterTypeToButtonIndexMap[viewModeFilterOptions.type] ?? 0)
       : (clientFilterTypeToButtonIndexMap[viewModeFilterOptions.type] ?? 0)
 
-  const [noAssigneOptionFlag, setNoAssigneeOptionFlag] = useState<boolean>(true)
-
   const { tokenPayload, workspace } = useSelector(selectAuthDetails)
 
   const [assigneeValue, setAssigneeValue] = useState(
@@ -102,67 +100,42 @@ export const FilterBar = ({ mode, updateViewModeSetting }: FilterBarProps) => {
     store.dispatch(setViewSettingsTemp(newViewSettings))
   }
 
-  /**
-   * Filters button functions start
-   */
-  const handleMyTasksClickForIU = () => {
-    const selfAssigneeId = IUTokenSchema.parse(tokenPayload).internalUserId
-    handleFilterOptionsChange(FilterOptions.TYPE, selfAssigneeId)
-    setAssigneeValue(undefined)
-    handleFilterOptionsChange(FilterOptions.ASSIGNEE, emptyAssignee)
-  }
+  // handles click on filter by type buttons
+  const handleFilterTypeClick = ({
+    emptyAssigneeFlag = true,
+    filterTypeValue,
+  }: {
+    emptyAssigneeFlag?: boolean
+    filterTypeValue: string | null | UserIdsType
+  }) => {
+    let filterValue = filterTypeValue
+    handleFilterOptionsChange(FilterOptions.TYPE, filterValue)
 
-  const handleTeamTasksClickForIU = () => {
-    handleFilterOptionsChange(FilterOptions.TYPE, FilterOptionsKeywords.TEAM)
-    setAssigneeValue(undefined)
-    setNoAssigneeOptionFlag(false)
-    handleFilterOptionsChange(FilterOptions.ASSIGNEE, emptyAssignee)
+    if (emptyAssigneeFlag) {
+      setAssigneeValue(undefined)
+      handleFilterOptionsChange(FilterOptions.ASSIGNEE, emptyAssignee)
+    }
   }
-
-  const handleClientTasksClickForIU = () => {
-    handleFilterOptionsChange(FilterOptions.TYPE, FilterOptionsKeywords.CLIENTS)
-    setAssigneeValue(undefined)
-    setNoAssigneeOptionFlag(false)
-    handleFilterOptionsChange(FilterOptions.ASSIGNEE, emptyAssignee)
-  }
-
-  const handleAllTasksClickForIU = () => {
-    handleFilterOptionsChange(FilterOptions.TYPE, '')
-    setAssigneeValue(undefined)
-    setNoAssigneeOptionFlag(true)
-    handleFilterOptionsChange(FilterOptions.ASSIGNEE, emptyAssignee)
-  }
-
-  const handleMyTasksClickForClient = () => {
-    handleFilterOptionsChange(FilterOptions.TYPE, FilterOptionsKeywords.CLIENTS)
-  }
-
-  const handleAllTasksClickForClient = () => {
-    handleFilterOptionsChange(FilterOptions.TYPE, FilterOptionsKeywords.CLIENT_WITH_VIEWERS)
-  }
-  /**
-   * Filter button functions end
-   */
 
   const IuFilterButtons = [
     {
       name: 'My tasks',
-      onClick: handleMyTasksClickForIU,
+      onClick: () => handleFilterTypeClick({ filterTypeValue: IUTokenSchema.parse(tokenPayload).internalUserId }),
       id: 'MyTasks',
     },
     {
       name: "My team's tasks",
-      onClick: handleTeamTasksClickForIU,
+      onClick: () => handleFilterTypeClick({ filterTypeValue: FilterOptionsKeywords.TEAM }),
       id: 'TeamTasks',
     },
     {
       name: `${getWorkspaceLabels(workspace, true).individualTerm} tasks`,
-      onClick: handleClientTasksClickForIU,
+      onClick: () => handleFilterTypeClick({ filterTypeValue: FilterOptionsKeywords.CLIENTS }),
       id: 'ClientTasks',
     },
     {
       name: 'All tasks',
-      onClick: handleAllTasksClickForIU,
+      onClick: () => handleFilterTypeClick({ filterTypeValue: '' }),
       id: 'AllTasks',
     },
   ]
@@ -170,12 +143,13 @@ export const FilterBar = ({ mode, updateViewModeSetting }: FilterBarProps) => {
   const CuFilterButtons = [
     {
       name: 'All tasks',
-      onClick: handleAllTasksClickForClient,
+      onClick: () =>
+        handleFilterTypeClick({ filterTypeValue: FilterOptionsKeywords.CLIENT_WITH_VIEWERS, emptyAssigneeFlag: false }),
       id: 'AllTasks',
     },
     {
       name: 'My tasks',
-      onClick: handleMyTasksClickForClient,
+      onClick: () => handleFilterTypeClick({ filterTypeValue: FilterOptionsKeywords.CLIENTS, emptyAssigneeFlag: false }),
       id: 'MyTasks',
     },
   ]

--- a/src/hooks/useFilter.tsx
+++ b/src/hooks/useFilter.tsx
@@ -87,10 +87,15 @@ function filterByType(filteredTasks: TaskResponse[], filterValue: string): TaskR
   filteredTasks = assigneeType.includes('all')
     ? filteredTasks
     : assigneeType == FilterOptionsKeywords.CLIENTS
-      ? filteredTasks.filter((task) => task?.assigneeType?.includes('client') || task?.assigneeType?.includes('company'))
-      : assigneeType == FilterOptionsKeywords.TEAM
-        ? filteredTasks.filter((task) => task?.assigneeType?.includes('internalUser'))
-        : filteredTasks.filter((task) => task.assigneeId == assigneeType)
+      ? filteredTasks.filter((task) => task?.assigneeType?.includes('client') || task?.assigneeType?.includes('company')) // show shared tasks
+      : assigneeType == FilterOptionsKeywords.CLIENT_WITH_VIEWERS
+        ? filteredTasks.filter(
+            (task) =>
+              !!task?.viewers?.length || task?.assigneeType?.includes('client') || task?.assigneeType?.includes('company'),
+          )
+        : assigneeType == FilterOptionsKeywords.TEAM
+          ? filteredTasks.filter((task) => task?.assigneeType?.includes('internalUser'))
+          : filteredTasks.filter((task) => task.assigneeId == assigneeType)
 
   return filteredTasks
 }

--- a/src/hooks/useFilter.tsx
+++ b/src/hooks/useFilter.tsx
@@ -84,20 +84,25 @@ function filterByKeyword(
 
 function filterByType(filteredTasks: TaskResponse[], filterValue: string): TaskResponse[] {
   const assigneeType = filterValue
-  filteredTasks = assigneeType.includes('all')
-    ? filteredTasks
-    : assigneeType == FilterOptionsKeywords.CLIENTS
-      ? filteredTasks.filter((task) => task?.assigneeType?.includes('client') || task?.assigneeType?.includes('company')) // show shared tasks
-      : assigneeType == FilterOptionsKeywords.CLIENT_WITH_VIEWERS
-        ? filteredTasks.filter(
-            (task) =>
-              !!task?.viewers?.length || task?.assigneeType?.includes('client') || task?.assigneeType?.includes('company'),
-          )
-        : assigneeType == FilterOptionsKeywords.TEAM
-          ? filteredTasks.filter((task) => task?.assigneeType?.includes('internalUser'))
-          : filteredTasks.filter((task) => task.assigneeId == assigneeType)
 
-  return filteredTasks
+  switch (filterValue) {
+    case FilterOptionsKeywords.CLIENTS:
+      return filteredTasks.filter(
+        (task) => task?.assigneeType?.includes('client') || task?.assigneeType?.includes('company'),
+      )
+
+    case FilterOptionsKeywords.CLIENT_WITH_VIEWERS:
+      return filteredTasks.filter(
+        (task) =>
+          !!task?.viewers?.length || task?.assigneeType?.includes('client') || task?.assigneeType?.includes('company'),
+      )
+
+    case FilterOptionsKeywords.TEAM:
+      return filteredTasks.filter((task) => task?.assigneeType?.includes('internalUser'))
+
+    default:
+      return filteredTasks.filter((task) => task.assigneeId == assigneeType)
+  }
 }
 
 export const useFilter = (filterOptions: IFilterOptions) => {

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -67,6 +67,7 @@ export enum FilterByOptions {
 export enum FilterOptionsKeywords {
   CLIENTS = 'clients_companies',
   TEAM = 'ius',
+  CLIENT_WITH_VIEWERS = 'client_with_viewers',
 }
 
 export enum HandleSelectorComponentModes {

--- a/src/types/objectMaps.ts
+++ b/src/types/objectMaps.ts
@@ -6,6 +6,11 @@ export const filterTypeToButtonIndexMap: Record<string, number> = {
   '': 3,
 }
 
+export const clientFilterTypeToButtonIndexMap: Record<string, number> = {
+  [FilterOptionsKeywords.CLIENT_WITH_VIEWERS]: 0,
+  [FilterOptionsKeywords.CLIENTS]: 1,
+}
+
 export const filterOptionsMap: Record<string, FilterByOptions> = {
   [FilterOptionsKeywords.CLIENTS]: FilterByOptions.CLIENT,
   [FilterOptionsKeywords.TEAM]: FilterByOptions.IUS,


### PR DESCRIPTION
## Changes

- [x] ability to toggle between two views: My tasks and All tasks
- [x] in "my tasks" tab: show all client assigned and client's company assigned tasks
- [x] in "all tasks" tab: show all client and company assigned tasks along with shared tasks

## Testing Criteria

[Loom](https://www.loom.com/share/51e944e40a844f6caea1f78640ee317a?sid=d0eb7071-022f-4437-b87d-49a97ad34a91)