### PR TITLE
OUT-2939 | Support comments' attachments deletion from supabase bucket.

### DIFF
--- a/prisma/migrations/20260126103335_comment_id_in_scrap_medias/migration.sql
+++ b/prisma/migrations/20260126103335_comment_id_in_scrap_medias/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "ScrapMedias" ADD COLUMN     "commentId" UUID;
+
+-- AddForeignKey
+ALTER TABLE "ScrapMedias" ADD CONSTRAINT "ScrapMedias_commentId_fkey" FOREIGN KEY ("commentId") REFERENCES "Comments"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema/comment.prisma
+++ b/prisma/schema/comment.prisma
@@ -21,6 +21,10 @@ model Comment {
   updatedAt     DateTime      @updatedAt @db.Timestamptz()
   deletedAt     DateTime?     @db.Timestamptz()
 
+
+  scrapMedias ScrapMedia[]
+
+
   @@map("Comments")
   @@index([taskId, workspaceId, createdAt(sort: Desc)], name: "IX_Comments_taskId_workspaceId_createdAt")
 }

--- a/prisma/schema/scrapMedia.prisma
+++ b/prisma/schema/scrapMedia.prisma
@@ -8,6 +8,10 @@ model ScrapMedia {
   deletedAt   DateTime?    @db.Timestamptz()
   templateId  String?      @db.Uuid
   template    TaskTemplate? @relation(fields: [templateId], references: [id], onDelete: Cascade)
+  commentId   String?      @db.Uuid
+  comment     Comment?     @relation(fields: [commentId], references: [id], onDelete: Cascade)
+
+
 
   @@index([createdAt])
   @@index([filePath])

--- a/src/app/api/comments/comment.service.ts
+++ b/src/app/api/comments/comment.service.ts
@@ -388,17 +388,17 @@ export class CommentService extends BaseService {
     for (const { originalSrc, newUrl } of replacements) {
       htmlString = htmlString.replace(originalSrc, newUrl)
     }
-    // const filePaths = newFilePaths.map(({ newFilePath }) => newFilePath)
-    // await this.db.scrapMedia.updateMany({
-    //   where: {
-    //     filePath: {
-    //       in: filePaths,
-    //     },
-    //   },
-    //   data: {
-    //     taskId: task_id,
-    //   },
-    // }) //todo: add support for commentId in scrapMedias.
+    const filePaths = newFilePaths.map(({ newFilePath }) => newFilePath)
+    await this.db.scrapMedia.updateMany({
+      where: {
+        filePath: {
+          in: filePaths,
+        },
+      },
+      data: {
+        commentId: commentId,
+      },
+    })
     return htmlString
   } //todo: make this resuable since this is highly similar to what we are doing on tasks.
 

--- a/src/app/api/workers/scrap-medias/scrap-medias.service.ts
+++ b/src/app/api/workers/scrap-medias/scrap-medias.service.ts
@@ -85,7 +85,6 @@ export class ScrapMediaService {
           continue
         }
         // If media is not valid
-
         scrapMediasToDeleteFromBucket.push(media.filePath)
         scrapMediasToDelete.push(media.id)
       } catch (e: unknown) {
@@ -95,7 +94,7 @@ export class ScrapMediaService {
 
     if (!!scrapMediasToDeleteFromBucket.length)
       await db.attachment.deleteMany({ where: { filePath: { in: scrapMediasToDeleteFromBucket } } })
-
+    console.info('ScrapMediaWorker#deleteFromBucket | Deleting these medias', scrapMediasToDeleteFromBucket)
     // remove attachments from bucket
     await supabase.removeAttachmentsFromBucket(scrapMediasToDeleteFromBucket)
 

--- a/src/app/api/workers/scrap-medias/scrap-medias.service.ts
+++ b/src/app/api/workers/scrap-medias/scrap-medias.service.ts
@@ -29,6 +29,10 @@ export class ScrapMediaService {
       .map((image) => image.templateId)
       .filter((templateId): templateId is string => templateId !== null)
 
+    const commentIds = scrapMedias
+      .map((medias) => medias.commentId)
+      .filter((commentId): commentId is string => commentId !== null)
+
     const tasks = taskIds.length
       ? await db.task.findMany({
           where: {
@@ -46,35 +50,46 @@ export class ScrapMediaService {
           })
         : []
 
+    const comments =
+      commentIds.length > 0
+        ? await db.comment.findMany({
+            where: {
+              id: { in: commentIds },
+            },
+          })
+        : []
+
     const scrapMediasToDelete = []
     const scrapMediasToDeleteFromBucket = []
 
-    for (const image of scrapMedias) {
+    for (const media of scrapMedias) {
       try {
         // For each scrap image, check if the task or taskTemplate still has the img url in its body
-        const task = tasks.find((_task) => _task.id === image.taskId)
-        const taskTemplate = taskTemplates.find((_template) => _template.id === image.templateId)
+        const task = tasks.find((_task) => _task.id === media.taskId)
+        const taskTemplate = taskTemplates.find((_template) => _template.id === media.templateId)
+        const comment = comments.find((_comment) => _comment.id === media.commentId)
 
-        const isInTaskBody = task && (task.body || '').includes(image.filePath)
-        const isInTemplateBody = taskTemplate && (taskTemplate.body || '').includes(image.filePath)
+        const isInTaskBody = task && (task.body || '').includes(media.filePath)
+        const isInTemplateBody = taskTemplate && (taskTemplate.body || '').includes(media.filePath)
+        const isInCommentBody = comment && (comment.content || '').includes(media.filePath)
 
-        if (!task && !taskTemplate) {
-          console.error('Could not find task for scrap image', image)
-          scrapMediasToDelete.push(image.id)
-          scrapMediasToDeleteFromBucket.push(image.filePath)
+        if (!task && !taskTemplate && !comment) {
+          console.error('Could not find location of scrap media', media)
+          scrapMediasToDelete.push(media.id)
+          scrapMediasToDeleteFromBucket.push(media.filePath)
           continue
         }
-        // If image is in task body
-        if (isInTaskBody || isInTemplateBody) {
-          scrapMediasToDelete.push(image.id)
+        // If media is valid
+        if (isInTaskBody || isInTemplateBody || isInCommentBody) {
+          scrapMediasToDelete.push(media.id)
           continue
         }
-        // If image is not in task body
+        // If media is not valid
 
-        scrapMediasToDeleteFromBucket.push(image.filePath)
-        scrapMediasToDelete.push(image.id)
+        scrapMediasToDeleteFromBucket.push(media.filePath)
+        scrapMediasToDelete.push(media.id)
       } catch (e: unknown) {
-        console.error('Error processing scrap image', e)
+        console.error('Error processing scrap media', e)
       }
     }
 

--- a/src/app/api/workers/scrap-medias/scrap-medias.service.ts
+++ b/src/app/api/workers/scrap-medias/scrap-medias.service.ts
@@ -92,11 +92,12 @@ export class ScrapMediaService {
       }
     }
 
-    if (!!scrapMediasToDeleteFromBucket.length)
+    if (!!scrapMediasToDeleteFromBucket.length) {
       await db.attachment.deleteMany({ where: { filePath: { in: scrapMediasToDeleteFromBucket } } })
-    console.info('ScrapMediaWorker#deleteFromBucket | Deleting these medias', scrapMediasToDeleteFromBucket)
-    // remove attachments from bucket
-    await supabase.removeAttachmentsFromBucket(scrapMediasToDeleteFromBucket)
+      console.info('ScrapMediaWorker#deleteFromBucket | Deleting these medias', scrapMediasToDeleteFromBucket)
+      // remove attachments from bucket
+      await supabase.removeAttachmentsFromBucket(scrapMediasToDeleteFromBucket)
+    }
 
     if (scrapMediasToDelete.length !== 0) {
       const idsToDelete = scrapMediasToDelete.map((id) => `'${id}'`).join(', ')

--- a/src/app/detail/ui/NewTaskCard.tsx
+++ b/src/app/detail/ui/NewTaskCard.tsx
@@ -21,7 +21,7 @@ import { selectCreateTemplate } from '@/redux/features/templateSlice'
 import { DateString } from '@/types/date'
 import { CreateTaskRequest, Associations } from '@/types/dto/tasks.dto'
 import { WorkflowStateResponse } from '@/types/dto/workflowStates.dto'
-import { FilterByOptions, IAssigneeCombined, InputValue, ITemplate, UserIds } from '@/types/interfaces'
+import { AttachmentTypes, FilterByOptions, IAssigneeCombined, InputValue, ITemplate, UserIds } from '@/types/interfaces'
 import { getAssigneeName, UserIdsType } from '@/utils/assignee'
 import { deleteEditorAttachmentsHandler, uploadAttachmentHandler } from '@/utils/attachmentUtils'
 import { createUploadFn } from '@/utils/createUploadFn'
@@ -372,7 +372,7 @@ export const NewTaskCard = ({
             placeholder="Add description.."
             editorClass="tapwrite-task-editor"
             uploadFn={uploadFn}
-            deleteEditorAttachments={(url) => deleteEditorAttachmentsHandler(url, token ?? '', null, null)}
+            deleteEditorAttachments={(url) => deleteEditorAttachmentsHandler(url, token ?? '', AttachmentTypes.TASK)}
             attachmentLayout={(props) => (
               <AttachmentLayout {...props} isComment={true} onUploadStatusChange={handleUploadStatusChange} />
             )}

--- a/src/app/detail/ui/TaskEditor.tsx
+++ b/src/app/detail/ui/TaskEditor.tsx
@@ -12,7 +12,7 @@ import { selectTaskDetails, setOpenImage, setShowConfirmDeleteModal } from '@/re
 import store from '@/redux/store'
 import { CreateAttachmentRequest } from '@/types/dto/attachments.dto'
 import { TaskResponse } from '@/types/dto/tasks.dto'
-import { UserType } from '@/types/interfaces'
+import { AttachmentTypes, UserType } from '@/types/interfaces'
 import { getDeleteMessage } from '@/utils/dialogMessages'
 import { deleteEditorAttachmentsHandler, getAttachmentPayload, uploadAttachmentHandler } from '@/utils/attachmentUtils'
 import { Box } from '@mui/material'
@@ -195,7 +195,7 @@ export const TaskEditor = ({
           placeholder="Add description..."
           uploadFn={uploadFn}
           handleImageDoubleClick={handleImagePreview}
-          deleteEditorAttachments={(url) => deleteEditorAttachmentsHandler(url, token ?? '', task_id, null)}
+          deleteEditorAttachments={(url) => deleteEditorAttachmentsHandler(url, token ?? '', AttachmentTypes.TASK, task_id)}
           attachmentLayout={(props) => <AttachmentLayout {...props} />}
           addAttachmentButton
           maxUploadLimit={MAX_UPLOAD_LIMIT}

--- a/src/app/manage-templates/ui/NewTemplateCard.tsx
+++ b/src/app/manage-templates/ui/NewTemplateCard.tsx
@@ -136,7 +136,7 @@ export const NewTemplateCard = ({
             placeholder="Add description.."
             editorClass="tapwrite-task-editor"
             uploadFn={uploadFn}
-            deleteEditorAttachments={(url) => deleteEditorAttachmentsHandler(url, token ?? '', null, null)}
+            deleteEditorAttachments={(url) => deleteEditorAttachmentsHandler(url, token ?? '', AttachmentTypes.TEMPLATE)}
             attachmentLayout={(props) => (
               <AttachmentLayout {...props} isComment={true} onUploadStatusChange={handleUploadStatusChange} />
             )}

--- a/src/app/manage-templates/ui/TemplateDetails.tsx
+++ b/src/app/manage-templates/ui/TemplateDetails.tsx
@@ -281,7 +281,9 @@ export default function TemplateDetails({
           placeholder="Add description..."
           uploadFn={uploadFn}
           handleImageDoubleClick={handleImagePreview}
-          deleteEditorAttachments={(url) => deleteEditorAttachmentsHandler(url, token ?? '', template_id, null)}
+          deleteEditorAttachments={(url) =>
+            deleteEditorAttachmentsHandler(url, token ?? '', AttachmentTypes.TEMPLATE, template_id)
+          }
           attachmentLayout={(props) => <AttachmentLayout {...props} />}
           addAttachmentButton
           maxUploadLimit={MAX_UPLOAD_LIMIT}

--- a/src/app/manage-templates/ui/TemplateForm.tsx
+++ b/src/app/manage-templates/ui/TemplateForm.tsx
@@ -152,14 +152,7 @@ const NewTemplateFormInputs = () => {
             placeholder="Add description.."
             editorClass="tapwrite-description-h-full"
             uploadFn={uploadFn}
-            deleteEditorAttachments={(url) =>
-              deleteEditorAttachmentsHandler(
-                url,
-                token ?? '',
-                null,
-                targetMethod == TargetMethod.POST ? null : targetTemplateId,
-              )
-            }
+            deleteEditorAttachments={(url) => deleteEditorAttachmentsHandler(url, token ?? '', AttachmentTypes.TEMPLATE)}
             attachmentLayout={(props) => <AttachmentLayout {...props} />}
             maxUploadLimit={MAX_UPLOAD_LIMIT}
             parentContainerStyle={{ gap: '0px', minHeight: '60px' }}

--- a/src/app/ui/NewTaskForm.tsx
+++ b/src/app/ui/NewTaskForm.tsx
@@ -34,6 +34,7 @@ import store from '@/redux/store'
 import { HomeParamActions } from '@/types/constants'
 import { WorkflowStateResponse } from '@/types/dto/workflowStates.dto'
 import {
+  AttachmentTypes,
   CreateTaskErrors,
   FilterByOptions,
   FilterOptions,
@@ -668,7 +669,7 @@ const NewTaskFormInputs = ({ isEditorReadonly }: NewTaskFormInputsProps) => {
             editorClass="tapwrite-description-h-full"
             uploadFn={uploadFn}
             readonly={isEditorReadonly}
-            deleteEditorAttachments={(url) => deleteEditorAttachmentsHandler(url, token ?? '', null, null)}
+            deleteEditorAttachments={(url) => deleteEditorAttachmentsHandler(url, token ?? '', AttachmentTypes.TASK)}
             attachmentLayout={(props) => <AttachmentLayout {...props} />}
             maxUploadLimit={MAX_UPLOAD_LIMIT}
             parentContainerStyle={{ gap: '0px', minHeight: '60px' }}

--- a/src/cmd/backfill-attachments/index.ts
+++ b/src/cmd/backfill-attachments/index.ts
@@ -140,10 +140,7 @@ async function run() {
 
   const { taskAttachmentRequests, commentAttachmentRequests } = await createAttachmentRequests(tasks, comments)
 
-  await Promise.all([
-    createAttachmentsInDatabase(db, taskAttachmentRequests),
-    createAttachmentsInDatabase(db, commentAttachmentRequests),
-  ])
+  await createAttachmentsInDatabase(db, [...taskAttachmentRequests, ...commentAttachmentRequests])
 
   console.info('✅ Backfill complete')
 }

--- a/src/cmd/backfill-attachments/index.ts
+++ b/src/cmd/backfill-attachments/index.ts
@@ -1,0 +1,149 @@
+import DBClient from '@/lib/db'
+import { CreateAttachmentRequestSchema } from '@/types/dto/attachments.dto'
+import { getFilePathFromUrl } from '@/utils/signedUrlReplacer'
+import { SupabaseActions } from '@/utils/SupabaseActions'
+import { Task, Comment } from '@prisma/client'
+
+const ATTACHMENT_TAG_REGEX = /<\s*[a-zA-Z]+\s+[^>]*data-type="attachment"[^>]*src="([^"]+)"[^>]*>/g
+const IMG_TAG_REGEX = /<img\s+[^>]*src="([^"]+)"[^>]*>/g
+
+interface AttachmentRequest {
+  createdById: string
+  workspaceId: string
+  attachmentRequest: ReturnType<typeof CreateAttachmentRequestSchema.parse>
+}
+
+interface ProcessedAttachments {
+  taskAttachmentRequests: AttachmentRequest[]
+  commentAttachmentRequests: AttachmentRequest[]
+  filesNotFoundInBucket: string[]
+}
+
+async function extractAttachmentsFromContent(
+  content: string,
+  supabaseActions: SupabaseActions,
+  filesNotFound: string[],
+): Promise<Array<{ filePath: string; fileSize?: number; fileType?: string; fileName?: string }>> {
+  const attachments: Array<{ filePath: string; fileSize?: number; fileType?: string; fileName?: string }> = []
+  const regexes = [IMG_TAG_REGEX, ATTACHMENT_TAG_REGEX]
+
+  for (const regex of regexes) {
+    let match
+    regex.lastIndex = 0
+    while ((match = regex.exec(content)) !== null) {
+      const originalSrc = match[1]
+      const filePath = getFilePathFromUrl(originalSrc)
+      if (!filePath) continue
+      const fileMetaData = await supabaseActions.getMetaData(filePath)
+      if (!fileMetaData) {
+        filesNotFound.push(filePath)
+        continue
+      }
+      const fileName = filePath.split('/').pop()
+      attachments.push({
+        filePath,
+        fileSize: fileMetaData.size,
+        fileType: fileMetaData.contentType,
+        fileName,
+      })
+    }
+  }
+  return attachments
+}
+
+async function createAttachmentRequests(tasks: Task[], comments: Comment[]): Promise<ProcessedAttachments> {
+  const taskAttachmentRequests: AttachmentRequest[] = []
+  const commentAttachmentRequests: AttachmentRequest[] = []
+  const filesNotFoundInBucket: string[] = []
+  const supabaseActions = new SupabaseActions()
+
+  for (const task of tasks) {
+    const bodyString = task.body ?? ''
+    const attachments = await extractAttachmentsFromContent(bodyString, supabaseActions, filesNotFoundInBucket)
+    for (const attachment of attachments) {
+      taskAttachmentRequests.push({
+        createdById: task.createdById,
+        workspaceId: task.workspaceId,
+        attachmentRequest: CreateAttachmentRequestSchema.parse({
+          taskId: task.id,
+          ...attachment,
+        }),
+      })
+    }
+  }
+
+  for (const comment of comments) {
+    const contentString = comment.content ?? ''
+    const attachments = await extractAttachmentsFromContent(contentString, supabaseActions, filesNotFoundInBucket)
+    for (const attachment of attachments) {
+      commentAttachmentRequests.push({
+        createdById: comment.initiatorId,
+        workspaceId: comment.workspaceId,
+        attachmentRequest: CreateAttachmentRequestSchema.parse({
+          commentId: comment.id,
+          ...attachment,
+        }),
+      })
+    }
+  }
+
+  if (taskAttachmentRequests.length) {
+    console.info('🔥 Task attachments to be populated:', taskAttachmentRequests.length)
+  }
+  if (commentAttachmentRequests.length) {
+    console.info('🔥 Comment attachments to be populated:', commentAttachmentRequests.length)
+  }
+  if (filesNotFoundInBucket.length) {
+    console.warn('⚠️  Files not found in bucket:', filesNotFoundInBucket)
+  }
+
+  return { taskAttachmentRequests, commentAttachmentRequests, filesNotFoundInBucket }
+}
+
+async function createAttachmentsInDatabase(
+  db: ReturnType<typeof DBClient.getInstance>,
+  attachmentRequests: AttachmentRequest[],
+) {
+  let created = 0
+  let skipped = 0
+
+  for (const { createdById, workspaceId, attachmentRequest } of attachmentRequests) {
+    try {
+      const existing = await db.attachment.findFirst({
+        where: { filePath: attachmentRequest.filePath },
+      })
+      if (existing) {
+        skipped++
+        continue
+      }
+      await db.attachment.create({
+        data: {
+          ...attachmentRequest,
+          createdById,
+          workspaceId,
+        },
+      })
+      created++
+    } catch (error) {
+      console.error('❌ Failed to create attachment:', attachmentRequest, error)
+    }
+  }
+
+  console.info(`📊 Created: ${created}, Skipped (already exists): ${skipped}`)
+}
+
+async function run() {
+  console.info('🧑🏻‍💻 Backfilling attachment entries for tasks and comments')
+
+  const db = DBClient.getInstance()
+  const [tasks, comments] = await Promise.all([db.task.findMany(), db.comment.findMany()])
+
+  const { taskAttachmentRequests, commentAttachmentRequests } = await createAttachmentRequests(tasks, comments)
+
+  await createAttachmentsInDatabase(db, taskAttachmentRequests)
+  await createAttachmentsInDatabase(db, commentAttachmentRequests)
+
+  console.info('✅ Backfill complete')
+}
+
+run()

--- a/src/cmd/backfill-attachments/index.ts
+++ b/src/cmd/backfill-attachments/index.ts
@@ -140,8 +140,10 @@ async function run() {
 
   const { taskAttachmentRequests, commentAttachmentRequests } = await createAttachmentRequests(tasks, comments)
 
-  await createAttachmentsInDatabase(db, taskAttachmentRequests)
-  await createAttachmentsInDatabase(db, commentAttachmentRequests)
+  await Promise.all([
+    createAttachmentsInDatabase(db, taskAttachmentRequests),
+    createAttachmentsInDatabase(db, commentAttachmentRequests),
+  ])
 
   console.info('✅ Backfill complete')
 }

--- a/src/components/cards/CommentCard.tsx
+++ b/src/components/cards/CommentCard.tsx
@@ -29,7 +29,7 @@ import store from '@/redux/store'
 import { CommentResponse, CreateComment, UpdateComment } from '@/types/dto/comment.dto'
 import { AttachmentTypes, IAssigneeCombined } from '@/types/interfaces'
 import { getAssigneeName } from '@/utils/assignee'
-import { deleteEditorAttachmentsHandler, getAttachmentPayload } from '@/utils/attachmentUtils'
+import { deleteEditorAttachmentsHandler, getAttachmentPayload, getCustomFilePath } from '@/utils/attachmentUtils'
 import { createUploadFn } from '@/utils/createUploadFn'
 import { fetcher } from '@/utils/fetcher'
 import { getTimeDifference } from '@/utils/getTimeDifference'
@@ -330,14 +330,13 @@ export const CommentCard = ({
                 editorClass={isReadOnly ? 'tapwrite-comment' : 'tapwrite-comment-editable'}
                 addAttachmentButton={!isReadOnly}
                 uploadFn={uploadFn}
-                deleteEditorAttachments={(url) =>
-                  deleteEditorAttachmentsHandler(
-                    url,
-                    token ?? '',
-                    AttachmentTypes.COMMENT,
-                    z.string().parse(commentIdRef.current),
-                  )
-                }
+                deleteEditorAttachments={(url) => {
+                  const commentId = z.string().parse(commentIdRef.current)
+                  const customFilePath = tokenPayload?.workspaceId
+                    ? getCustomFilePath(tokenPayload?.workspaceId, task_id, commentId, url)
+                    : undefined
+                  return deleteEditorAttachmentsHandler(url, token ?? '', AttachmentTypes.COMMENT, commentId, customFilePath)
+                }}
                 maxUploadLimit={MAX_UPLOAD_LIMIT}
                 attachmentLayout={(props) => <AttachmentLayout {...props} isComment={true} />}
                 hardbreak

--- a/src/components/cards/CommentCard.tsx
+++ b/src/components/cards/CommentCard.tsx
@@ -330,7 +330,14 @@ export const CommentCard = ({
                 editorClass={isReadOnly ? 'tapwrite-comment' : 'tapwrite-comment-editable'}
                 addAttachmentButton={!isReadOnly}
                 uploadFn={uploadFn}
-                deleteEditorAttachments={(url) => deleteEditorAttachmentsHandler(url, token ?? '', task_id, null)}
+                deleteEditorAttachments={(url) =>
+                  deleteEditorAttachmentsHandler(
+                    url,
+                    token ?? '',
+                    AttachmentTypes.COMMENT,
+                    z.string().parse(commentIdRef.current),
+                  )
+                }
                 maxUploadLimit={MAX_UPLOAD_LIMIT}
                 attachmentLayout={(props) => <AttachmentLayout {...props} isComment={true} />}
                 hardbreak

--- a/src/components/cards/ReplyCard.tsx
+++ b/src/components/cards/ReplyCard.tsx
@@ -245,7 +245,14 @@ export const ReplyCard = ({
               editorClass={isReadOnly ? 'tapwrite-comment' : 'tapwrite-comment-editable'}
               addAttachmentButton={!isReadOnly}
               uploadFn={uploadFn}
-              deleteEditorAttachments={(url) => deleteEditorAttachmentsHandler(url, token ?? '', task_id, null)}
+              deleteEditorAttachments={(url) =>
+                deleteEditorAttachmentsHandler(
+                  url,
+                  token ?? '',
+                  AttachmentTypes.COMMENT,
+                  z.string().parse(commentIdRef.current),
+                )
+              }
               maxUploadLimit={MAX_UPLOAD_LIMIT}
               attachmentLayout={(props) => <AttachmentLayout {...props} isComment={true} />}
               hardbreak

--- a/src/components/cards/ReplyCard.tsx
+++ b/src/components/cards/ReplyCard.tsx
@@ -19,7 +19,7 @@ import { selectTaskBoard } from '@/redux/features/taskBoardSlice'
 import { UpdateComment } from '@/types/dto/comment.dto'
 import { AttachmentTypes, IAssigneeCombined } from '@/types/interfaces'
 import { getAssigneeName } from '@/utils/assignee'
-import { deleteEditorAttachmentsHandler, getAttachmentPayload } from '@/utils/attachmentUtils'
+import { deleteEditorAttachmentsHandler, getAttachmentPayload, getCustomFilePath } from '@/utils/attachmentUtils'
 import { createUploadFn } from '@/utils/createUploadFn'
 import { getTimeDifference } from '@/utils/getTimeDifference'
 import { isTapwriteContentEmpty } from '@/utils/isTapwriteContentEmpty'
@@ -245,14 +245,13 @@ export const ReplyCard = ({
               editorClass={isReadOnly ? 'tapwrite-comment' : 'tapwrite-comment-editable'}
               addAttachmentButton={!isReadOnly}
               uploadFn={uploadFn}
-              deleteEditorAttachments={(url) =>
-                deleteEditorAttachmentsHandler(
-                  url,
-                  token ?? '',
-                  AttachmentTypes.COMMENT,
-                  z.string().parse(commentIdRef.current),
-                )
-              }
+              deleteEditorAttachments={(url) => {
+                const commentId = z.string().parse(commentIdRef.current)
+                const customFilePath = tokenPayload?.workspaceId
+                  ? getCustomFilePath(tokenPayload?.workspaceId, task_id, commentId, url)
+                  : undefined
+                return deleteEditorAttachmentsHandler(url, token ?? '', AttachmentTypes.COMMENT, commentId, customFilePath)
+              }}
               maxUploadLimit={MAX_UPLOAD_LIMIT}
               attachmentLayout={(props) => <AttachmentLayout {...props} isComment={true} />}
               hardbreak

--- a/src/components/inputs/CommentInput.tsx
+++ b/src/components/inputs/CommentInput.tsx
@@ -9,6 +9,7 @@ import { useWindowWidth } from '@/hooks/useWindowWidth'
 import { selectAuthDetails } from '@/redux/features/authDetailsSlice'
 import { selectTaskBoard } from '@/redux/features/taskBoardSlice'
 import { CreateComment } from '@/types/dto/comment.dto'
+import { AttachmentTypes } from '@/types/interfaces'
 import { deleteEditorAttachmentsHandler, uploadAttachmentHandler } from '@/utils/attachmentUtils'
 import { createUploadFn } from '@/utils/createUploadFn'
 import { getMentionsList } from '@/utils/getMentionList'
@@ -168,7 +169,7 @@ export const CommentInput = ({ createComment, task_id, token }: Prop) => {
             whiteSpace: 'pre-wrap',
           }}
           uploadFn={uploadFn}
-          deleteEditorAttachments={(url) => deleteEditorAttachmentsHandler(url, token ?? '', task_id, null)}
+          deleteEditorAttachments={(url) => deleteEditorAttachmentsHandler(url, token ?? '', AttachmentTypes.COMMENT)}
           attachmentLayout={(props) => (
             <AttachmentLayout {...props} isComment={true} onUploadStatusChange={handleUploadStatusChange} />
           )}

--- a/src/components/inputs/ReplyInput.tsx
+++ b/src/components/inputs/ReplyInput.tsx
@@ -13,6 +13,7 @@ import { Dispatch, SetStateAction, useCallback, useEffect, useRef, useState } fr
 import { useSelector } from 'react-redux'
 import { Tapwrite } from 'tapwrite'
 import { createUploadFn } from '@/utils/createUploadFn'
+import { AttachmentTypes } from '@/types/interfaces'
 
 interface ReplyInputProps {
   token: string
@@ -197,7 +198,7 @@ export const ReplyInput = ({
               flexGrow: 1,
             }}
             addAttachmentButton
-            deleteEditorAttachments={(url) => deleteEditorAttachmentsHandler(url, token ?? '', task_id, null)}
+            deleteEditorAttachments={(url) => deleteEditorAttachmentsHandler(url, token ?? '', AttachmentTypes.COMMENT)}
             uploadFn={uploadFn}
             maxUploadLimit={MAX_UPLOAD_LIMIT}
             endButtons={<SubmitCommentButtons handleSubmit={handleReplySubmission} disabled={isUploading} />}

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -216,8 +216,9 @@ export const NotificationRequestBodySchema = z
 
 export const ScrapMediaRequestSchema = z.object({
   filePath: z.string(),
-  taskId: z.string().uuid().nullable(),
-  templateId: z.string().uuid().nullable(),
+  taskId: z.string().uuid().optional(),
+  templateId: z.string().uuid().optional(),
+  commentId: z.string().uuid().optional(),
 })
 
 export type ScrapMediaRequest = z.infer<typeof ScrapMediaRequestSchema>

--- a/src/utils/attachmentUtils.ts
+++ b/src/utils/attachmentUtils.ts
@@ -57,11 +57,12 @@ export const deleteEditorAttachmentsHandler = async (
   token: string,
   entityType: AttachmentTypes,
   entityId?: string,
+  customFilePath?: string, //used only for comments and replies. Because newly created comments and replies have mismatched urls. And the url doesnt refresh without a page refresh.
 ) => {
   const filePath = getFilePathFromUrl(url)
   if (filePath) {
     const payload: ScrapMediaRequest = {
-      filePath,
+      filePath: customFilePath ?? filePath,
       ...(entityType === AttachmentTypes.TASK
         ? { taskId: entityId }
         : entityType === AttachmentTypes.TEMPLATE
@@ -94,4 +95,13 @@ export const getAttachmentPayload = (
 export const getFileNameFromPath = (path: string): string => {
   const segments = path.split('/').filter(Boolean)
   return segments[segments.length - 1] || ''
+}
+
+export const getCustomFilePath = (workspaceId: string, task_id: string, commentId: string, url: string) => {
+  const filePath = getFilePathFromUrl(url)
+  if (!filePath) {
+    return undefined
+  }
+  const fileName = getFileNameFromPath(filePath)
+  return `${workspaceId}/${task_id}/comments/${commentId}/${fileName}`
 }

--- a/src/utils/attachmentUtils.ts
+++ b/src/utils/attachmentUtils.ts
@@ -55,15 +55,18 @@ export const uploadAttachmentHandler = async (
 export const deleteEditorAttachmentsHandler = async (
   url: string,
   token: string,
-  task_id: string | null,
-  template_id: string | null,
+  entityType: AttachmentTypes,
+  entityId?: string,
 ) => {
   const filePath = getFilePathFromUrl(url)
   if (filePath) {
     const payload: ScrapMediaRequest = {
-      filePath: filePath,
-      taskId: task_id,
-      templateId: template_id,
+      filePath,
+      ...(entityType === AttachmentTypes.TASK
+        ? { taskId: entityId }
+        : entityType === AttachmentTypes.TEMPLATE
+          ? { templateId: entityId }
+          : { commentId: entityId }),
     }
     postScrapMedia(token, payload)
   }


### PR DESCRIPTION
## Changes

- [x] added support for comments attachments deletion from supabase buckets in scrap medias. cleaned out some services

## Testing Criteria 

- [LOOM](https://www.loom.com/share/a0d6ba6e71dc4d00b4e3b0362db18497)

