### PR TITLE
OUT-2390: include viewer removed log when viewer is reassigned

### DIFF
--- a/src/app/api/tasks/tasks.logger.ts
+++ b/src/app/api/tasks/tasks.logger.ts
@@ -67,6 +67,7 @@ export class TasksActivityLogger extends BaseService {
         const currentViewerId = currentViewers[0]?.clientId || currentViewers[0]?.companyId || null
         const previousViewerId = prevViewers[0]?.clientId || prevViewers[0]?.companyId || null
         if (currentViewerId) {
+          if (previousViewerId) await this.logTaskViewerRemoved(previousViewerId) // if previous viewer exists, log removed event
           await this.logTaskViewerUpdated(previousViewerId, currentViewerId)
           setUpdate()
         } else {


### PR DESCRIPTION
## Changes

- [x] store viewer removed log when viewer is re-assigned

## Testing Criteria

[Loom](https://www.loom.com/share/4ab22311a67142f68d302f91d10630bd?sid=1169ff72-fadb-461f-8ebb-508b733b2fc7)