### PR TITLE
OUT-2376 | Due date text messed up in sub tasks list.

### DIFF
--- a/src/app/detail/ui/TaskCardList.tsx
+++ b/src/app/detail/ui/TaskCardList.tsx
@@ -212,7 +212,11 @@ export const TaskCardList = ({ task, variant, workflowState, mode, handleUpdate,
                 flexShrink: 1,
               }}
             >
-              <TaskTitle variant={variant == 'task' ? 'list' : 'subtasks'} title={task.title} />
+              <TaskTitle
+                variant={variant == 'task' ? 'list' : 'subtasks'}
+                title={task.title}
+                isClient={mode === UserRole.Client}
+              />
 
               {(task.subtaskCount > 0 || task.isArchived) && (
                 <Stack direction="row" sx={{ display: 'flex', gap: '12px', flexShrink: 0, alignItems: 'center' }}>

--- a/src/components/atoms/TaskTitle.tsx
+++ b/src/components/atoms/TaskTitle.tsx
@@ -5,9 +5,10 @@ import { CopilotTooltip } from './CopilotTooltip'
 interface TaskTitleProps {
   title?: string
   variant?: 'board' | 'list' | 'subtasks'
+  isClient?: boolean
 }
 
-const TaskTitle = ({ title, variant = 'board' }: TaskTitleProps) => {
+const TaskTitle = ({ title, variant = 'board', isClient = false }: TaskTitleProps) => {
   const textRef = useRef<HTMLElement>(null)
   const [isOverflowing, setIsOverflowing] = useState(false)
 
@@ -48,6 +49,7 @@ const TaskTitle = ({ title, variant = 'board' }: TaskTitleProps) => {
           flexShrink: 1,
           flexGrow: 0,
           minWidth: 0,
+          maxWidth: isClient ? '105px' : 'none',
         }}
       >
         {title}


### PR DESCRIPTION
## Changes

- [x] due date layout in client views task board subtasks list fixed.

## Testing Criteria

Client view : 
<img width="426" height="321" alt="image" src="https://github.com/user-attachments/assets/32736cc6-30d2-4e22-b1d6-ae87f1e5c434" />

IU view : 
<img width="442" height="278" alt="image" src="https://github.com/user-attachments/assets/1dd2bf5d-f091-4152-a929-f280a2b138c2" />

