### PR TITLE
OUT-3221: hide 'share with client' toggle on CU task details page

### DIFF
--- a/src/app/detail/ui/Sidebar.tsx
+++ b/src/app/detail/ui/Sidebar.tsx
@@ -110,7 +110,7 @@ export const Sidebar = ({
   const [isTaskShared, setIsTaskShared] = useState(false)
 
   const baseAssociationCondition = assigneeValue && assigneeValue.type === FilterByOptions.IUS
-  const showShareToggle = baseAssociationCondition && taskAssociationValue
+  const showShareToggle = baseAssociationCondition && taskAssociationValue && !disabled
   const showAssociation = !assigneeValue || baseAssociationCondition
 
   const { renderingItem: _statusValue, updateRenderingItem: updateStatusValue } = useHandleSelectorComponent({
@@ -359,7 +359,7 @@ export const Sidebar = ({
             }
           />
         </Box>
-        {assigneeValue && assigneeValue.type === FilterByOptions.IUS && (
+        {showAssociation && (
           <Box
             sx={{
               width: 'fit-content',
@@ -397,6 +397,24 @@ export const Sidebar = ({
                   }
                 />
               }
+            />
+          </Box>
+        )}
+        {showShareToggle && (
+          <Box
+            sx={{
+              width: 'fit-content',
+              height: '30px',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            <CopilotToggle
+              label="Share with client"
+              disabled={(disabled && !previewMode) || fromNotificationCenter} // allow task share in preview mode
+              onChange={handleTaskShared}
+              checked={isTaskShared}
             />
           </Box>
         )}


### PR DESCRIPTION
## Changes

- [x] add condition to hide 'Share with client' toggle in CU task details page view
- [x] add 'share with client' toggle in mobile view for IU

## Testing Criteria

[Loom](https://www.loom.com/share/1dcbb5c99f3e4530b2c28362d556964a)