### PR TITLE
OUT-3127: show confirmation dialog when assignee/association is changed of shared task

### DIFF
--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -2,55 +2,55 @@
 // The config you add here will be used whenever a users loads a page in their browser.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
-import * as Sentry from "@sentry/nextjs";
+import * as Sentry from '@sentry/nextjs'
 
-const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN || process.env.SENTRY_DSN;
-const vercelEnv = process.env.NEXT_PUBLIC_VERCEL_ENV;
-const isProd = process.env.NEXT_PUBLIC_VERCEL_ENV === "production";
+const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN || process.env.SENTRY_DSN
+const vercelEnv = process.env.NEXT_PUBLIC_VERCEL_ENV
+const isProd = process.env.NEXT_PUBLIC_VERCEL_ENV === 'production'
 
 if (dsn) {
-	Sentry.init({
-		dsn,
+  Sentry.init({
+    dsn,
 
-		// Adjust this value in production, or use tracesSampler for greater control
-		tracesSampleRate: isProd ? 0.2 : 1,
-		profilesSampleRate: 0.1,
-		// NOTE: reducing sample only 10% of transactions in prod to get general trends instead of detailed and overfitted data
+    // Adjust this value in production, or use tracesSampler for greater control
+    tracesSampleRate: isProd ? 0.2 : 1,
+    profilesSampleRate: 0.1,
+    // NOTE: reducing sample only 10% of transactions in prod to get general trends instead of detailed and overfitted data
 
-		// Setting this option to true will print useful information to the console while you're setting up Sentry.
-		debug: false,
+    // Setting this option to true will print useful information to the console while you're setting up Sentry.
+    debug: false,
 
-		// You can remove this option if you're not planning to use the Sentry Session Replay feature:
-		// NOTE: Since session replay barely helps us anyways, getting rid of it to reduce some bundle size at least
-		// replaysOnErrorSampleRate: 1.0,
-		// replaysSessionSampleRate: 0,
-		integrations: [
-			Sentry.browserTracingIntegration({
-				beforeStartSpan: (e) => {
-					console.info('SentryBrowserTracingSpan', e.name)
-					return e
-				},
-			}),
-			//   Sentry.replayIntegration({
-			// Additional Replay configuration goes in here, for example:
-			//     maskAllText: true,
-			//     blockAllMedia: true,
-			//   }),
-		],
+    // You can remove this option if you're not planning to use the Sentry Session Replay feature:
+    // NOTE: Since session replay barely helps us anyways, getting rid of it to reduce some bundle size at least
+    // replaysOnErrorSampleRate: 1.0,
+    // replaysSessionSampleRate: 0,
+    integrations: [
+      Sentry.browserTracingIntegration({
+        beforeStartSpan: (e) => {
+          console.info('SentryBrowserTracingSpan', e.name)
+          return e
+        },
+      }),
+      //   Sentry.replayIntegration({
+      // Additional Replay configuration goes in here, for example:
+      //     maskAllText: true,
+      //     blockAllMedia: true,
+      //   }),
+    ],
 
-		// ignoreErrors: [/fetch failed/i],
-		ignoreErrors: [/fetch failed/i],
+    // ignoreErrors: [/fetch failed/i],
+    ignoreErrors: [/fetch failed/i],
 
-		beforeSend(event) {
-			if (!isProd && event.type === undefined) {
-				return null
-			}
-			event.tags = {
-				...event.tags,
-				// Adding additional app_env tag for cross-checking
-				app_env: isProd ? 'production' : vercelEnv || 'development',
-			}
-			return event
-		},
-	})
+    beforeSend(event) {
+      if (!isProd && event.type === undefined) {
+        return null
+      }
+      event.tags = {
+        ...event.tags,
+        // Adding additional app_env tag for cross-checking
+        app_env: isProd ? 'production' : vercelEnv || 'development',
+      }
+      return event
+    },
+  })
 }

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -2,31 +2,31 @@
 // The config you add here will be used whenever the server handles a request.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
