### PR TITLE
OUT-2453 | Fix FilterBar borders in CRM preview

### DIFF
--- a/src/components/layouts/FilterBar.tsx
+++ b/src/components/layouts/FilterBar.tsx
@@ -35,7 +35,7 @@ interface FilterBarProps {
 }
 
 export const FilterBar = ({ mode, updateViewModeSetting }: FilterBarProps) => {
-  const { view, filterOptions, assignee, viewSettingsTemp, showArchived, showUnarchived, showSubtasks } =
+  const { view, filterOptions, assignee, viewSettingsTemp, showArchived, showUnarchived, showSubtasks, previewMode } =
     useSelector(selectTaskBoard)
 
   const viewMode = viewSettingsTemp ? viewSettingsTemp.viewMode : view
@@ -154,10 +154,14 @@ export const FilterBar = ({ mode, updateViewModeSetting }: FilterBarProps) => {
 
   return (
     <Box
-      sx={{
-        border: (theme) => `1px solid ${theme.color.borders.borderDisabled}`,
-        borderTop: 'none',
-      }}
+      sx={
+        previewMode
+          ? { borderBottom: (theme) => `1px solid ${theme.color.borders.borderDisabled}` }
+          : {
+              border: (theme) => `1px solid ${theme.color.borders.borderDisabled}`,
+              borderTop: 'none',
+            }
+      }
     >
       <Box
         sx={{


### PR DESCRIPTION
## Changes

- [x] Before vs After

<img width="1244" height="204" alt="image" src="https://github.com/user-attachments/assets/dd567e26-c896-49f8-ba28-fd3556023e46" />

<img width="1151" height="234" alt="image" src="https://github.com/user-attachments/assets/e355157b-771e-4b8b-bbd7-e15d8b6f5fbd" />


- [x] Normal app borders are unaffected