### PR TITLE
OUT-2377 | Task details are missing when opening a task from email notification & notification center

### DIFF
--- a/src/app/_cache/AssigneeCacheGetter.tsx
+++ b/src/app/_cache/AssigneeCacheGetter.tsx
@@ -14,7 +14,9 @@ export const AssigneeCacheGetter = ({ lookupKey }: ClientAssigneeCacheGetterProp
     const run = async () => {
       await migrateAssignees(lookupKey) //migrate from localStorage to localForage if required. Remember to remove this after a while.
       const assignee = await getAssignees(lookupKey)
-      store.dispatch(setAssigneeList(assignee))
+      if (assignee.length) {
+        store.dispatch(setAssigneeList(assignee))
+      }
     }
     run()
   }, [lookupKey])

--- a/src/app/detail/[task_id]/[user_type]/page.tsx
+++ b/src/app/detail/[task_id]/[user_type]/page.tsx
@@ -41,15 +41,20 @@ import { Box, Stack } from '@mui/material'
 import { z } from 'zod'
 import { fetchWithErrorHandler } from '@/app/_fetchers/fetchWithErrorHandler'
 import { AssigneeCacheGetter } from '@/app/_cache/AssigneeCacheGetter'
-import { ClientDetailAppBridge } from '@/app/detail/ui/ClientDetailAppBridge'
 
-async function getOneTask(token: string, taskId: string): Promise<TaskResponse> {
-  const data = await fetchWithErrorHandler<{ task: TaskResponse }>(`${apiUrl}/api/tasks/${taskId}?token=${token}`, {
-    cache: 'no-store',
-    next: { tags: ['getOneTask'] },
-  })
-
-  return data.task
+async function getOneTask(token: string, taskId: string): Promise<TaskResponse | null> {
+  try {
+    const data = await fetchWithErrorHandler<{ task: TaskResponse }>(`${apiUrl}/api/tasks/${taskId}?token=${token}`, {
+      cache: 'no-store',
+    })
+    return data.task
+  } catch (error) {
+    if (error instanceof Error && error.message.includes('(404)')) {
+      //the message surely includes 404 if the task is not found.
+      return null
+    }
+    throw error
+  }
 }
 
 async function getWorkspace(token: string): Promise<WorkspaceResponse> {


### PR DESCRIPTION
## Changes

- [x] empty list on assignee cache getter overriding the fetched assignee value on fresh load-out. 
- [x] Solved issue of app crashing when opening deleted task from notifications.

## Testing Criteria

- [LOOM](https://www.loom.com/share/2d00b9a40db54c97a63f89bb892e6a87)

