### PR TITLE
OUT-3178 | Allow no assignee task creation from Public API

### DIFF
--- a/src/app/api/tasks/public/public.dto.ts
+++ b/src/app/api/tasks/public/public.dto.ts
@@ -118,14 +118,6 @@ export const publicTaskCreateDtoSchemaFactory = (token: string) => {
         }
       }
 
-      if (!internalUserId && !clientId && !companyId) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: 'At least one of internalUserId, clientId, or companyId is required',
-          path: ['internalUserId'],
-        })
-      }
-
       if (internalUserId && (clientId || companyId)) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,

--- a/src/app/api/tasks/public/public.dto.ts
+++ b/src/app/api/tasks/public/public.dto.ts
@@ -42,6 +42,7 @@ export const PublicTaskDtoSchema = z.object({
   clientId: z.string().uuid().nullable(),
   companyId: z.string().uuid().nullable(),
   association: AssociationsSchema,
+  viewers: AssociationsSchema,
   attachments: z.array(PublicAttachmentDtoSchema),
   isShared: z.boolean().optional(),
 })

--- a/src/app/api/tasks/public/public.serializer.ts
+++ b/src/app/api/tasks/public/public.serializer.ts
@@ -64,6 +64,7 @@ export class PublicTaskSerializer {
       clientId: task.clientId,
       companyId: task.companyId,
       association: AssociationsSchema.parse(task.associations),
+      viewers: task.isShared ? AssociationsSchema.parse(task.associations) : [],
       attachments: await PublicAttachmentSerializer.serializeAttachments({
         attachments: task.attachments,
         uploadedByUserType: 'internalUser', // task creator is always IU

--- a/src/app/api/tasks/public/public.service.ts
+++ b/src/app/api/tasks/public/public.service.ts
@@ -169,13 +169,13 @@ export class PublicTasksService extends TasksSharedService {
       console.info('TasksService#createTask | createdById overridden for public API:', createdById)
     }
 
-    let viewers: Associations = []
+    let associations: Associations = []
     if (data.associations?.length) {
-      if (!validatedIds.internalUserId) {
+      if (!!data.isShared && !validatedIds.internalUserId) {
         throw new APIError(httpStatus.BAD_REQUEST, `Task cannot be created with viewers if its not assigned to an IU.`)
       }
-      viewers = await this.validateAssociations(data.associations)
-      console.info('PublicTasksService#createTask | Associations validated for task:', viewers)
+      associations = await this.validateAssociations(data.associations)
+      console.info('PublicTasksService#createTask | Associations validated for task:', associations)
     }
 
     // Create a new task associated with current workspaceId. Also inject current request user as the creator.
@@ -190,7 +190,7 @@ export class PublicTasksService extends TasksSharedService {
         source: Source.api,
         assigneeId,
         assigneeType,
-        associations: viewers,
+        associations,
         ...validatedIds,
         ...(opts?.manualTimestamp && { createdAt: opts.manualTimestamp }),
         ...(await getTaskTimestamps('create', this.user, data, undefined, workflowStateStatus)),

--- a/src/app/api/tasks/public/public.service.ts
+++ b/src/app/api/tasks/public/public.service.ts
@@ -332,25 +332,13 @@ export class PublicTasksService extends TasksSharedService {
       companyId: validatedIds?.companyId ?? null,
     })
 
-    // const associations: Associations = await this.getValidatedAssociations({
-    //   prevAssociations: prevTask.associations,
-    //   associationsResetCondition: shouldUpdateUserIds ? !!clientId || !!companyId : !prevTask.internalUserId,
-    // })
-
-    let associations: Associations = AssociationsSchema.parse(prevTask.associations)
-    // check if current or previous assignee is a client or company
-    const associationsResetCondition = shouldUpdateUserIds
-      ? !!clientId || !!companyId
-      : prevTask.clientId || prevTask.companyId
-
-    if (data.associations) {
-      // only update of associations attribute is available. No associations in payload attribute means the data remains as it is in DB.
-      if (associationsResetCondition || !data.associations?.length) {
-        associations = [] // reset associations to [] if task is not reassigned to IU.
-      } else if (data.associations?.length) {
-        associations = await this.validateAssociations(data.associations)
-      }
-    }
+    const associations = await this.resolveAssociations({
+      prevTask,
+      data,
+      shouldUpdateUserIds,
+      clientId,
+      companyId,
+    })
 
     const userAssignmentFields = shouldUpdateUserIds
       ? {

--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -313,24 +313,6 @@ export class TasksService extends TasksSharedService {
     }
   }
 
-  private validateTaskShare(prevTask: Task, data: UpdateTaskRequest): boolean | undefined {
-    const isTaskShared = data.isShared
-
-    if (isTaskShared === undefined) return undefined
-
-    if (isTaskShared) {
-      const isEligibleForShare = !!(
-        (prevTask.associations.length && prevTask.internalUserId) ||
-        (data.associations?.length && data.internalUserId)
-      )
-      if (!isEligibleForShare) {
-        throw new APIError(httpStatus.BAD_REQUEST, 'Cannot share task with assocations')
-      }
-      return true
-    }
-    return false
-  }
-
   async updateOneTask(id: string, data: UpdateTaskRequest) {
     const policyGate = new PoliciesService(this.user)
     policyGate.authorize(UserAction.Update, Resource.Tasks)

--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -347,20 +347,13 @@ export class TasksService extends TasksSharedService {
       companyId: validatedIds?.companyId ?? null,
     })
 
-    let associations: Associations = AssociationsSchema.parse(prevTask.associations)
-
-    // check if current or previous assignee is a client or company
-    const associationsResetCondition = shouldUpdateUserIds
-      ? !!clientId || !!companyId
-      : prevTask.clientId || prevTask.companyId
-    if (data.associations) {
-      // only update of associations attribute is available. No associations in payload attribute means the data remains as it is in DB.
-      if (associationsResetCondition || !data.associations?.length) {
-        associations = [] // reset associations to [] if task is not reassigned to IU.
-      } else if (data.associations?.length) {
-        associations = await this.validateAssociations(data.associations)
-      }
-    }
+    const associations = await this.resolveAssociations({
+      prevTask,
+      data,
+      shouldUpdateUserIds,
+      clientId,
+      companyId,
+    })
 
     const userAssignmentFields = shouldUpdateUserIds
       ? {

--- a/src/app/api/tasks/tasksShared.service.ts
+++ b/src/app/api/tasks/tasksShared.service.ts
@@ -2,7 +2,13 @@ import { maxSubTaskDepth } from '@/constants/tasks'
 import { MAX_FETCH_ASSIGNEE_COUNT } from '@/constants/users'
 import { InternalUsers, TempClientFilter, Uuid } from '@/types/common'
 import { CreateAttachmentRequestSchema } from '@/types/dto/attachments.dto'
-import { CreateTaskRequest, CreateTaskRequestSchema, Associations, UpdateTaskRequest } from '@/types/dto/tasks.dto'
+import {
+  CreateTaskRequest,
+  CreateTaskRequestSchema,
+  Associations,
+  UpdateTaskRequest,
+  AssociationsSchema,
+} from '@/types/dto/tasks.dto'
 import { getFileNameFromPath } from '@/utils/attachmentUtils'
 import { buildLtree, buildLtreeNodeString } from '@/utils/ltree'
 import { getFilePathFromUrl } from '@/utils/signedUrlReplacer'
@@ -557,5 +563,48 @@ export abstract class TasksSharedService extends BaseService {
     }
 
     return true
+  }
+
+  protected async resolveAssociations(params: {
+    prevTask: Task
+    data: UpdateTaskRequest
+    shouldUpdateUserIds: boolean
+    clientId?: string | null
+    companyId?: string | null
+  }): Promise<Associations> {
+    const { prevTask, data, shouldUpdateUserIds, clientId, companyId } = params
+    if (!data.associations) {
+      return AssociationsSchema.parse(prevTask.associations)
+    }
+
+    const shouldReset = this.shouldResetAssociations({
+      shouldUpdateUserIds,
+      prevTask,
+      clientId,
+      companyId,
+    })
+
+    if (shouldReset) return []
+
+    const parsed = AssociationsSchema.parse(data.associations)
+
+    if (!parsed?.length) return []
+
+    return this.validateAssociations(parsed)
+  }
+
+  private shouldResetAssociations(params: {
+    shouldUpdateUserIds: boolean
+    prevTask: Task
+    clientId?: string | null
+    companyId?: string | null
+  }): boolean {
+    const { shouldUpdateUserIds, prevTask, clientId, companyId } = params
+
+    if (shouldUpdateUserIds) {
+      return !!clientId || !!companyId
+    }
+
+    return !!prevTask.clientId || !!prevTask.companyId
   }
 }


### PR DESCRIPTION
## Changes

- [x] Removed validation that required at least one of the `userIds` while creating a task from Public API.

## Testing Criteria

<img width="667" height="733" alt="image" src="https://github.com/user-attachments/assets/a44abbdd-21fc-4799-a52d-57e2226059af" />


