### PR TITLE
OUT-2449 | CU can see the in-product notification for a completed company task

### DIFF
--- a/src/app/api/notification/notification.service.ts
+++ b/src/app/api/notification/notification.service.ts
@@ -495,10 +495,10 @@ export class NotificationService extends BaseService {
     return { senderId, senderCompanyId, recipientId, recipientIds, actionUser, companyName }
   }
 
-  async getAllForTasks(tasks: Task[], user: User): Promise<ClientNotification[]> {
+  async getAllForTasks(tasks: Task[]): Promise<ClientNotification[]> {
     const taskIds = tasks.map((task) => task.id)
     return await this.db.clientNotification.findMany({
-      where: { taskId: { in: taskIds }, clientId: user.clientId, companyId: user.companyId },
+      where: { taskId: { in: taskIds }, clientId: this.user.clientId, companyId: this.user.companyId },
     })
   }
 

--- a/src/app/api/notification/notification.service.ts
+++ b/src/app/api/notification/notification.service.ts
@@ -174,7 +174,6 @@ export class NotificationService extends BaseService {
           console.info('NotificationService#bulkCreate | Creating single notification:', notificationDetails)
           let notification: NotificationCreatedResponse
           try {
-            console.log('creating notification', notificationDetails)
             notification = await copilot.createNotification(notificationDetails)
           } catch (e: unknown) {
             notification = await this.handleIfSenderCompanyIdError(e, copilot, notificationDetails)

--- a/src/app/api/notification/validate-count/validateCount.service.ts
+++ b/src/app/api/notification/validate-count/validateCount.service.ts
@@ -49,7 +49,7 @@ export class ValidateCountService extends NotificationService {
     console.info('ValidateCount :: User tasks for company', companyId, ':', tasks.length)
 
     // Query all notifications triggered for a list of client/company tasks
-    const appNotifications = await this.getAllForTasks(tasks, this.user)
+    const appNotifications = await this.getAllForTasks(tasks)
     const appNotificationIds = appNotifications.map((n) => n.notificationId)
     console.info('ValidateCount :: App notifications', appNotifications.length)
 
@@ -66,7 +66,7 @@ export class ValidateCountService extends NotificationService {
       await this.removeOrphanNotificationsFromCopilot(appNotificationIds, copilotNotificationIds)
     }
 
-    const newAppNotifications = await this.getAllForTasks(tasks, this.user)
+    const newAppNotifications = await this.getAllForTasks(tasks)
     // Add robustness and legacy fixes by checking and fixing duplicate notifications for tasks
     if (tasks.length !== newAppNotifications.length || 1) {
       await this.removeDuplicateNotifications(clientId)

--- a/src/app/api/notification/validate-count/validateCount.service.ts
+++ b/src/app/api/notification/validate-count/validateCount.service.ts
@@ -49,7 +49,7 @@ export class ValidateCountService extends NotificationService {
     console.info('ValidateCount :: User tasks for company', companyId, ':', tasks.length)
 
     // Query all notifications triggered for a list of client/company tasks
-    const appNotifications = await this.getAllForTasks(tasks)
+    const appNotifications = await this.getAllForTasks(tasks, this.user)
     const appNotificationIds = appNotifications.map((n) => n.notificationId)
     console.info('ValidateCount :: App notifications', appNotifications.length)
 
@@ -66,7 +66,7 @@ export class ValidateCountService extends NotificationService {
       await this.removeOrphanNotificationsFromCopilot(appNotificationIds, copilotNotificationIds)
     }
 
-    const newAppNotifications = await this.getAllForTasks(tasks)
+    const newAppNotifications = await this.getAllForTasks(tasks, this.user)
     // Add robustness and legacy fixes by checking and fixing duplicate notifications for tasks
     if (tasks.length !== newAppNotifications.length || 1) {
       await this.removeDuplicateNotifications(clientId)
@@ -79,7 +79,7 @@ export class ValidateCountService extends NotificationService {
         FROM (
           SELECT "taskId", "clientId", "createdAt"
           FROM "ClientNotifications"
-          WHERE "clientId" = ${clientId}::uuid 
+          WHERE "clientId" = ${clientId}::uuid
             AND "deletedAt" IS NULL
         ) c
         GROUP BY "taskId"


### PR DESCRIPTION
## Changes

- [x] The validate notification service was fetching notification from clientNotifications table based on taskId only. This was fetching notification of another client/company having same task and deleting those notifications by removeOrphanNotificaiton.
- [x] To solve this issue, added clientId and companyId while querying for clientNotifications from the user's tokenPayload.

