### PR TITLE
OUT-2428 | OUT-2430: Filter by type option is missing on smaller windows in CRM and CU views

### DIFF
--- a/src/components/layouts/FilterBar.tsx
+++ b/src/components/layouts/FilterBar.tsx
@@ -310,7 +310,7 @@ export const FilterBar = ({ mode, updateViewModeSetting, isPreviewMode }: Filter
       </Box>
       <Box sx={{ padding: '12px 20px', display: { sm: 'block', sd: 'none' } }}>
         <Stack direction="column" rowGap={'8px'}>
-          {mode === UserRole.IU && <FilterButtonGroup filterButtons={filterButtons} activeButtonIndex={ButtonIndex} />}
+          <FilterButtonGroup filterButtons={filterButtons} activeButtonIndex={ButtonIndex} />
 
           <Stack
             direction="row"

--- a/src/hoc/ClientSideStateUpdate.tsx
+++ b/src/hoc/ClientSideStateUpdate.tsx
@@ -23,7 +23,7 @@ import { HomeParamActions } from '@/types/constants'
 import { TaskResponse } from '@/types/dto/tasks.dto'
 import { CreateViewSettingsDTO } from '@/types/dto/viewSettings.dto'
 import { WorkflowStateResponse } from '@/types/dto/workflowStates.dto'
-import { IAssigneeCombined, IAssigneeSuggestions, ITemplate } from '@/types/interfaces'
+import { FilterOptionsKeywords, IAssigneeCombined, IAssigneeSuggestions, ITemplate } from '@/types/interfaces'
 import { filterOptionsMap } from '@/types/objectMaps'
 import { getPreviewMode, handlePreviewMode } from '@/utils/previewMode'
 import { ReactNode, useEffect } from 'react'
@@ -93,9 +93,18 @@ export const ClientSideStateUpdate = ({
 
     if (viewSettings) {
       const viewSettingsCopy = viewSettingsTemp ? structuredClone(viewSettingsTemp) : structuredClone(viewSettings) //deep cloning for immutability and prevent the reducer mutating the original object.
+      const previewMode = tokenPayload && !!getPreviewMode(tokenPayload)
+      if (previewMode && !viewSettingsCopy.filterOptions.type) {
+        viewSettingsCopy.filterOptions.type = FilterOptionsKeywords.CLIENTS
+      }
       store.dispatch(setViewSettings(viewSettingsCopy))
       const view = viewSettingsTemp ? viewSettingsTemp.filterOptions : viewSettingsCopy.filterOptions
-      store.dispatch(setFilteredAssigneeList({ filteredType: filterOptionsMap[view?.type] || filterOptionsMap.default }))
+      store.dispatch(
+        setFilteredAssigneeList({
+          filteredType:
+            filterOptionsMap[view?.type] || (previewMode ? FilterOptionsKeywords.CLIENTS : filterOptionsMap.default),
+        }),
+      )
     }
 
     if (tokenPayload) {

--- a/src/redux/features/taskBoardSlice.tsx
+++ b/src/redux/features/taskBoardSlice.tsx
@@ -163,13 +163,6 @@ const taskBoardSlice = createSlice({
           }
         }
       }
-      if (state.previewMode && !filterOptions.type) {
-        // Engineering note: CRM view and IU view uses same view setting config. In CRM view, we don't have "All tasks": filter by type. If the "All task" tab is selected, we are manually setting the type to "clients" to show all client tasks.
-        updatedFilterOptions = {
-          ...updatedFilterOptions,
-          type: FilterOptionsKeywords.CLIENTS,
-        }
-      }
       state.filterOptions = updatedFilterOptions
     }, //updates filters according to viewSettings
 


### PR DESCRIPTION
## Changes

- [x] enable filter option for small screens by removing IU only condition
- [x] show client tasks when "filter by all tasks" is implemented in CRM view (on initial load)

## Testing Criteria

- screenshot of mobile view
CU view
<img width="394" height="300" alt="image" src="https://github.com/user-attachments/assets/ce9abdf1-c722-4d8b-9a22-3464a8716470" />

CRM view 
<img width="455" height="303" alt="image" src="https://github.com/user-attachments/assets/2774d5fc-5d81-45e9-b20e-50cbdaf3310b" />


