### PR TITLE
OUT-3186 | Include both viewers and association property in public api

### DIFF
--- a/src/app/api/tasks/public/public.dto.ts
+++ b/src/app/api/tasks/public/public.dto.ts
@@ -42,6 +42,7 @@ export const PublicTaskDtoSchema = z.object({
   clientId: z.string().uuid().nullable(),
   companyId: z.string().uuid().nullable(),
   association: AssociationsSchema,
+  viewers: AssociationsSchema,
   attachments: z.array(PublicAttachmentDtoSchema),
   isShared: z.boolean().optional(),
 })

--- a/src/app/api/tasks/public/public.serializer.ts
+++ b/src/app/api/tasks/public/public.serializer.ts
@@ -64,6 +64,7 @@ export class PublicTaskSerializer {
       clientId: task.clientId,
       companyId: task.companyId,
       association: AssociationsSchema.parse(task.associations),
+      viewers: task.isShared ? AssociationsSchema.parse(task.associations) : [],
       attachments: await PublicAttachmentSerializer.serializeAttachments({
         attachments: task.attachments,
         uploadedByUserType: 'internalUser', // task creator is always IU


### PR DESCRIPTION
## Changes

- [x] Added `viewers` property in public task response. Applicable on all public tasks apis. 
- [x] `viewers` are a bit different from `association`. `viewers` have the same value as `association` only if the value of `task.isShared` is true.

## Testing Criteria

<img width="672" height="720" alt="image" src="https://github.com/user-attachments/assets/71c0ca22-e1e7-4fe7-bbf3-fc29fd9b27ef" />

<img width="517" height="208" alt="image" src="https://github.com/user-attachments/assets/fd7407f3-deed-4cc4-be07-8d390fdbfd9b" />
