### PR TITLE
fix(OUT-3297): subtasks inherit parent assignee from template

### DIFF
--- a/src/app/api/tasks/tasksShared.service.ts
+++ b/src/app/api/tasks/tasksShared.service.ts
@@ -494,7 +494,6 @@ export abstract class TasksSharedService extends BaseService {
 
   protected async createSubtasksFromTemplate(data: TaskTemplate, parentTask: Task, manualTimestamp: Date) {
     const { workspaceId, title, body, workflowStateId } = data
-    const previewMode = Boolean(this.user.clientId || this.user.companyId)
     const { id: parentId, internalUserId, clientId, companyId, viewers } = parentTask
 
     try {
@@ -505,12 +504,10 @@ export abstract class TasksSharedService extends BaseService {
         workflowStateId,
         parentId,
         templateId: undefined, //just to be safe from circular recursion
-        ...(previewMode && {
-          internalUserId,
-          clientId,
-          companyId,
-          viewers,
-        }), //On CRM view, we set assignee and viewers for subtasks same as the parent task.
+        internalUserId,
+        clientId,
+        companyId,
+        viewers,
       })
 
       await this.createTask(createTaskPayload, { disableSubtaskTemplates: true, manualTimestamp: manualTimestamp })


### PR DESCRIPTION
## Summary
- Removed `previewMode` conditional in `createSubtasksFromTemplate` so assignee fields (`internalUserId`, `clientId`, `companyId`, `associations`) are always passed to subtasks created from templates
- Previously subtasks only inherited the parent assignee when creating from CRM preview mode; now they inherit it from the main app as well

## Test plan
- [x] As an internal user, create a task from a template with subtasks and assign the parent — verify subtasks inherit the assignee
- [x] As a client/company user (CRM preview), create a task from a template — verify subtasks still inherit the assignee as before
- [x] Create a task from a template without assigning anyone — verify subtasks are also unassigned


https://github.com/user-attachments/assets/d71672c9-d0c5-4b10-a7d9-d830868b73a0



Linear: https://linear.app/assemblycom/issue/OUT-3297

🤖 Generated with [Claude Code](https://claude.com/claude-code)