### PR TITLE
OUT-2379: Visual regressions with tasks with long name

### DIFF
--- a/src/components/atoms/TaskTitle.tsx
+++ b/src/components/atoms/TaskTitle.tsx
@@ -32,6 +32,7 @@ const TaskTitle = ({ title, variant = 'board', isClient = false }: TaskTitleProp
           WebkitLineClamp: 2,
           overflow: 'hidden',
           textOverflow: 'ellipsis',
+          wordBreak: 'break-word',
         }}
       >
         {title}
@@ -56,9 +57,13 @@ const TaskTitle = ({ title, variant = 'board', isClient = false }: TaskTitleProp
       </Typography>
     )
 
+  const TaskTitleComponent = () => {
+    return <Box sx={{ overflow: 'hidden', wordBreak: 'break-word' }}>{title}</Box>
+  }
+
   return isOverflowing ? (
-    <Box sx={{ flexShrink: 1, minWidth: 0, overflow: 'hidden' }}>
-      <CopilotTooltip content={title} allowMaxWidth={true}>
+    <Box sx={{ flexShrink: 1, minWidth: 0 }}>
+      <CopilotTooltip content={<TaskTitleComponent />} allowMaxWidth={true}>
         {typographyComponent}
       </CopilotTooltip>
     </Box>


### PR DESCRIPTION
## Changes

- [x] implement word break styling for title text in tool tip and task card

## Testing Criteria

[Loom](https://www.loom.com/share/a04c26281bef47c6bfdc496aac3029fd?sid=4a632921-6d3b-4ea0-94b9-01ff9cc85ffe)