### PR TITLE
OUT-2393 | Robust retry mechanism to handle sporadic Copilot API errors

### DIFF
--- a/src/app/api/core/utils/withRetry.ts
+++ b/src/app/api/core/utils/withRetry.ts
@@ -29,8 +29,8 @@ export const withRetry = async <T>(fn: (...args: any[]) => Promise<T>, args: any
 
     {
       retries: 3,
-      minTimeout: 1000,
-      maxTimeout: 3000,
+      minTimeout: 500,
+      maxTimeout: 5000,
       factor: 2, // Exponential factor for timeout delay. Tweak this if issues still persist
       onFailedAttempt: (error: FailedAttemptError) => {
         console.warn(

--- a/src/app/api/core/utils/withRetry.ts
+++ b/src/app/api/core/utils/withRetry.ts
@@ -29,20 +29,19 @@ export const withRetry = async <T>(fn: (...args: any[]) => Promise<T>, args: any
 
     {
       retries: 3,
-      minTimeout: 500,
-      maxTimeout: 2000,
+      minTimeout: 1000,
+      maxTimeout: 3000,
       factor: 2, // Exponential factor for timeout delay. Tweak this if issues still persist
       onFailedAttempt: (error: FailedAttemptError) => {
         console.warn(
-          `CopilotAPI#withRetry | Attempt ${error.attemptNumber} failed. There are ${error.retriesLeft} retries left. Error:`,
-          error,
+          `CopilotAPI#withRetry | Attempt ${error.attemptNumber} failed. There are ${error.retriesLeft} retries left`,
         )
       },
       shouldRetry: (error: any) => {
         // Typecasting because Copilot doesn't export an error class
         const err = error as StatusableError
-        // Retry only if statusCode === 429
-        return err.status === 429
+        // Retry if statusCode is 429 (ratelimit), 408 (timeouts), or any server related (5xx) error
+        return [408, 429].includes(err.status) || (err.status >= 500 && err.status <= 511)
       },
     },
   )


### PR DESCRIPTION
## Changes

- [x] Show a readable body on `manualFetch` error, not an object notation

<img width="691" height="106" alt="image" src="https://github.com/user-attachments/assets/2736f9b0-337b-46de-bf7b-1b112422f529" />


- [x] Handle Copilot server side errors and schedule exponential backoff retries
- [x] Implement `withRetry` for manualFetch

## Testing Criteria:

<img width="1275" height="647" alt="image" src="https://github.com/user-attachments/assets/d5024b5c-af35-427f-ace7-000a6ff391fb" />
