### PR TITLE
OUT-3179 | Resetting association from public API on task update endpoint does not work

### DIFF
--- a/src/app/api/tasks/public/public.dto.ts
+++ b/src/app/api/tasks/public/public.dto.ts
@@ -42,6 +42,7 @@ export const PublicTaskDtoSchema = z.object({
   clientId: z.string().uuid().nullable(),
   companyId: z.string().uuid().nullable(),
   association: AssociationsSchema,
+  viewers: AssociationsSchema,
   attachments: z.array(PublicAttachmentDtoSchema),
   isShared: z.boolean().optional(),
 })

--- a/src/app/api/tasks/public/public.serializer.ts
+++ b/src/app/api/tasks/public/public.serializer.ts
@@ -64,6 +64,7 @@ export class PublicTaskSerializer {
       clientId: task.clientId,
       companyId: task.companyId,
       association: AssociationsSchema.parse(task.associations),
+      viewers: task.isShared ? AssociationsSchema.parse(task.associations) : [],
       attachments: await PublicAttachmentSerializer.serializeAttachments({
         attachments: task.attachments,
         uploadedByUserType: 'internalUser', // task creator is always IU

--- a/src/app/api/tasks/public/public.service.ts
+++ b/src/app/api/tasks/public/public.service.ts
@@ -332,25 +332,13 @@ export class PublicTasksService extends TasksSharedService {
       companyId: validatedIds?.companyId ?? null,
     })
 
-    // const associations: Associations = await this.getValidatedAssociations({
-    //   prevAssociations: prevTask.associations,
-    //   associationsResetCondition: shouldUpdateUserIds ? !!clientId || !!companyId : !prevTask.internalUserId,
-    // })
-
-    let associations: Associations = AssociationsSchema.parse(prevTask.associations)
-    // check if current or previous assignee is a client or company
-    const associationsResetCondition = shouldUpdateUserIds
-      ? !!clientId || !!companyId
-      : prevTask.clientId || prevTask.companyId
-
-    if (data.associations) {
-      // only update of associations attribute is available. No associations in payload attribute means the data remains as it is in DB.
-      if (associationsResetCondition || !data.associations?.length) {
-        associations = [] // reset associations to [] if task is not reassigned to IU.
-      } else if (data.associations?.length) {
-        associations = await this.validateAssociations(data.associations)
-      }
-    }
+    const associations = await this.resolveAssociations({
+      prevTask,
+      data,
+      shouldUpdateUserIds,
+      clientId,
+      companyId,
+    })
 
     const userAssignmentFields = shouldUpdateUserIds
       ? {

--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -313,24 +313,6 @@ export class TasksService extends TasksSharedService {
     }
   }
 
-  private validateTaskShare(prevTask: Task, data: UpdateTaskRequest): boolean | undefined {
-    const isTaskShared = data.isShared
-
-    if (isTaskShared === undefined) return undefined
-
-    if (isTaskShared) {
-      const isEligibleForShare = !!(
-        (prevTask.associations.length && prevTask.internalUserId) ||
-        (data.associations?.length && data.internalUserId)
-      )
-      if (!isEligibleForShare) {
-        throw new APIError(httpStatus.BAD_REQUEST, 'Cannot share task with assocations')
-      }
-      return true
-    }
-    return false
-  }
-
   async updateOneTask(id: string, data: UpdateTaskRequest) {
     const policyGate = new PoliciesService(this.user)
     policyGate.authorize(UserAction.Update, Resource.Tasks)

--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -347,20 +347,13 @@ export class TasksService extends TasksSharedService {
       companyId: validatedIds?.companyId ?? null,
     })
 
-    let associations: Associations = AssociationsSchema.parse(prevTask.associations)
-
-    // check if current or previous assignee is a client or company
-    const associationsResetCondition = shouldUpdateUserIds
-      ? !!clientId || !!companyId
-      : prevTask.clientId || prevTask.companyId
-    if (data.associations) {
-      // only update of associations attribute is available. No associations in payload attribute means the data remains as it is in DB.
-      if (associationsResetCondition || !data.associations?.length) {
-        associations = [] // reset associations to [] if task is not reassigned to IU.
-      } else if (data.associations?.length) {
-        associations = await this.validateAssociations(data.associations)
-      }
-    }
+    const associations = await this.resolveAssociations({
+      prevTask,
+      data,
+      shouldUpdateUserIds,
+      clientId,
+      companyId,
+    })
 
     const userAssignmentFields = shouldUpdateUserIds
       ? {

--- a/src/app/api/tasks/tasksShared.service.ts
+++ b/src/app/api/tasks/tasksShared.service.ts
@@ -2,7 +2,13 @@ import { maxSubTaskDepth } from '@/constants/tasks'
 import { MAX_FETCH_ASSIGNEE_COUNT } from '@/constants/users'
 import { InternalUsers, TempClientFilter, Uuid } from '@/types/common'
 import { CreateAttachmentRequestSchema } from '@/types/dto/attachments.dto'
-import { CreateTaskRequest, CreateTaskRequestSchema, Associations, UpdateTaskRequest } from '@/types/dto/tasks.dto'
+import {
+  CreateTaskRequest,
+  CreateTaskRequestSchema,
+  Associations,
+  UpdateTaskRequest,
+  AssociationsSchema,
+} from '@/types/dto/tasks.dto'
 import { getFileNameFromPath } from '@/utils/attachmentUtils'
 import { buildLtree, buildLtreeNodeString } from '@/utils/ltree'
 import { getFilePathFromUrl } from '@/utils/signedUrlReplacer'
@@ -557,5 +563,48 @@ export abstract class TasksSharedService extends BaseService {
     }
 
     return true
+  }
+
+  protected async resolveAssociations(params: {
+    prevTask: Task
+    data: UpdateTaskRequest
+    shouldUpdateUserIds: boolean
+    clientId?: string | null
+    companyId?: string | null
+  }): Promise<Associations> {
+    const { prevTask, data, shouldUpdateUserIds, clientId, companyId } = params
+    if (!data.associations) {
+      return AssociationsSchema.parse(prevTask.associations)
+    }
+
+    const shouldReset = this.shouldResetAssociations({
+      shouldUpdateUserIds,
+      prevTask,
+      clientId,
+      companyId,
+    })
+
+    if (shouldReset) return []
+
+    const parsed = AssociationsSchema.parse(data.associations)
+
+    if (!parsed?.length) return []
+
+    return this.validateAssociations(parsed)
+  }
+
+  private shouldResetAssociations(params: {
+    shouldUpdateUserIds: boolean
+    prevTask: Task
+    clientId?: string | null
+    companyId?: string | null
+  }): boolean {
+    const { shouldUpdateUserIds, prevTask, clientId, companyId } = params
+
+    if (shouldUpdateUserIds) {
+      return !!clientId || !!companyId
+    }
+
+    return !!prevTask.clientId || !!prevTask.companyId
   }
 }


### PR DESCRIPTION
## Changes

- [x] kept the association logic consistent on public task update service. 
- [x] fixed the logic for validating isShared value on task update apis : both web and public. 

## Testing Criteria

- Case 1 : when all value aligns with requirement. 
<img width="822" height="719" alt="image" src="https://github.com/user-attachments/assets/049dc44b-9a44-4c64-9ae7-b40e422a112e" />

-Case 2 : when association is empty but isShared is on.
<img width="895" height="597" alt="image" src="https://github.com/user-attachments/assets/f4247326-78e9-4ae1-92ba-a1bdc6fcf337" />

-Case 3 : when internalUserId is null but isShared is on.
<img width="972" height="623" alt="image" src="https://github.com/user-attachments/assets/5302b53c-a8d3-4ae2-97b2-83f7e9542dd8" />


-Case 4 : removing association with isShared off. 
<img width="835" height="725" alt="image" src="https://github.com/user-attachments/assets/531c6f18-0e22-4e4e-bfff-1f0ddc19e825" />



