### PR TITLE
OUT-2941 | No notification when assignees complete a shared task

### DIFF
--- a/src/app/api/tasks/task-notifications.service.ts
+++ b/src/app/api/tasks/task-notifications.service.ts
@@ -273,6 +273,9 @@ export class TaskNotificationsService extends BaseService {
       } catch (e: unknown) {
         console.error(`Failed to find ClientNotification for task ${updatedTask.id}`, e)
       }
+    } else if (updatedTask.assigneeType === AssigneeType.internalUser) {
+      shouldCreateNotification &&
+        (await this.notificationService.create(NotificationTaskActions.CompletedByIU, updatedTask, { disableEmail: true }))
     }
   }
 


### PR DESCRIPTION
## Changes

- [x] added a mechanism to send task completed notifications to the task creator IU when it is completed my another iu. Previously this feature was missing

## Testing Criteria

<img width="2163" height="620" alt="image" src="https://github.com/user-attachments/assets/49715749-c32c-47bd-b5c2-657c35d8bae6" />

<img width="644" height="69" alt="image" src="https://github.com/user-attachments/assets/c1e53e55-13ae-45a0-9787-39d48538657d" />

