### PR TITLE
OUT-2381 | OUT-2400: Change prefil behavior for assignee field in CRM details view

### DIFF
--- a/src/redux/features/taskBoardSlice.tsx
+++ b/src/redux/features/taskBoardSlice.tsx
@@ -3,7 +3,14 @@ import { UrlActionParamsType, PreviewMode, PreviewClientCompanyType } from '@/ty
 import { TaskResponse } from '@/types/dto/tasks.dto'
 import { CreateViewSettingsDTO, FilterOptionsType } from '@/types/dto/viewSettings.dto'
 import { WorkflowStateResponse } from '@/types/dto/workflowStates.dto'
-import { FilterByOptions, FilterOptions, IAssigneeCombined, IFilterOptions, UserIds } from '@/types/interfaces'
+import {
+  FilterByOptions,
+  FilterOptions,
+  FilterOptionsKeywords,
+  IAssigneeCombined,
+  IFilterOptions,
+  UserIds,
+} from '@/types/interfaces'
 import { emptyAssignee, UserIdsType } from '@/utils/assignee'
 import { ViewMode } from '@prisma/client'
 import { createSlice } from '@reduxjs/toolkit'
@@ -154,6 +161,13 @@ const taskBoardSlice = createSlice({
             ...updatedFilterOptions,
             assignee: emptyAssignee,
           }
+        }
+      }
+      if (state.previewMode && !filterOptions.type) {
+        // Engineering note: CRM view and IU view uses same view setting config. In CRM view, we don't have "All tasks": filter by type. If the "All task" tab is selected, we are manually setting the type to "clients" to show all client tasks.
+        updatedFilterOptions = {
+          ...updatedFilterOptions,
+          type: FilterOptionsKeywords.CLIENTS,
         }
       }
       state.filterOptions = updatedFilterOptions


### PR DESCRIPTION
## Changes

While task creation:

- [x] Filter "My tasks": current IU as default assignee with CU as a viewer
- [x] Filter "Team tasks": leave assignee and visibility field empty
- [x] Filter "Client tasks": CU as default assignee

Updated changes:

- [x] assignee is selector is enabled in CRM view for create task modal.
- [x] client visibility is disabled with current CU as default value
- [x] CRM view and IU view shares same viewSettings. When "All tasks" tab is selected and stored from IU view, displays "Client tasks" in CRM view initially (no All tasks tab in CRM).


## Testing Criteria

Original
[Loom](https://www.loom.com/share/74467f26e9674975b1a8ffa91409c393)

Updated
[Loom](https://www.loom.com/share/8b2853117b8345b8bfb6f1801e35afdc?sid=55eac6a4-0b85-4768-9827-b53039b17c06)