### PR TITLE
OUT-3160: add an unassigned view in IU and CRM dashboard

### DIFF
--- a/src/components/inputs/FilterSelector/FilterTypeSection.tsx
+++ b/src/components/inputs/FilterSelector/FilterTypeSection.tsx
@@ -16,7 +16,7 @@ export const FilterTypeSection = ({ setFilterMode, filterModes }: FilterTypeSect
     filterOptions: { type },
   } = useSelector(selectTaskBoard)
 
-  const disabled = type === FilterOptionsKeywords.CLIENTS ? [FilterType.Association, FilterType.IsShared] : []
+  const disabled = type === FilterOptionsKeywords.CLIENTS || FilterOptionsKeywords.UNASSIGNED ? [FilterType.IsShared] : []
   const removed = type.length > 20 ? [FilterType.Assignee] : []
 
   return (
@@ -68,7 +68,9 @@ export const FilterTypeSection = ({ setFilterMode, filterModes }: FilterTypeSect
                 <CopilotTooltip
                   content={
                     <div>
-                      <div>Client association is only available</div>
+                      <div>
+                        <strong>Shared with</strong> is only available
+                      </div>
                       <div>for tasks assigned to internal users.</div>
                     </div>
                   }

--- a/src/hooks/useFilter.tsx
+++ b/src/hooks/useFilter.tsx
@@ -148,6 +148,9 @@ function filterByType(filteredTasks: TaskResponse[], filterValue: string): TaskR
     case FilterOptionsKeywords.TEAM:
       return filteredTasks.filter((task) => task?.assigneeType?.includes('internalUser'))
 
+    case FilterOptionsKeywords.UNASSIGNED:
+      return filteredTasks.filter((task) => !task.assigneeId)
+
     default:
       return filteredTasks.filter((task) => task.assigneeId == assigneeType)
   }

--- a/src/hooks/useFilterBar.tsx
+++ b/src/hooks/useFilterBar.tsx
@@ -57,22 +57,27 @@ export const useFilterBar = () => {
 
   const iuFilterButtons = [
     {
-      name: 'My tasks',
+      name: 'Me',
       onClick: () => handleFilterTypeClick({ filterTypeValue: IUTokenSchema.parse(tokenPayload).internalUserId }),
       id: 'MyTasks',
     },
     {
-      name: 'Team tasks',
+      name: 'Team',
       onClick: () => handleFilterTypeClick({ filterTypeValue: FilterOptionsKeywords.TEAM }),
       id: 'TeamTasks',
     },
     {
-      name: `${getWorkspaceLabels(workspace, true).individualTerm} tasks`,
+      name: `${getWorkspaceLabels(workspace, true).individualTerm}`,
       onClick: () => handleFilterTypeClick({ filterTypeValue: FilterOptionsKeywords.CLIENTS }),
       id: 'ClientTasks',
     },
     {
-      name: 'All tasks',
+      name: 'Unassigned',
+      onClick: () => handleFilterTypeClick({ filterTypeValue: FilterOptionsKeywords.UNASSIGNED }),
+      id: 'UnassignedTasks',
+    },
+    {
+      name: 'All',
       onClick: () => handleFilterTypeClick({ filterTypeValue: '' }),
       id: 'AllTasks',
     },
@@ -80,12 +85,12 @@ export const useFilterBar = () => {
 
   const clientFilterButtons = [
     {
-      name: 'All tasks',
+      name: 'All',
       onClick: () => handleFilterTypeClick({ filterTypeValue: FilterOptionsKeywords.CLIENT_WITH_VIEWERS }),
       id: 'AllTasks',
     },
     {
-      name: 'My tasks',
+      name: 'Me',
       onClick: () => handleFilterTypeClick({ filterTypeValue: FilterOptionsKeywords.CLIENTS }),
       id: 'MyTasks',
     },
@@ -93,19 +98,24 @@ export const useFilterBar = () => {
 
   const previewFilterButtons = [
     {
-      name: 'My tasks',
+      name: 'Me',
       onClick: () => {
         handleFilterTypeClick({ filterTypeValue: IUTokenSchema.parse(tokenPayload).internalUserId })
       },
       id: 'MyTasks',
     },
     {
-      name: 'Team tasks',
+      name: 'Team',
       onClick: () => handleFilterTypeClick({ filterTypeValue: FilterOptionsKeywords.TEAM }),
       id: 'TeamTasks',
     },
     {
-      name: `${getWorkspaceLabels(workspace, true).individualTerm} tasks`,
+      name: 'Unassigned',
+      onClick: () => handleFilterTypeClick({ filterTypeValue: FilterOptionsKeywords.UNASSIGNED }),
+      id: 'UnassignedTasks',
+    },
+    {
+      name: `${getWorkspaceLabels(workspace, true).individualTerm}`,
       onClick: () => handleFilterTypeClick({ filterTypeValue: FilterOptionsKeywords.CLIENTS }),
       id: 'ClientTasks',
     },

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -70,6 +70,7 @@ export enum FilterByOptions {
 export enum FilterOptionsKeywords {
   CLIENTS = 'clients_companies',
   TEAM = 'ius',
+  UNASSIGNED = 'unassigned',
   CLIENT_WITH_VIEWERS = 'client_with_viewers',
 }
 

--- a/src/types/objectMaps.ts
+++ b/src/types/objectMaps.ts
@@ -5,7 +5,8 @@ import { StateType } from '@prisma/client'
 export const filterTypeToButtonIndexMap: Record<string, number> = {
   [FilterOptionsKeywords.CLIENTS]: 2,
   [FilterOptionsKeywords.TEAM]: 1,
-  '': 3,
+  [FilterOptionsKeywords.UNASSIGNED]: 3,
+  '': 4,
 }
 
 export const clientFilterTypeToButtonIndexMap: Record<string, number> = {
@@ -14,8 +15,9 @@ export const clientFilterTypeToButtonIndexMap: Record<string, number> = {
 }
 
 export const previewFilterTypeToButtonIndexMap: Record<string, number> = {
-  [FilterOptionsKeywords.CLIENTS]: 2,
   [FilterOptionsKeywords.TEAM]: 1,
+  [FilterOptionsKeywords.UNASSIGNED]: 2,
+  [FilterOptionsKeywords.CLIENTS]: 3,
 }
 
 export const filterOptionsMap: Record<string, FilterByOptions> = {


### PR DESCRIPTION
## Changes

- [x] new separate view for unassigned tasks
- [x] association tasks are also shown in unassigned view. Not shared as shared tasks require IU as assignee.
- [x] update tabs copy
- [x] implement in IU and CRM view

## Testing Criteria

[Loom](https://www.loom.com/share/83e870895f16404f89c3f8dd20887fad)
