### PR TITLE
OUT-3202 | Viewers list is not backwards compatible with client association

### DIFF
--- a/src/app/api/tasks/public/public.dto.ts
+++ b/src/app/api/tasks/public/public.dto.ts
@@ -48,6 +48,32 @@ export const PublicTaskDtoSchema = z.object({
 })
 export type PublicTaskDto = z.infer<typeof PublicTaskDtoSchema>
 
+const viewersAssociationExclusivitySchema = z
+  .object({
+    viewers: AssociationsSchema.optional(),
+    association: AssociationsSchema.optional(),
+    isShared: z.boolean().optional(),
+  })
+  .superRefine((val, ctx) => {
+    const hasViewers = val.viewers !== undefined
+    const hasAssociation = val.association !== undefined
+    const hasIsShared = val.isShared !== undefined
+
+    if (hasViewers && (hasAssociation || hasIsShared)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          'viewers cannot be used together with association or isShared. Use either viewers alone, or association/isShared together.',
+        path: ['viewers'],
+      })
+    }
+  })
+  .transform(({ viewers, association, isShared, ...rest }) => ({
+    ...rest,
+    association: viewers ?? association,
+    isShared: viewers ? true : isShared,
+  }))
+
 export const publicTaskCreateDtoSchemaFactory = (token: string) => {
   return z
     .object({
@@ -61,9 +87,8 @@ export const publicTaskCreateDtoSchemaFactory = (token: string) => {
       internalUserId: z.string().uuid().optional(),
       clientId: z.string().uuid().optional(),
       companyId: z.string().uuid().optional(),
-      association: AssociationsSchema, //right now, we only need the feature to have max of 1 viewer per task
-      isShared: z.boolean().optional(),
     })
+    .and(viewersAssociationExclusivitySchema)
     .superRefine(async (data, ctx) => {
       const { name, templateId, internalUserId, clientId, status } = data
       let { companyId } = data
@@ -151,6 +176,7 @@ export const PublicTaskUpdateDtoSchema = z
     association: AssociationsSchema,
     isShared: z.boolean().optional(),
   })
+  .and(viewersAssociationExclusivitySchema)
   .superRefine(validateUserIds)
 
 export type PublicTaskUpdateDto = z.infer<typeof PublicTaskUpdateDtoSchema>

--- a/src/app/api/tasks/public/public.dto.ts
+++ b/src/app/api/tasks/public/public.dto.ts
@@ -173,8 +173,6 @@ export const PublicTaskUpdateDtoSchema = z
     internalUserId: z.string().uuid().nullish(),
     clientId: z.string().uuid().nullish(),
     companyId: z.string().uuid().nullish(),
-    association: AssociationsSchema,
-    isShared: z.boolean().optional(),
   })
   .and(viewersAssociationExclusivitySchema)
   .superRefine(validateUserIds)


### PR DESCRIPTION
## Changes

- [x] accepted `viewers` in create/update task request from public api alongside `association` and `isShared`.
- [x] `viewers` and `association`/`isShared` is mutually exclusive. which means viewers cannot be used together with association or isShared. Use either viewers alone, or association/isShared together.
- [x] if `viewers` is used in payload for task create/update from public api. the value is transformed i.e `association` becomes `viewers`  and `isShared` becomes true. 

## Testing Criteria

<img width="729" height="743" alt="image" src="https://github.com/user-attachments/assets/7e688575-9d3e-499b-abfd-91215fe6f68a" />
<img width="626" height="576" alt="Screenshot 2026-02-25 at 18 09 59" src="https://github.com/user-attachments/assets/c53bf5bb-1d06-4e1b-b42a-fe1232006c7a" />
<img width="658" height="729" alt="image" src="https://github.com/user-attachments/assets/b65d92db-969c-4f7e-af0d-e8246b8a4149" />