-import * as Sentry from "@sentry/nextjs";
+import * as Sentry from '@sentry/nextjs'
 
 const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN || process.env.SENTRY_DSN
 const vercelEnv = process.env.NEXT_PUBLIC_VERCEL_ENV
 const isProd = process.env.NEXT_PUBLIC_VERCEL_ENV === 'production'
 
 if (dsn) {
-	Sentry.init({
-		dsn,
+  Sentry.init({
+    dsn,
 
-		// Adjust this value in production, or use tracesSampler for greater control
-		tracesSampleRate: 1,
+    // Adjust this value in production, or use tracesSampler for greater control
+    tracesSampleRate: 1,
 
-		// Setting this option to true will print useful information to the console while you're setting up Sentry.
-		debug: false,
+    // Setting this option to true will print useful information to the console while you're setting up Sentry.
+    debug: false,
 
-		// Uncomment the line below to enable Spotlight (https://spotlightjs.com)
-		// spotlight: process.env.NODE_ENV === 'development',
-		ignoreErrors: [/fetch failed/i],
+    // Uncomment the line below to enable Spotlight (https://spotlightjs.com)
+    // spotlight: process.env.NODE_ENV === 'development',
+    ignoreErrors: [/fetch failed/i],
 
-		beforeSend(event) {
-			if (!isProd && event.type === undefined) {
-				return null
-			}
-			return event
-		},
-	})
+    beforeSend(event) {
+      if (!isProd && event.type === undefined) {
+        return null
+      }
+      return event
+    },
+  })
 }

--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -313,7 +313,7 @@ export class TasksService extends TasksSharedService {
     }
   }
 
-  private validateTaskShare(prevTask: Task, data: UpdateTaskRequest) {
+  private validateTaskShare(prevTask: Task, data: UpdateTaskRequest): boolean | undefined {
     const isTaskShared = data.isShared
 
     if (isTaskShared === undefined) return undefined

--- a/src/app/detail/[task_id]/[user_type]/actions.ts
+++ b/src/app/detail/[task_id]/[user_type]/actions.ts
@@ -58,7 +58,7 @@ export const updateAssignee = async (
       clientId,
       companyId,
       ...(associations && { associations: clientId || companyId ? [] : associations }), // if assignee is not internal user, remove associations. Only include associations if viewer are changed. Not including viewer means not chaning the current state of associations in DB.
-      ...(isShared !== undefined && { isShared }),
+      isShared: isShared ?? undefined,
     }),
   })
 }

--- a/src/app/detail/[task_id]/[user_type]/actions.ts
+++ b/src/app/detail/[task_id]/[user_type]/actions.ts
@@ -57,8 +57,8 @@ export const updateAssignee = async (
       internalUserId,
       clientId,
       companyId,
-      ...(associations && { associations: !internalUserId ? [] : associations }), // if assignee is not internal user, remove associations. Only include associations if viewer are changed. Not including viewer means not chaning the current state of associations in DB.
-      ...(isShared && { isShared }),
+      ...(associations && { associations: clientId || companyId ? [] : associations }), // if assignee is not internal user, remove associations. Only include associations if viewer are changed. Not including viewer means not chaning the current state of associations in DB.
+      ...(isShared !== undefined && { isShared }),
     }),
   })
 }

--- a/src/app/detail/ui/Sidebar.tsx
+++ b/src/app/detail/ui/Sidebar.tsx
@@ -41,7 +41,7 @@ import {
 } from '@/utils/selector'
 import {
   shouldConfirmBeforeReassignment,
-  shouldConfirmAssociationBeforeReassignment,
+  shouldConfirmTaskSharedBeforeReassignment,
 } from '@/utils/shouldConfirmBeforeReassign'
 import { useEffect, useState } from 'react'
 import { useSelector } from 'react-redux'
