### PR TITLE
OUT-2412 | Blurring the Assignee selector attempts to remove Viewer

### DIFF
--- a/src/components/inputs/CopilotSelector.tsx
+++ b/src/components/inputs/CopilotSelector.tsx
@@ -88,19 +88,21 @@ export const CopilotPopSelector = ({
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
 
   const shouldCallOnChangeWithEmpty = useRef(false)
+  const initialAssignee = initialValue && parseAssigneeToSelectorOptions(initialValue)
 
   const handleClick = useCallback(
     (event: React.MouseEvent<HTMLDivElement>) => {
       event.preventDefault()
       event.stopPropagation()
       if (!disabled) {
+        setSelectedAssignee(initialAssignee && selectorOptionsToInputValue(initialAssignee))
         setAnchorEl(anchorEl ? null : event.currentTarget)
+        shouldCallOnChangeWithEmpty.current = false
       }
     },
-    [anchorEl, disabled],
+    [anchorEl, disabled, initialAssignee],
   )
 
-  const initialAssignee = initialValue && parseAssigneeToSelectorOptions(initialValue)
   const [selectedAssignee, setSelectedAssignee] = useState<InputValue[] | undefined>(
     initialAssignee && selectorOptionsToInputValue(initialAssignee),
   )


### PR DESCRIPTION
## Changes

- [x] fixed by resetting selectedAssignee to initial value and shouldCallOnChangeWithEmpty ref when opening the selector.

## Testing Criteria

- [LOOM](https://www.loom.com/share/e14febcd6bbb4f11a7ceb5159ba6d6db)

