### PR TITLE
fix: await async assemblyApi() factory with lazy init pattern

### DIFF
--- a/src/utils/CopilotAPI.ts
+++ b/src/utils/CopilotAPI.ts
@@ -42,13 +42,13 @@ import { assemblyApi } from '@assembly-js/node-sdk'
 import { z } from 'zod'
 
 export class CopilotAPI {
-  copilot: SDK
+  private assemblyPromise: Promise<SDK>
 
   constructor(
     private token: string,
     customApiKey?: string,
   ) {
-    this.copilot = assemblyApi({ apiKey: customApiKey ?? apiKey, token })
+    this.assemblyPromise = assemblyApi({ apiKey: customApiKey ?? apiKey, token })
   }
 
   private async _manualFetch(route: string, query?: Record<string, string>, workspaceId?: string) {
@@ -76,9 +76,10 @@ export class CopilotAPI {
   // NOTE: Any method prefixed with _ is a API method that doesn't implement retry & delay
   // NOTE: Any normal API method name implements `withRetry` with default config
 
-  // Get Token Payload from copilot request token
+  // Get Token Payload from assembly request token
   async _getTokenPayload(): Promise<Token | null> {
-    const getTokenPayload = this.copilot.getTokenPayload
+    const assembly = await this.assemblyPromise
+    const getTokenPayload = assembly.getTokenPayload
     if (!getTokenPayload) {
       console.error(`CopilotAPI#getTokenPayload | Could not parse token payload for token ${this.token}`)
       return null
@@ -89,13 +90,12 @@ export class CopilotAPI {
 
   async _me(): Promise<MeResponse | null> {
     console.info('CopilotAPI#_me', this.token)
+    const assembly = await this.assemblyPromise
     const tokenPayload = await this.getTokenPayload()
     const id = tokenPayload?.internalUserId || tokenPayload?.clientId
     if (!tokenPayload || !id) return null
 
-    const retrieveCurrentUserInfo = tokenPayload.internalUserId
-      ? this.copilot.retrieveInternalUser
-      : this.copilot.retrieveClient
+    const retrieveCurrentUserInfo = tokenPayload.internalUserId ? assembly.retrieveInternalUser : assembly.retrieveClient
     const currentUserInfo = await retrieveCurrentUserInfo({ id })
 
     return MeResponseSchema.parse(currentUserInfo)
@@ -103,7 +103,8 @@ export class CopilotAPI {
 
   async _getWorkspace(): Promise<WorkspaceResponse> {
     console.info('CopilotAPI#_getWorkspace', this.token)
-    return WorkspaceResponseSchema.parse(await this.copilot.retrieveWorkspace())
+    const assembly = await this.assemblyPromise
+    return WorkspaceResponseSchema.parse(await assembly.retrieveWorkspace())
   }
 
   async _getClientTokenPayload(): Promise<ClientToken | null> {
@@ -124,30 +125,33 @@ export class CopilotAPI {
 
   async _createClient(requestBody: ClientRequest, sendInvite: boolean = false): Promise<ClientResponse> {
     console.info('CopilotAPI#_createClient', this.token)
-    return ClientResponseSchema.parse(await this.copilot.createClient({ sendInvite, requestBody }))
+    const assembly = await this.assemblyPromise
+    return ClientResponseSchema.parse(await assembly.createClient({ sendInvite, requestBody }))
   }
 
   async _getClient(id: string): Promise<ClientResponse> {
     console.info('CopilotAPI#_getClient', this.token)
-    return ClientResponseSchema.parse(await this.copilot.retrieveClient({ id }))
+    const assembly = await this.assemblyPromise
+    return ClientResponseSchema.parse(await assembly.retrieveClient({ id }))
   }
 
   async _getClients(args: CopilotListArgs & { companyId?: string } = {}) {
     console.info('CopilotAPI#_getClients', this.token)
+    const assembly = await this.assemblyPromise
     const maxLimit = MAX_LIMIT_CLIENT_COUNT
     const requestedLimit = args.limit || maxLimit
     let clients: ClientResponse[] = []
     let nextToken: string | undefined = undefined
 
     if (requestedLimit <= maxLimit) {
-      return ClientsResponseSchema.parse(await this.copilot.listClients(args))
+      return ClientsResponseSchema.parse(await assembly.listClients(args))
     }
 
     //fetching client data in batches of MAX_LIMIT_CLIENT_COUNT instead of fetching it as a whole.
     do {
       const remaining = requestedLimit - clients.length
       const fetchLimit = Math.min(maxLimit, remaining)
-      const response = await this.copilot.listClients({
+      const response = await assembly.listClients({
         ...args,
         limit: fetchLimit,
         nextToken,
@@ -162,28 +166,33 @@ export class CopilotAPI {
 
   async _updateClient(id: string, requestBody: ClientRequest): Promise<ClientResponse> {
     console.info('CopilotAPI#_updateClient', this.token)
+    const assembly = await this.assemblyPromise
     // @ts-ignore
-    return ClientResponseSchema.parse(await this.copilot.updateClient({ id, requestBody }))
+    return ClientResponseSchema.parse(await assembly.updateClient({ id, requestBody }))
   }
 
   async _deleteClient(id: string) {
     console.info('CopilotAPI#_deleteClient', this.token)
-    return await this.copilot.deleteClient({ id })
+    const assembly = await this.assemblyPromise
+    return await assembly.deleteClient({ id })
   }
 
   async _createCompany(requestBody: CompanyCreateRequest) {
     console.info('CopilotAPI#_createCompany', this.token)
-    return CompanyResponseSchema.parse(await this.copilot.createCompany({ requestBody }))
+    const assembly = await this.assemblyPromise
+    return CompanyResponseSchema.parse(await assembly.createCompany({ requestBody }))
   }
 
   async _getCompany(id: string): Promise<CompanyResponse> {
     console.info('CopilotAPI#_getCompany', this.token)
-    return CompanyResponseSchema.parse(await this.copilot.retrieveCompany({ id }))
+    const assembly = await this.assemblyPromise
+    return CompanyResponseSchema.parse(await assembly.retrieveCompany({ id }))
   }
 
   async _getCompanies(args: CopilotListArgs & { isPlaceholder?: boolean } = {}): Promise<CompaniesResponse> {
     console.info('CopilotAPI#_getCompanies', this.token)
-    return CompaniesResponseSchema.parse(await this.copilot.listCompanies(args))
+    const assembly = await this.assemblyPromise
+    return CompaniesResponseSchema.parse(await assembly.listCompanies(args))
   }
 
   async _getCompanyClients(companyId: string): Promise<ClientResponse[]> {
@@ -193,28 +202,33 @@ export class CopilotAPI {
 
   async _getCustomFields(): Promise<CustomFieldResponse> {
     console.info('CopilotAPI#_getCustomFields', this.token)
-    return CustomFieldResponseSchema.parse(await this.copilot.listCustomFields({}))
+    const assembly = await this.assemblyPromise
+    return CustomFieldResponseSchema.parse(await assembly.listCustomFields({}))
   }
 
   async _getInternalUsers(args: CopilotListArgs = {}): Promise<InternalUsersResponse> {
     console.info('CopilotAPI#_getInternalUsers', this.token)
-    return InternalUsersResponseSchema.parse(await this.copilot.listInternalUsers(args))
+    const assembly = await this.assemblyPromise
+    return InternalUsersResponseSchema.parse(await assembly.listInternalUsers(args))
   }
 
   async _getInternalUser(id: string): Promise<InternalUsers> {
     console.info('CopilotAPI#_getInternalUser', this.token)
-    return InternalUsersSchema.parse(await this.copilot.retrieveInternalUser({ id }))
+    const assembly = await this.assemblyPromise
+    return InternalUsersSchema.parse(await assembly.retrieveInternalUser({ id }))
   }
 
   async _createNotification(requestBody: NotificationRequestBody): Promise<NotificationCreatedResponse> {
     console.info('CopilotAPI#_createNotification', this.token)
-    const notification = await this.copilot.createNotification({ requestBody })
+    const assembly = await this.assemblyPromise
+    const notification = await assembly.createNotification({ requestBody })
     return NotificationCreatedResponseSchema.parse(notification)
   }
 
   async _markNotificationAsRead(id: string): Promise<void> {
     console.info('CopilotAPI#_markNotificationAsRead', this.token)
-    await this.copilot.markNotificationRead({ id })
+    const assembly = await this.assemblyPromise
+    await assembly.markNotificationRead({ id })
   }
 
   async _bulkMarkNotificationsAsRead(notificationIds: string[], shouldThrowError: boolean = true): Promise<void> {
@@ -247,7 +261,8 @@ export class CopilotAPI {
 
   async _deleteNotification(id: string): Promise<void> {
     console.info('CopilotAPI#_deleteNotification', this.token)
-    await this.copilot.deleteNotification({ id })
+    const assembly = await this.assemblyPromise
+    await assembly.deleteNotification({ id })
   }
 
   async _bulkDeleteNotifications(notificationIds: string[]): Promise<void> {

--- a/src/utils/CopilotAPI.ts
+++ b/src/utils/CopilotAPI.ts
@@ -42,7 +42,7 @@ import { assemblyApi } from '@assembly-js/node-sdk'
 import { z } from 'zod'
 
 export class CopilotAPI {
-  private assemblyPromise: Promise<SDK>
+  private assemblyPromise: ReturnType<typeof assemblyApi>
 
   constructor(
     private token: string,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4901,6 +4901,14 @@ copilot-design-system@^2.3.4:
     tailwind-merge "^2.3.0"
     uuid "^9.0.1"
 
+copilot-node-sdk@^3.16.0:
+  version "3.19.1"
+  resolved "https://registry.yarnpkg.com/copilot-node-sdk/-/copilot-node-sdk-3.19.1.tgz#4467873d003379dac4db57a99a620685b8ae2cd9"
+  integrity sha512-NV5jS50wMxAf+327fPjoizOJgC/+uaENqAJjjofurD38pnLKp5PpVjru02L4wBQOL0le9EaU59VE9tLmjmS4+Q==
+  dependencies:
+    isomorphic-fetch "^3.0.0"
+    next "^14.0.2"
+
 copy-anything@^3.0.2:
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/copy-anything/-/copy-anything-3.0.5.tgz#2d92dce8c498f790fa7ad16b01a1ae5a45b020a0"


### PR DESCRIPTION
## Summary
- The `@assembly-js/node-sdk` `assemblyApi()` factory is `async` and returns `Promise<AssemblyAPI>`, but was being assigned synchronously in the `CopilotAPI` constructor — causing all SDK method calls to operate on a Promise object instead of the resolved client.
- Uses lazy init pattern: store the promise in the constructor, `await` it in each method. Zero changes to external call sites (`new CopilotAPI(token)` still works as before).
- Renamed internal `this.copilot` references to `assembly` to reflect the company rename.

## Test plan
- [ ] Deploy to a preview environment and verify SDK calls (token payload, client retrieval, notifications, etc.) work correctly
- [ ] Verify no regressions in task creation, comment notifications, and webhook dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)