### PR TITLE
HOTFIX: validate notification count errors 

### DIFF
--- a/src/utils/CopilotAPI.ts
+++ b/src/utils/CopilotAPI.ts
@@ -266,12 +266,16 @@ export class CopilotAPI {
     } = { limit: 100 },
   ) {
     console.info('CopilotAPI#_getClientNotifications', this.token)
-    const response = await this.manualFetch('notifications', {
-      recipientClientId,
-      recipientCompanyId,
-      limit: `${opts.limit}`,
+    const response = await this.manualFetch(
+      'notifications',
+      {
+        recipientClientId,
+        recipientCompanyId,
+        limit: `${opts.limit}`,
+        workspaceId,
+      },
       workspaceId,
-    })
+    )
     const notifications = z.array(NotificationCreatedResponseSchema).parse(response.data)
     // Return only all notifications triggered by tasks-app
     return notifications


### PR DESCRIPTION
## Changes

- [x] validate notification count failing through manual fetch api for notifications because of invalid workspaceId passed (undefined)