@@ -215,7 +215,7 @@ export const Sidebar = ({
     const previousAssignee = assignee.find((assignee) => assignee.id == getAssigneeId(getUserIds(activeTask)))
     const nextAssignee = getSelectorAssignee(assignee, inputValue)
     const shouldShowConfirmModal = shouldConfirmBeforeReassignment(previousAssignee, nextAssignee)
-    const shouldShowConfirmAssociationModal = shouldConfirmAssociationBeforeReassignment(
+    const showAssociationConfirmModal = shouldConfirmTaskSharedBeforeReassignment(
       taskAssociationValue,
       isTaskShared,
       nextAssignee,
@@ -223,7 +223,7 @@ export const Sidebar = ({
     if (shouldShowConfirmModal) {
       setSelectedAssignee(newUserIds)
       store.dispatch(toggleShowConfirmAssignModal())
-    } else if (shouldShowConfirmAssociationModal) {
+    } else if (showAssociationConfirmModal) {
       setSelectedAssignee(newUserIds)
       setAssociationConfirmationModal(true)
     } else {
@@ -240,7 +240,7 @@ export const Sidebar = ({
     setSelectorFieldType(SelectorFieldType.ASSOCIATION)
     const newTaskAssociationIds = getSelectedViewerIds(inputValue)
 
-    const showModal = shouldConfirmAssociationBeforeReassignment(taskAssociationValue, isTaskShared)
+    const showModal = shouldConfirmTaskSharedBeforeReassignment(taskAssociationValue, isTaskShared)
     if (showModal) {
       setAssociationConfirmationModal(true)
     } else if (newTaskAssociationIds) {

--- a/src/app/detail/ui/Sidebar.tsx
+++ b/src/app/detail/ui/Sidebar.tsx
@@ -148,23 +148,22 @@ export const Sidebar = ({
 
   const checkForAssociationAndShared = (userIds: UserIdsType): UserIdsWithAssociationSharedType => {
     const { internalUserId, clientId, companyId } = userIds
+
+    if (internalUserId) return userIds
+
     const noAssignee = !internalUserId && !clientId && !companyId
+    const temp: Partial<UserIdsWithAssociationSharedType> = {}
 
-    if (!internalUserId) {
-      const temp: Partial<UserIdsWithAssociationSharedType> = {}
-
-      if (isTaskShared) {
-        temp.isShared = false
-        setIsTaskShared(false)
-      }
-
-      if (!noAssignee) {
-        temp.associations = [] // remove association only if assignee is non empty and not IU
-        setTaskAssociationValue(null)
-      }
-      return { ...userIds, ...temp } // remove task shared if assignee is cleared or changed to client or company
+    if (isTaskShared) {
+      temp.isShared = false
+      setIsTaskShared(false)
     }
-    return userIds
+
+    if (!noAssignee) {
+      temp.associations = [] // remove association only if assignee is non empty and not IU
+      setTaskAssociationValue(null)
+    }
+    return { ...userIds, ...temp } // remove task shared if assignee is cleared or changed to client or company
   }
 
   const handleConfirmAssigneeChange = (userIds: UserIdsType) => {
@@ -176,7 +175,7 @@ export const Sidebar = ({
 
   const handleConfirmAssociationChange = () => {
     updateAssignee({
-      internalUserId: assigneeValue ? assigneeValue.id : null,
+      internalUserId: assigneeValue?.id || null,
       clientId: null,
       companyId: null,
       isShared: false,

--- a/src/app/detail/ui/TaskCardList.tsx
+++ b/src/app/detail/ui/TaskCardList.tsx
@@ -48,7 +48,7 @@ import {
 } from '@/utils/selector'
 import {
   shouldConfirmBeforeReassignment,
-  shouldConfirmAssociationBeforeReassignment,
+  shouldConfirmTaskSharedBeforeReassignment,
 } from '@/utils/shouldConfirmBeforeReassign'
 import { checkIfTaskViewer } from '@/utils/taskViewer'
 
@@ -138,7 +138,7 @@ export const TaskCardList = ({
     const previousAssignee = assignee.find((assignee) => assignee.id == getAssigneeId(getUserIds(task)))
     const nextAssignee = getSelectorAssignee(assignee, inputValue)
     const shouldShowConfirmModal = shouldConfirmBeforeReassignment(previousAssignee, nextAssignee)
-    const shouldShowConfirmAssociationModal = shouldConfirmAssociationBeforeReassignment(
+    const showAssociationConfirmModal = shouldConfirmTaskSharedBeforeReassignment(
       getSelectorAssociationFromTask(assignee, task) ?? null,
       !!task.isShared,
       nextAssignee,
@@ -146,7 +146,7 @@ export const TaskCardList = ({
     if (shouldShowConfirmModal) {
       setSelectedAssignee(newUserIds)
       store.dispatch(setConfirmAssigneeModalId(task.id))
-    } else if (shouldShowConfirmAssociationModal) {
+    } else if (showAssociationConfirmModal) {
       setSelectedAssignee(newUserIds)
       store.dispatch(setConfirmAssociationModalId(task.id))
     } else {

--- a/src/components/cards/TaskCard.tsx
+++ b/src/components/cards/TaskCard.tsx
@@ -10,7 +10,7 @@ import {
   selectTaskBoard,
   setAssigneeCache,
   setConfirmAssigneeModalId,
-  setConfirmViewershipModalId,
+  setConfirmAssociationModalId,
   updateWorkflowStateIdByTaskId,
 } from '@/redux/features/taskBoardSlice'
 import store from '@/redux/store'
@@ -20,7 +20,7 @@ import { IAssigneeCombined, InputValue, Sizes } from '@/types/interfaces'
 import {
   getAssigneeId,
   getAssigneeName,
-  getAssigneeValueFromViewers,
+  getAssigneeValueFromAssociations,
   getUserIds,
   isEmptyAssignee,
   UserIdsType,
@@ -47,11 +47,11 @@ import {
   getSelectedUserIds,
   getSelectorAssignee,
   getSelectorAssigneeFromTask,
-  getSelectorViewerFromTask,
+  getSelectorAssociationFromTask,
 } from '@/utils/selector'
 import {
   shouldConfirmBeforeReassignment,
-  shouldConfirmViewershipBeforeReassignment,
+  shouldConfirmAssociationBeforeReassignment,
 } from '@/utils/shouldConfirmBeforeReassign'
 import z from 'zod'
 import { StyledModal } from '@/app/detail/ui/styledComponent'
@@ -96,7 +96,7 @@ export const TaskCard = ({ task, href, workflowState, mode, subtasks, workflowDi
     accessibleTasks,
     showSubtasks,
     confirmAssignModalId,
-    confirmViewershipModalId,
+    confirmAssociationModalId,
   } = useSelector(selectTaskBoard)
 
   const subtaskCount = useSubtaskCount(task.id)
@@ -132,11 +132,14 @@ export const TaskCard = ({ task, href, workflowState, mode, subtasks, workflowDi
   }, [task.dueDate])
 
   const handleConfirmAssigneeChange = (userIds: UserIdsType) => {
+    const isAssigneeClient = !!(userIds.clientId || userIds.companyId)
+    const hasNoAssignee = !userIds.internalUserId && !isAssigneeClient
+    const associations = isAssigneeClient ? [] : undefined
+    const isShared = hasNoAssignee || isAssigneeClient ? false : undefined
     const { internalUserId, clientId, companyId } = userIds
-    const viewers = !internalUserId ? [] : undefined
     store.dispatch(setConfirmAssigneeModalId(undefined))
-    store.dispatch(setConfirmViewershipModalId(undefined))
-    token && updateAssignee(token, task.id, internalUserId, clientId, companyId, viewers)
+    store.dispatch(setConfirmAssociationModalId(undefined))
+    token && updateAssignee(token, task.id, internalUserId, clientId, companyId, associations, isShared)
   }
 
   const handleAssigneeChange = (inputValue: InputValue[]) => {
@@ -144,23 +147,28 @@ export const TaskCard = ({ task, href, workflowState, mode, subtasks, workflowDi
     const previousAssignee = assignee.find((assignee) => assignee.id == getAssigneeId(getUserIds(task)))
     const nextAssignee = getSelectorAssignee(assignee, inputValue)
     const shouldShowConfirmModal = shouldConfirmBeforeReassignment(previousAssignee, nextAssignee)
-    const shouldShowConfirmViewershipModal = shouldConfirmViewershipBeforeReassignment(
-      getSelectorViewerFromTask(assignee, task) ?? null,
+    const shouldShowConfirmAssociationModal = shouldConfirmAssociationBeforeReassignment(
+      getSelectorAssociationFromTask(assignee, task) ?? null,
+      !!task.isShared,
       nextAssignee,
     )
     if (shouldShowConfirmModal) {
       setSelectedAssignee(newUserIds)
       store.dispatch(setConfirmAssigneeModalId(task.id))
-    } else if (shouldShowConfirmViewershipModal) {
+    } else if (shouldShowConfirmAssociationModal) {
       setSelectedAssignee(newUserIds)
-      store.dispatch(setConfirmViewershipModalId(task.id))
+      store.dispatch(setConfirmAssociationModalId(task.id))
     } else {
       const { internalUserId, clientId, companyId } = newUserIds
-      const viewers = !internalUserId ? [] : undefined
-      token && updateAssignee(token, task.id, internalUserId, clientId, companyId, viewers)
+      const isAssigneeClient = !!(clientId || companyId)
+      const hasNoAssignee = !internalUserId && !isAssigneeClient
+      const associations = isAssigneeClient ? [] : undefined
+      const isShared = hasNoAssignee || isAssigneeClient ? false : undefined
+      token && updateAssignee(token, task.id, internalUserId, clientId, companyId, associations, isShared)
       setAssigneeValue(nextAssignee ?? NoAssignee)
     }
   }
+
   const getAssigneeValue = (userIds?: UserIdsType) => {
     if (!userIds) {
       return NoAssignee
@@ -330,11 +338,11 @@ export const TaskCard = ({ task, href, workflowState, mode, subtasks, workflowDi
         )}
       </Stack>
       <StyledModal
-        open={confirmAssignModalId === task.id || confirmViewershipModalId === task.id}
+        open={confirmAssignModalId === task.id || confirmAssociationModalId === task.id}
         onClose={(e: React.MouseEvent) => {
           e.stopPropagation()
           store.dispatch(setConfirmAssigneeModalId(undefined))
-          store.dispatch(setConfirmViewershipModalId(undefined))
+          store.dispatch(setConfirmAssociationModalId(undefined))
         }}
         aria-labelledby="confirm-reassignment-modal"
         aria-describedby="confirm-reassignment"
@@ -343,14 +351,14 @@ export const TaskCard = ({ task, href, workflowState, mode, subtasks, workflowDi
           handleCancel={() => {
             setSelectedAssignee(undefined)
             store.dispatch(setConfirmAssigneeModalId(undefined))
-            store.dispatch(setConfirmViewershipModalId(undefined))
+            store.dispatch(setConfirmAssociationModalId(undefined))
           }}
           handleConfirm={() => {
             if (selectedAssignee) {
               handleConfirmAssigneeChange(selectedAssignee)
             }
           }}
-          buttonText={confirmViewershipModalId === task.id ? 'Remove' : 'Reassign'}
+          buttonText={confirmAssociationModalId === task.id ? 'Remove' : 'Reassign'}
           description={
             confirmAssignModalId === task.id ? (
               <>
@@ -362,17 +370,21 @@ export const TaskCard = ({ task, href, workflowState, mode, subtasks, workflowDi
               </>
             ) : (
               <>
+                The task will be stopped sharing with{' '}
                 <strong>
-                  {getAssigneeName(getAssigneeValueFromViewers(getSelectorViewerFromTask(assignee, task) ?? null, assignee))}
-                </strong>{' '}
-                will also lose visibility to the task.
+                  {getAssigneeName(
+                    getAssigneeValueFromAssociations(getSelectorAssociationFromTask(assignee, task) ?? null, assignee),
+                  )}
+                </strong>
               </>
             )
           }
           title={
-            confirmViewershipModalId === task.id && isEmptyAssignee(selectedAssignee) ? 'Remove assignee?' : 'Reassign task?'
+            confirmAssociationModalId === task.id && isEmptyAssignee(selectedAssignee)
+              ? 'Remove assignee?'
+              : 'Reassign task?'
           }
-          variant={confirmViewershipModalId === task.id ? 'danger' : 'default'}
+          variant={confirmAssociationModalId === task.id ? 'danger' : 'default'}
         />
       </StyledModal>
     </TaskCardContainer>

--- a/src/components/cards/TaskCard.tsx
+++ b/src/components/cards/TaskCard.tsx
@@ -51,7 +51,7 @@ import {
 } from '@/utils/selector'
 import {
   shouldConfirmBeforeReassignment,
-  shouldConfirmAssociationBeforeReassignment,
+  shouldConfirmTaskSharedBeforeReassignment,
 } from '@/utils/shouldConfirmBeforeReassign'
 import z from 'zod'
 import { StyledModal } from '@/app/detail/ui/styledComponent'
@@ -147,7 +147,7 @@ export const TaskCard = ({ task, href, workflowState, mode, subtasks, workflowDi
     const previousAssignee = assignee.find((assignee) => assignee.id == getAssigneeId(getUserIds(task)))
     const nextAssignee = getSelectorAssignee(assignee, inputValue)
     const shouldShowConfirmModal = shouldConfirmBeforeReassignment(previousAssignee, nextAssignee)
-    const shouldShowConfirmAssociationModal = shouldConfirmAssociationBeforeReassignment(
+    const showAssociationConfirmModal = shouldConfirmTaskSharedBeforeReassignment(
       getSelectorAssociationFromTask(assignee, task) ?? null,
       !!task.isShared,
       nextAssignee,
@@ -155,7 +155,7 @@ export const TaskCard = ({ task, href, workflowState, mode, subtasks, workflowDi
     if (shouldShowConfirmModal) {
       setSelectedAssignee(newUserIds)
       store.dispatch(setConfirmAssigneeModalId(task.id))
-    } else if (shouldShowConfirmAssociationModal) {
+    } else if (showAssociationConfirmModal) {
       setSelectedAssignee(newUserIds)
       store.dispatch(setConfirmAssociationModalId(task.id))
     } else {

--- a/src/redux/features/taskBoardSlice.tsx
+++ b/src/redux/features/taskBoardSlice.tsx
@@ -27,7 +27,7 @@ interface IInitialState {
   accesibleTaskIds: string[]
   accessibleTasks: TaskResponse[]
   confirmAssignModalId: string | undefined
-  confirmViewershipModalId: string | undefined
+  confirmAssociationModalId: string | undefined
   assigneeCache: Record<string, IAssigneeCombined>
   previewClientCompany: PreviewClientCompanyType
   urlActionParams: UrlActionParamsType
@@ -63,7 +63,7 @@ const initialState: IInitialState = {
   accesibleTaskIds: [],
   accessibleTasks: [],
   confirmAssignModalId: '',
-  confirmViewershipModalId: '',
+  confirmAssociationModalId: '',
   assigneeCache: {},
   urlActionParams: {
     action: '',
@@ -221,8 +221,8 @@ const taskBoardSlice = createSlice({
       state.confirmAssignModalId = action.payload
     },
 
-    setConfirmViewershipModalId: (state, action: { payload: string | undefined }) => {
-      state.confirmViewershipModalId = action.payload
+    setConfirmAssociationModalId: (state, action: { payload: string | undefined }) => {
+      state.confirmAssociationModalId = action.payload
     },
 
     setAssigneeCache: (state, action: { payload: { key: string; value: IAssigneeCombined } }) => {
@@ -255,7 +255,7 @@ export const {
   setAccesibleTaskIds,
   setAccessibleTasks,
   setConfirmAssigneeModalId,
-  setConfirmViewershipModalId,
+  setConfirmAssociationModalId,
   setAssigneeCache,
   setPreviewClientCompany,
   setUrlActionParams,

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -328,3 +328,8 @@ export enum FilterType {
   Visibility = 'Client Visibility',
   Creator = 'Creator',
 }
+
+export enum SelectorFieldType {
+  ASSIGNEE = 'assignee',
+  ASSOCIATION = 'association',
+}

--- a/src/utils/assignee.ts
+++ b/src/utils/assignee.ts
@@ -106,7 +106,7 @@ export const isEmptyAssignee = (userIds?: UserIdsType) => {
   return Object.values(userIds).every((value) => value === null)
 }
 
-export const getAssigneeValueFromViewers = (viewer: IAssigneeCombined | null, assignee: IAssigneeCombined[]) => {
+export const getAssigneeValueFromAssociations = (viewer: IAssigneeCombined | null, assignee: IAssigneeCombined[]) => {
   if (!viewer) {
     return NoAssignee
   }

--- a/src/utils/selector.ts
+++ b/src/utils/selector.ts
@@ -58,7 +58,7 @@ export const getSelectorAssigneeFromTask = (assignee: IAssigneeCombined[], task:
   )
 } //util to get initial assignee from task for selector.
 
-export const getSelectorViewerFromTask = (assignee: IAssigneeCombined[], task: TaskResponse) => {
+export const getSelectorAssociationFromTask = (assignee: IAssigneeCombined[], task: TaskResponse) => {
   if (!task) return undefined
   return assignee.find(
     (assignee) =>

--- a/src/utils/shouldConfirmBeforeReassign.ts
+++ b/src/utils/shouldConfirmBeforeReassign.ts
@@ -34,7 +34,7 @@ export const shouldConfirmBeforeReassignment = (
   }
 }
 
-export const shouldConfirmAssociationBeforeReassignment = (
+export const shouldConfirmTaskSharedBeforeReassignment = (
   association: IAssigneeCombined | null,
   isTaskShared: boolean,
   currentAssignee?: IAssigneeCombined,

--- a/src/utils/shouldConfirmBeforeReassign.ts
+++ b/src/utils/shouldConfirmBeforeReassign.ts
@@ -34,13 +34,14 @@ export const shouldConfirmBeforeReassignment = (
   }
 }
 
-export const shouldConfirmViewershipBeforeReassignment = (
-  viewer: IAssigneeCombined | null,
+export const shouldConfirmAssociationBeforeReassignment = (
+  association: IAssigneeCombined | null,
+  isTaskShared: boolean,
   currentAssignee?: IAssigneeCombined,
 ) => {
-  if (viewer) {
+  if (association && isTaskShared) {
     const assigneeType = currentAssignee && getAssigneeTypeCorrected(currentAssignee)
-    if (!assigneeType || (assigneeType !== AssigneeType.internalUser && currentAssignee.id !== viewer.id)) {
+    if (!assigneeType || (assigneeType !== AssigneeType.internalUser && currentAssignee.id !== association.id)) {
       //no assignee or assignee is a non-IU
       return true
     }


### PR DESCRIPTION
## Changes

- [x] show dialog when assignee is removed
- [x] show dialog when assignee is changed to CU
- [x] if assignee is CU, drop associations
- [x] code refactor: rename functions, variable that matches association behavior
- [x] show dialog when task is shared and assignee is remove or replaced by CU

## Testing Criteria

[Loom 1 for detail page](https://www.loom.com/share/1f7b8202b64749d59feee81061b684d3)
[Loom 2 for board and list view](https://www.loom.com/share/0b1e8729edca4f57a59750485401d7e9)
