### PR TITLE
OUT-2427: No tasks state in client experience

### DIFF
--- a/src/app/client/page.tsx
+++ b/src/app/client/page.tsx
@@ -75,6 +75,8 @@ export default async function ClientPage({ searchParams }: { searchParams: { tok
 
   console.info(`app/client/page.tsx | Serving user ${token} with payload`, tokenPayload)
 
+  if (!tasks.length && !previewMode) return <DashboardEmptyState userType={UserRole.Client} />
+
   return (
     <>
       <Suspense>{!previewMode && <ValidateNotificationCountFetcher token={token} />}</Suspense>

--- a/src/app/client/page.tsx
+++ b/src/app/client/page.tsx
@@ -10,6 +10,7 @@ import { ValidateNotificationCountFetcher } from '@/app/_fetchers/ValidateNotifi
 import { ModalNewTaskForm } from '@/app/ui/Modal_NewTaskForm'
 import { TaskBoard } from '@/app/ui/TaskBoard'
 import { TaskBoardAppBridge } from '@/app/ui/TaskBoardAppBridge'
+import DashboardEmptyState from '@/components/layouts/EmptyState/DashboardEmptyState'
 import { SilentError } from '@/components/templates/SilentError'
 import { apiUrl } from '@/config'
 import { ClientSideStateUpdate } from '@/hoc/ClientSideStateUpdate'
@@ -73,6 +74,8 @@ export default async function ClientPage({ searchParams }: { searchParams: { tok
   const previewMode = getPreviewMode(tokenPayload)
 
   console.info(`app/client/page.tsx | Serving user ${token} with payload`, tokenPayload)
+
+  if (!tasks.length && !previewMode) return <DashboardEmptyState userType={UserRole.Client} />
 
   return (
     <>

--- a/src/app/client/page.tsx
+++ b/src/app/client/page.tsx
@@ -10,7 +10,6 @@ import { ValidateNotificationCountFetcher } from '@/app/_fetchers/ValidateNotifi
 import { ModalNewTaskForm } from '@/app/ui/Modal_NewTaskForm'
 import { TaskBoard } from '@/app/ui/TaskBoard'
 import { TaskBoardAppBridge } from '@/app/ui/TaskBoardAppBridge'
-import DashboardEmptyState from '@/components/layouts/EmptyState/DashboardEmptyState'
 import { SilentError } from '@/components/templates/SilentError'
 import { apiUrl } from '@/config'
 import { ClientSideStateUpdate } from '@/hoc/ClientSideStateUpdate'
@@ -74,8 +73,6 @@ export default async function ClientPage({ searchParams }: { searchParams: { tok
   const previewMode = getPreviewMode(tokenPayload)
 
   console.info(`app/client/page.tsx | Serving user ${token} with payload`, tokenPayload)
-
-  if (!tasks.length && !previewMode) return <DashboardEmptyState userType={UserRole.Client} />
 
   return (
     <>

--- a/src/app/client/page.tsx
+++ b/src/app/client/page.tsx
@@ -75,8 +75,6 @@ export default async function ClientPage({ searchParams }: { searchParams: { tok
 
   console.info(`app/client/page.tsx | Serving user ${token} with payload`, tokenPayload)
 
-  if (!tasks.length && !previewMode) return <DashboardEmptyState userType={UserRole.Client} />
-
   return (
     <>
       <Suspense>{!previewMode && <ValidateNotificationCountFetcher token={token} />}</Suspense>

--- a/src/app/ui/TaskBoard.tsx
+++ b/src/app/ui/TaskBoard.tsx
@@ -9,6 +9,7 @@ import { CustomDragLayer } from '@/components/CustomDragLayer'
 import { CardDragLayer } from '@/components/cards/CardDragLayer'
 import { TaskColumn } from '@/components/cards/TaskColumn'
 import { TaskRow } from '@/components/cards/TaskRow'
+import DashboardEmptyState from '@/components/layouts/EmptyState/DashboardEmptyState'
 import { FilterBar } from '@/components/layouts/FilterBar'
 import { Header } from '@/components/layouts/Header'
 import { DragDropHandler } from '@/hoc/DragDropHandler'
@@ -109,6 +110,9 @@ export const TaskBoard = ({ mode, workspace, token }: TaskBoardProps) => {
   } //fix this logic as soon as copilot API natively supports access scopes by creating an endpoint which shows the count of filteredTask and total tasks.
 
   const showHeader = !!previewMode
+
+  if ((!Array.isArray(tasks) || !tasks.length) && !previewMode && mode === UserRole.Client)
+    return <DashboardEmptyState userType={mode} />
 
   return (
     <>

--- a/src/app/ui/TaskBoard.tsx
+++ b/src/app/ui/TaskBoard.tsx
@@ -9,6 +9,7 @@ import { CustomDragLayer } from '@/components/CustomDragLayer'
 import { CardDragLayer } from '@/components/cards/CardDragLayer'
 import { TaskColumn } from '@/components/cards/TaskColumn'
 import { TaskRow } from '@/components/cards/TaskRow'
+import DashboardEmptyState from '@/components/layouts/EmptyState/DashboardEmptyState'
 import { FilterBar } from '@/components/layouts/FilterBar'
 import { Header } from '@/components/layouts/Header'
 import { DragDropHandler } from '@/hoc/DragDropHandler'
@@ -109,6 +110,8 @@ export const TaskBoard = ({ mode, workspace, token }: TaskBoardProps) => {
   } //fix this logic as soon as copilot API natively supports access scopes by creating an endpoint which shows the count of filteredTask and total tasks.
 
   const showHeader = !!previewMode
+
+  if (!accessibleTasks.length && !previewMode && mode === UserRole.Client) return <DashboardEmptyState userType={mode} />
 
   return (
     <>

--- a/src/app/ui/TaskBoard.tsx
+++ b/src/app/ui/TaskBoard.tsx
@@ -45,6 +45,8 @@ export const TaskBoard = ({ mode, workspace, token }: TaskBoardProps) => {
     previewMode,
     accessibleTasks,
     showSubtasks,
+    showArchived,
+    showUnarchived,
   } = useSelector(selectTaskBoard)
 
   const onDropItem = useCallback(
@@ -78,8 +80,18 @@ export const TaskBoard = ({ mode, workspace, token }: TaskBoardProps) => {
   }
 
   const viewBoardSettings = viewSettingsTemp ? viewSettingsTemp.viewMode : view
+  const archivedOptions = {
+    showArchived: viewSettingsTemp ? viewSettingsTemp.showArchived : showArchived,
+    showUnarchived: viewSettingsTemp ? viewSettingsTemp.showUnarchived : showUnarchived,
+  }
 
   useFilter(viewSettingsTemp ? viewSettingsTemp.filterOptions : filterOptions)
+  const userHasNoFilter =
+    filterOptions &&
+    !filterOptions.type &&
+    !filterOptions.keyword &&
+    archivedOptions.showUnarchived &&
+    !archivedOptions.showArchived
 
   const [hasInitialized, setHasInitialized] = useState(false)
   useEffect(() => {
@@ -109,9 +121,16 @@ export const TaskBoard = ({ mode, workspace, token }: TaskBoardProps) => {
     return <TaskDataFetcher token={token} />
   } //fix this logic as soon as copilot API natively supports access scopes by creating an endpoint which shows the count of filteredTask and total tasks.
 
-  const showHeader = !!previewMode
+  if (tasks && !tasks.length && userHasNoFilter && mode === UserRole.Client && !previewMode && !isTasksLoading) {
+    return (
+      <>
+        <TaskDataFetcher token={token ?? ''} />
+        <DashboardEmptyState userType={mode} />
+      </>
+    )
+  }
 
-  if (!accessibleTasks.length && !previewMode && mode === UserRole.Client) return <DashboardEmptyState userType={mode} />
+  const showHeader = !!previewMode
 
   return (
     <>

--- a/src/app/ui/TaskBoard.tsx
+++ b/src/app/ui/TaskBoard.tsx
@@ -9,7 +9,6 @@ import { CustomDragLayer } from '@/components/CustomDragLayer'
 import { CardDragLayer } from '@/components/cards/CardDragLayer'
 import { TaskColumn } from '@/components/cards/TaskColumn'
 import { TaskRow } from '@/components/cards/TaskRow'
-import DashboardEmptyState from '@/components/layouts/EmptyState/DashboardEmptyState'
 import { FilterBar } from '@/components/layouts/FilterBar'
 import { Header } from '@/components/layouts/Header'
 import { DragDropHandler } from '@/hoc/DragDropHandler'
@@ -110,9 +109,6 @@ export const TaskBoard = ({ mode, workspace, token }: TaskBoardProps) => {
   } //fix this logic as soon as copilot API natively supports access scopes by creating an endpoint which shows the count of filteredTask and total tasks.
 
   const showHeader = !!previewMode
-
-  if ((!Array.isArray(tasks) || !tasks.length) && !previewMode && mode === UserRole.Client)
-    return <DashboardEmptyState userType={mode} />
 
   return (
     <>


### PR DESCRIPTION
## Changes

- [x] show "No task assigned" state when no task assigned to client or company in CU view

## Testing Criteria

[Loom](https://www.loom.com/share/e12d45e68477418fa5dce32d56599dbe?sid=c829cdfe-8012-42a6-86b6-4a984e04b2d4)
