### PR TITLE
OUT-2378: show breadcrumbs for tasks where client is viewer in CU view

### DIFF
--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -854,6 +854,7 @@ export class TasksService extends BaseService {
             clientId: true,
             companyId: true,
             internalUserId: true,
+            viewers: true,
           },
         }),
       ) as Promise<AncestorTaskResponse>[],

--- a/src/types/dto/tasks.dto.ts
+++ b/src/types/dto/tasks.dto.ts
@@ -4,16 +4,13 @@ import { WorkflowStateResponseSchema } from './workflowStates.dto'
 import { DateStringSchema } from '@/types/date'
 import { ClientResponseSchema, CompanyResponseSchema, InternalUsersSchema } from '../common'
 
-export const ViewersSchema = z
-  .array(
-    z.object({
-      clientId: z.string().uuid().optional(),
-      companyId: z.string().uuid(),
-    }),
-  )
-  .max(1)
-  .optional()
+export const ViewerSchema = z.object({
+  clientId: z.string().uuid().optional(),
+  companyId: z.string().uuid(),
+})
+export type ViewerType = z.infer<typeof ViewerSchema>
 
+export const ViewersSchema = z.array(ViewerSchema).max(1).optional()
 export type Viewers = z.infer<typeof ViewersSchema>
 
 export const validateUserIds = (
@@ -112,7 +109,7 @@ export const SubTaskStatusSchema = z.object({
 
 export type SubTaskStatusResponse = z.infer<typeof SubTaskStatusSchema>
 
-export type AncestorTaskResponse = Pick<Task, 'id' | 'title' | 'label'> & {
+export type AncestorTaskResponse = Pick<Task, 'id' | 'title' | 'label' | 'viewers'> & {
   internalUserId: string | null
   clientId: string | null
   companyId: string | null


### PR DESCRIPTION
## Changes

- [x] select viewers column when retrieving task path
- [x] add condition that returns accessible path when current user is CU and viewer ids matches current user ids

## Testing Criteria

[Loom](https://www.loom.com/share/a9ea3fde16f94e688a85696791ab5f9c?sid=52df4183-2a2f-4da8-8f9a-f7143157bfce)