### PR TITLE
OUT-3013 | Send notification for client/company when task is shared

### DIFF
--- a/src/app/api/notification/notification.service.ts
+++ b/src/app/api/notification/notification.service.ts
@@ -18,7 +18,7 @@ import Bottleneck from 'bottleneck'
 import httpStatus from 'http-status'
 import { z } from 'zod'
 import { AssociationsSchema } from '@/types/dto/tasks.dto'
-import { getTaskViewers } from '@/utils/assignee'
+import { getTaskAssociations } from '@/utils/assignee'
 
 export class NotificationService extends BaseService {
   async create(
@@ -74,8 +74,6 @@ export class NotificationService extends BaseService {
       }
 
       console.info('NotificationService#create | Created single notification:', notification)
-
-      const taskViewers = AssociationsSchema.parse(task.associations)
 
       // 3. Save notification to ClientNotification or InternalUserNotification table. Check for notification.recipientClientId too
       if (task.assigneeType === AssigneeType.client && !!notification.recipientClientId && !opts.disableInProduct) {
@@ -280,14 +278,14 @@ export class NotificationService extends BaseService {
    */
   markClientNotificationAsRead = async (task: Task) => {
     try {
-      const taskViewer = getTaskViewers(task)
+      const taskAssociations = getTaskAssociations(task)
 
       // Due to race conditions, we are forced to allow multiple client notifications for a single notification as well
       const relatedNotifications = await this.db.clientNotification.findMany({
         where: {
           // Accomodate company task lookups where clientId is null
-          clientId: Uuid.nullable().parse(task.clientId) || taskViewer?.clientId,
-          companyId: Uuid.parse(task.companyId ?? taskViewer?.companyId),
+          clientId: Uuid.nullable().parse(task.clientId) || taskAssociations?.clientId,
+          companyId: Uuid.parse(task.companyId ?? taskAssociations?.companyId),
           taskId: task.id,
         },
       })
@@ -381,18 +379,18 @@ export class NotificationService extends BaseService {
           throw new APIError(httpStatus.NOT_FOUND, `Unknown assignee type: ${task.assigneeType}`)
       }
     }
-    const viewers = AssociationsSchema.parse(task.associations)
+    const associations = AssociationsSchema.parse(task.associations)
 
     switch (action) {
       case NotificationTaskActions.Shared:
         senderId = task.createdById
-        recipientId = !!viewers?.length ? z.string().parse(viewers[0].clientId) : ''
+        recipientId = !!associations?.length ? z.string().parse(associations[0].clientId) : ''
         actionTrigger = await this.copilot.getInternalUser(senderId)
         break
       case NotificationTaskActions.SharedToCompany:
         senderId = task.createdById
-        recipientIds = !!viewers?.length
-          ? (await this.copilot.getCompanyClients(z.string().parse(viewers[0].companyId))).map((client) => client.id)
+        recipientIds = !!associations?.length
+          ? (await this.copilot.getCompanyClients(z.string().parse(associations[0].companyId))).map((client) => client.id)
           : []
         actionTrigger = await this.copilot.getInternalUser(senderId)
         break
@@ -450,17 +448,17 @@ export class NotificationService extends BaseService {
           console.info('fetched client Ids', clientIds)
           recipientIds = clientIds
         }
-        if (viewers?.length) {
-          const clientId = viewers[0].clientId
+        if (associations?.length) {
+          const clientId = associations[0].clientId
           if (clientId) {
-            recipientIds = [clientId] //spread recipientIds if we allow viewers on client tasks.
+            recipientIds = [clientId] //spread recipientIds if we allow associations on client tasks.
           } else {
-            const clientsInCompany = await this.copilot.getCompanyClients(viewers[0].companyId)
+            const clientsInCompany = await this.copilot.getCompanyClients(associations[0].companyId)
             const clientIds = clientsInCompany.map((client) => client.id)
             console.info('fetched client Ids', clientIds)
             recipientIds = clientIds
           }
-        } //viewers comment notifications
+        } //associations comment notifications
         // this break is needed otherwise we will fallthrough to the IU case.
         // This is honestly unhinged JS behavior, I would not expect the
         // next case to run if the switch did not match it

--- a/src/app/api/tasks/task-notifications.service.ts
+++ b/src/app/api/tasks/task-notifications.service.ts
@@ -1,7 +1,7 @@
 import { Uuid } from '@/types/common'
 import { TaskWithWorkflowState } from '@/types/db'
 import { TaskResponseSchema, Associations, AssociationsSchema, ViewerType } from '@/types/dto/tasks.dto'
-import { getTaskViewers } from '@/utils/assignee'
+import { getTaskAssociations } from '@/utils/assignee'
 import { CopilotAPI } from '@/utils/CopilotAPI'
 import User from '@api/core/models/User.model'
 import { BaseService } from '@api/core/services/base.service'
@@ -37,8 +37,8 @@ export class TaskNotificationsService extends BaseService {
   private async checkParentAccessible(task: TaskWithWorkflowState): Promise<boolean> {
     if (!task.assigneeId || !task.parentId) return false
 
-    const viewers = AssociationsSchema.parse(task.associations)
-    const checkParentViewers = (
+    const associations = AssociationsSchema.parse(task.associations)
+    const checkParentAssociations = (
       clientId: string | null,
       companyIds?: string[],
       parentViewer?: ViewerType,
@@ -49,7 +49,7 @@ export class TaskNotificationsService extends BaseService {
         if (
           (parentViewerClientId === clientId && companyIds?.includes(parentViewerCompanyId)) || //check if parent's client assignee is same as the viewer of child task.
           (parentViewerClientId && clientIds?.includes(parentViewerClientId)) || //case when child is assigned or shared to a company and parent contains client list of the company.
-          (parentViewerClientId === null && companyIds?.includes(parentViewerCompanyId)) //case when child is assigned or shared to a company and parent contains companyId in viewers of the clients.
+          (parentViewerClientId === null && companyIds?.includes(parentViewerCompanyId)) //case when child is assigned or shared to a company and parent contains companyId in association of the clients.
         ) {
           return true
         }
@@ -57,21 +57,21 @@ export class TaskNotificationsService extends BaseService {
       return false
     }
 
-    if (task.assigneeType === AssigneeType.client || task.assigneeType === AssigneeType.company || !!viewers?.length) {
+    if (task.assigneeType === AssigneeType.client || task.assigneeType === AssigneeType.company || !!associations?.length) {
       const parentTask = await this.db.task.findFirst({
         where: { id: task.parentId, workspaceId: this.user.workspaceId },
         select: { assigneeId: true, assigneeType: true, associations: true },
       })
       if (!parentTask) return false
 
-      const parentViewer = getTaskViewers(TaskResponseSchema.pick({ associations: true }).parse(parentTask))
+      const parentViewer = getTaskAssociations(TaskResponseSchema.pick({ associations: true }).parse(parentTask))
 
       if (task.assigneeType === AssigneeType.client) {
         const client = await this.copilot.getClient(task.assigneeId)
         if (parentTask.assigneeId === client.id || parentTask.assigneeId === client.companyId) {
           return true
         }
-        if (checkParentViewers(client.id, client.companyIds, parentViewer)) {
+        if (checkParentAssociations(client.id, client.companyIds, parentViewer)) {
           return true
         }
       } else {
@@ -81,32 +81,32 @@ export class TaskNotificationsService extends BaseService {
         if (companyClientIds.includes(parentTask.assigneeId || '__empty__')) {
           return true
         }
-        if (checkParentViewers(null, [task.assigneeId], parentViewer, companyClientIds)) {
+        if (checkParentAssociations(null, [task.assigneeId], parentViewer, companyClientIds)) {
           return true
         }
       } //for assignment notifications
 
-      if (!!viewers?.length) {
-        if (viewers[0].clientId) {
-          const client = await this.copilot.getClient(viewers[0].clientId)
+      if (!!associations?.length) {
+        if (associations[0].clientId) {
+          const client = await this.copilot.getClient(associations[0].clientId)
           if (parentTask.assigneeId === client.id || parentTask.assigneeId === client.companyId) {
             return true
           }
-          if (checkParentViewers(client.id, client.companyIds, parentViewer)) {
+          if (checkParentAssociations(client.id, client.companyIds, parentViewer)) {
             return true
           }
         } else {
           const clients = await this.copilot.getClients()
           const companyClientIds =
-            clients.data?.filter((client) => client.companyId === viewers[0].companyId).map((client) => client.id) || []
+            clients.data?.filter((client) => client.companyId === associations[0].companyId).map((client) => client.id) || []
           if (companyClientIds.includes(parentTask.assigneeId || '__empty__')) {
             return true
           }
-          if (checkParentViewers(null, [viewers[0].companyId], parentViewer, companyClientIds)) {
+          if (checkParentAssociations(null, [associations[0].companyId], parentViewer, companyClientIds)) {
             return true
           }
         }
-      } //for viewers notifications
+      } //for task shared notifications
     }
     return false
   }
@@ -121,14 +121,12 @@ export class TaskNotificationsService extends BaseService {
     // If task is a subtask for a client/company and isn't visible on task board (is disjoint)
     if (await this.checkParentAccessible(task)) return
 
-    const viewers = AssociationsSchema.parse(task.associations)
+    const associations = AssociationsSchema.parse(task.associations)
     const isShared = task.isShared
-    if (viewers?.length && !isReassigned && isShared) {
-      const clientId = viewers[0].clientId
-      const sendViewersNotifications = clientId
-        ? this.sendUserTaskSharedNotification
-        : this.sendCompanyTaskSharedNotification
-      await sendViewersNotifications(task, viewers)
+    if (associations?.length && !isReassigned && isShared) {
+      const clientId = associations[0].clientId
+      const sendSharedNotifications = clientId ? this.sendUserTaskSharedNotification : this.sendCompanyTaskSharedNotification
+      await sendSharedNotifications(task, associations)
     }
 
     // If task is assigned to the same person that created it, no need to notify yourself
@@ -157,28 +155,26 @@ export class TaskNotificationsService extends BaseService {
     if (prevTask.isArchived !== updatedTask.isArchived) {
       await this.handleTaskArchiveToggle(prevTask, updatedTask)
     }
-    const updatedViewers = getTaskViewers(updatedTask)
-    const prevViewers = getTaskViewers(prevTask)
+    const updatedAssociations = getTaskAssociations(updatedTask)
+    const prevAssociations = getTaskAssociations(prevTask)
     const becameShared = !prevTask.isShared && updatedTask.isShared
-    const isViewersUpdated =
-      !!updatedViewers &&
-      ((!!updatedViewers.clientId && prevViewers?.clientId !== updatedViewers?.clientId) ||
-        prevViewers?.companyId !== updatedViewers.companyId)
+    const isAssociationsUpdated =
+      !!updatedAssociations &&
+      ((!!updatedAssociations.clientId && prevAssociations?.clientId !== updatedAssociations?.clientId) ||
+        prevAssociations?.companyId !== updatedAssociations.companyId)
     // Return if not workflowState / assignee updated
 
     const isReassigned = prevTask.assigneeId !== updatedTask.assigneeId
-    if (prevTask.workflowStateId === updatedTask.workflowStateId && !isReassigned && !isViewersUpdated && !becameShared)
+    if (prevTask.workflowStateId === updatedTask.workflowStateId && !isReassigned && !isAssociationsUpdated && !becameShared)
       return
 
     // Case 2
-    // -Handle viewers changed, or viewers updated in a task.
-    // if the task became shared, or task the viewer changed in a shared task condition:
-    if (updatedViewers && (becameShared || (updatedTask.isShared && isViewersUpdated))) {
-      const clientId = updatedViewers.clientId
-      const sendViewersNotifications = clientId
-        ? this.sendUserTaskSharedNotification
-        : this.sendCompanyTaskSharedNotification
-      await sendViewersNotifications(updatedTask, [updatedViewers])
+    // -Handle associations changed, or associations updated in a task when task is shared.
+    // if the task became shared, or task the association changed in a shared task condition:
+    if (updatedAssociations && (becameShared || (updatedTask.isShared && isAssociationsUpdated))) {
+      const clientId = updatedAssociations.clientId
+      const sendSharedNotifications = clientId ? this.sendUserTaskSharedNotification : this.sendCompanyTaskSharedNotification
+      await sendSharedNotifications(updatedTask, [updatedAssociations])
     }
 
     // Case 3
@@ -357,15 +353,15 @@ export class TaskNotificationsService extends BaseService {
     }
   }
 
-  private sendUserTaskSharedNotification = async (task: Task, viewers: Associations) => {
-    if (!viewers?.length) return
+  private sendUserTaskSharedNotification = async (task: Task, associations: Associations) => {
+    if (!associations?.length) return
 
     const notificationType = NotificationTaskActions.Shared
 
     const existingNotification = await this.getExistingClientNotificationForTask(
       task.id,
-      Uuid.parse(viewers[0].clientId),
-      Uuid.parse(viewers[0].companyId),
+      Uuid.parse(associations[0].clientId),
+      Uuid.parse(associations[0].companyId),
     )
     if (existingNotification) {
       console.error('Found an existing notification. Skipping creating a new one:', existingNotification)

--- a/src/app/ui/NewTaskForm.tsx
+++ b/src/app/ui/NewTaskForm.tsx
@@ -435,7 +435,6 @@ export const NewTaskForm = ({ handleCreate, handleClose }: NewTaskFormProps) => 
             >
               <CopilotToggle
                 label="Share with client"
-                disabled={!previewMode}
                 onChange={() => {
                   const localSharedState = store.getState().createTask.isShared
                   store.dispatch(setCreateTaskFields({ targetField: 'isShared', value: !localSharedState }))

--- a/src/utils/assignee.ts
+++ b/src/utils/assignee.ts
@@ -119,8 +119,8 @@ export const getAssigneeValueFromAssociations = (viewer: IAssigneeCombined | nul
   return match ?? undefined
 }
 
-export const getTaskViewers = (task: TaskResponse | Task | Pick<TaskResponse, 'associations'>) => {
-  const taskViewers = AssociationsSchema.parse(task.associations)
-  const viewer = !!taskViewers?.length ? taskViewers[0] : undefined
-  return viewer
+export const getTaskAssociations = (task: TaskResponse | Task | Pick<TaskResponse, 'associations'>) => {
+  const taskAssociations = AssociationsSchema.parse(task.associations)
+  const association = !!taskAssociations?.length ? taskAssociations[0] : undefined
+  return association
 }


### PR DESCRIPTION
## Changes

- [x] Changed notification logic on shared task for clients and companies. 
- [x] On task creation, shared task notification will only be dispatched if isShared is toggled on in a task. 
- [x] On task update, shared task notification will only be dispatched if the task became shared or isShared is on with viewers change. 

## Testing Criteria

<img width="1051" height="482" alt="image" src="https://github.com/user-attachments/assets/b8edabf6-5240-449c-8d51-af2dcb0fd789" />




Right now the copy is same if a task is shared to a company or a client. 




