### PR TITLE
OUT-3204: disallow association with placeholder company IDs

### DIFF
--- a/src/app/api/tasks/tasksShared.service.ts
+++ b/src/app/api/tasks/tasksShared.service.ts
@@ -377,7 +377,10 @@ export abstract class TasksSharedService extends BaseService {
           throw new APIError(httpStatus.BAD_REQUEST, 'Invalid companyId for the provided association.')
         }
       } else {
-        await this.copilot.getCompany(association.companyId)
+        const company = await this.copilot.getCompany(association.companyId)
+        if (company.isPlaceholder) {
+          throw new APIError(httpStatus.BAD_REQUEST, 'Invalid companyId for the provided association.')
+        }
       }
     } catch (err) {
       if (err instanceof APIError) {


### PR DESCRIPTION
## Changes

- [x] throw 400 error if the association has placeholder company id

## Testing Criteria

- [x] Screencast

https://github.com/user-attachments/assets/6b18cbe3-fa87-4429-af60-8525a69c1555
