### PR TITLE
OUT-2346: Add support for client-visibility activity logs.

### DIFF
--- a/prisma/migrations/20250918111546_add_viewer_activity_type/migration.sql
+++ b/prisma/migrations/20250918111546_add_viewer_activity_type/migration.sql
@@ -1,0 +1,10 @@
+-- AlterEnum
+-- This migration adds more than one value to an enum.
+-- With PostgreSQL versions 11 and earlier, this is not possible
+-- in a single migration. This can be worked around by creating
+-- multiple migrations, each migration adding only one value to
+-- the enum.
+
+
+ALTER TYPE "ActivityType" ADD VALUE 'VIEWER_ADDED';
+ALTER TYPE "ActivityType" ADD VALUE 'VIEWER_REMOVED';

--- a/prisma/schema/activityLog.prisma
+++ b/prisma/schema/activityLog.prisma
@@ -7,6 +7,8 @@ enum ActivityType {
   COMMENT_ADDED
   DUE_DATE_CHANGED
   ARCHIVE_STATE_UPDATED
+  VIEWER_ADDED
+  VIEWER_REMOVED
 }
 
 model ActivityLog {

--- a/src/app/api/activity-logs/const.ts
+++ b/src/app/api/activity-logs/const.ts
@@ -7,6 +7,7 @@ import { TitleUpdatedSchema } from '@api/activity-logs/schemas/TitleUpdatedSchem
 import { WorkflowStateUpdatedSchema } from '@api/activity-logs/schemas/WorkflowStateUpdatedSchema'
 import { ActivityType, AssigneeType } from '@prisma/client'
 import { z } from 'zod'
+import { ViewerAddedSchema, ViewerRemovedSchema } from './schemas/ViewerSchema'
 
 export const SchemaByActivityType = {
   [ActivityType.TASK_CREATED]: TaskCreatedSchema,
@@ -17,6 +18,8 @@ export const SchemaByActivityType = {
   [ActivityType.COMMENT_ADDED]: CommentAddedSchema,
   [ActivityType.DUE_DATE_CHANGED]: DueDateChangedSchema,
   [ActivityType.ARCHIVE_STATE_UPDATED]: ArchivedStateUpdatedSchema,
+  [ActivityType.VIEWER_ADDED]: ViewerAddedSchema,
+  [ActivityType.VIEWER_REMOVED]: ViewerRemovedSchema,
 }
 
 export const DBActivityLogDetailsSchema = z.record(z.string(), z.unknown())

--- a/src/app/api/activity-logs/schemas/ViewerSchema.ts
+++ b/src/app/api/activity-logs/schemas/ViewerSchema.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod'
+
+export const ViewerAddedSchema = z.object({
+  oldValue: z.string().uuid().nullable(),
+  newValue: z.string().uuid().nullable(),
+})
+
+export const ViewerRemovedSchema = z.object({
+  oldValue: z.string().uuid().nullable(),
+  newValue: z.null(),
+})

--- a/src/app/api/tasks/tasks.logger.ts
+++ b/src/app/api/tasks/tasks.logger.ts
@@ -10,6 +10,8 @@ import { ActivityLogger } from '@api/activity-logs/services/activity-logger.serv
 import User from '@api/core/models/User.model'
 import { BaseService } from '@api/core/services/base.service'
 import { ActivityType, AssigneeType, Task, WorkflowState } from '@prisma/client'
+import { ViewerAddedSchema, ViewerRemovedSchema } from '../activity-logs/schemas/ViewerSchema'
+import { Viewers } from '@/types/dto/tasks.dto'
 
 /**
  * Wrapper over ActivityLogger to implement a clean abstraction for task creation / update events
@@ -52,6 +54,28 @@ export class TasksActivityLogger extends BaseService {
         setUpdate()
       }
     }
+
+    if (Array.isArray(this.task.viewers) && Array.isArray(prevTask.viewers)) {
+      const currentViewers = (this.task.viewers as Viewers) || []
+      const prevViewers = (prevTask.viewers as Viewers) || []
+
+      if (
+        (!!currentViewers.length || !!prevViewers.length) &&
+        (currentViewers[0]?.clientId !== prevViewers[0]?.clientId ||
+          currentViewers[0]?.companyId !== prevViewers[0]?.companyId)
+      ) {
+        const currentViewerId = currentViewers[0]?.clientId || currentViewers[0]?.companyId || null
+        const previousViewerId = prevViewers[0]?.clientId || prevViewers[0]?.companyId || null
+        if (currentViewerId) {
+          await this.logTaskViewerUpdated(previousViewerId, currentViewerId)
+          setUpdate()
+        } else {
+          await this.logTaskViewerRemoved(previousViewerId)
+          setUpdate()
+        }
+      }
+    }
+
     if (this.task.workflowStateId !== prevTask?.workflowStateId) {
       await this.logWorkflowStateUpdated(prevTask)
       setUpdate()
@@ -141,6 +165,26 @@ export class TasksActivityLogger extends BaseService {
         taskId: this.task.id,
       }),
       createdBy,
+    )
+  }
+
+  private async logTaskViewerUpdated(previousViewerId: string | null, currentViewerId: string | null) {
+    await this.activityLogger.log(
+      ActivityType.VIEWER_ADDED,
+      ViewerAddedSchema.parse({
+        oldValue: previousViewerId,
+        newValue: currentViewerId,
+      }),
+    )
+  }
+
+  private async logTaskViewerRemoved(previousViewerId: string | null) {
+    await this.activityLogger.log(
+      ActivityType.VIEWER_REMOVED,
+      ViewerRemovedSchema.parse({
+        oldValue: previousViewerId,
+        newValue: null,
+      }),
     )
   }
 }

--- a/src/app/detail/ui/ActivityLog.tsx
+++ b/src/app/detail/ui/ActivityLog.tsx
@@ -48,6 +48,8 @@ export const ActivityLog = ({ log }: Prop) => {
           return [getWorkflowStateName(oldValue), getWorkflowStateName(newValue)]
 
         case ActivityType.TASK_ASSIGNED:
+        case ActivityType.VIEWER_ADDED:
+        case ActivityType.VIEWER_REMOVED:
           const taskAssignees = TaskAssignedResponseSchema.parse(log.details)
           return getAssignedToName(taskAssignees)
 
@@ -135,6 +137,22 @@ export const ActivityLog = ({ log }: Prop) => {
       </>
     ),
     [ActivityType.COMMENT_ADDED]: () => null,
+    [ActivityType.VIEWER_ADDED]: (_from: string, to: string) => (
+      <>
+        <StyledTypography> added </StyledTypography>
+        <BoldTypography>{to}</BoldTypography>
+        <StyledTypography> as a viewer </StyledTypography>
+        <DotSeparator />
+      </>
+    ),
+    [ActivityType.VIEWER_REMOVED]: (from: string, _to: string) => (
+      <>
+        <StyledTypography> removed </StyledTypography>
+        <BoldTypography>{from}</BoldTypography>
+        <StyledTypography> as a viewer </StyledTypography>
+        <DotSeparator />
+      </>
+    ),
   }
 
   const activityUser = assignee.find((assignee) => assignee.id == log.userId)


### PR DESCRIPTION
## Changes

- [x] log viewer related activities when viewer is added or removed (can be client or company)
- [x] migration to alter the activity type (add viewer related activity type)
- [x] show viewer activity logs in activity section of the task detail page

## Testing Criteria

[Loom](https://www.loom.com/share/eec03d1accba4e99bb77a677ece0f017?sid=0b8db6d6-e2e6-4592-b83c-97d841824528)