### PR TITLE
OUT-2426 | Assignee selector scroll glitch

### DIFF
--- a/src/hoc/RealTime.tsx
+++ b/src/hoc/RealTime.tsx
@@ -7,6 +7,7 @@ import { Token } from '@/types/common'
 import { TaskResponse } from '@/types/dto/tasks.dto'
 import { AssigneeType } from '@prisma/client'
 import { RealtimePostgresChangesPayload } from '@supabase/supabase-js'
+import deepEqual from 'deep-equal'
 import { usePathname, useRouter } from 'next/navigation'
 import { ReactNode, useEffect } from 'react'
 import { useSelector } from 'react-redux'
@@ -57,7 +58,17 @@ export const RealTime = ({
     }
   }
 
+  function isPayloadEqual(payload: RealtimePostgresChangesPayload<RealTimeTaskResponse>): boolean {
+    const newPayload = payload.new
+    const oldPayload = payload.old
+    if (!newPayload || !oldPayload) return true
+    return deepEqual(newPayload, oldPayload)
+  }
+
   const handleRealtimeEvents = (payload: RealtimePostgresChangesPayload<RealTimeTaskResponse>) => {
+    if (isPayloadEqual(payload)) {
+      return //no changes for the same payload
+    }
     const user = assignee.find((el) => el.id === userId)
     if (!user || !userRole) return
 

--- a/src/lib/supabase-privilege/grant-all-privileges.sql
+++ b/src/lib/supabase-privilege/grant-all-privileges.sql
@@ -8,3 +8,6 @@ alter default privileges in schema public grant all on tables to postgres, anon,
 alter default privileges in schema public grant all on functions to postgres, anon, authenticated, service_role;
 alter default privileges in schema public grant all on sequences to postgres, anon, authenticated, service_role;
 
+alter table
+  "Tasks" replica identity full;
+


### PR DESCRIPTION
## Changes

- [x] an interactive component like selectors on task board was causing muliple prefetches which led to fire an update event from postgreschanges. This causes state update in tasks and was rerendering the board causing performance issue and glitches.
- [x] applied a check for new and old payloads for realtime changes to exit early in case the old and new payloads are same.
- [x] to get the full old payload granted full replica identity to tasks table.


