### PR TITLE
OUT-3439: support dynamic fields and its conversion on task template title

### DIFF
--- a/src/app/detail/ui/NewTaskCard.tsx
+++ b/src/app/detail/ui/NewTaskCard.tsx
@@ -31,6 +31,7 @@ import {
   getSelectorAssignee,
   getSelectorAssigneeFromFilterOptions,
 } from '@/utils/selector'
+import { resolveDynamicFields } from '@/utils/dynamicFields'
 import { trimAllTags } from '@/utils/trimTags'
 import { Box, Stack, Typography } from '@mui/material'
 import dayjs from 'dayjs'
@@ -165,15 +166,16 @@ export const NewTaskCard = ({
         try {
           setIsEditorReadonly?.(true)
 
+          const resolvedTitle = resolveDynamicFields(templateTitle)
           if (!subTaskFields.title.trim()) {
             setSubTaskFields((prev) => ({
               ...prev,
-              title: templateTitle,
+              title: resolvedTitle,
             }))
           } else {
             setSubTaskFields((prev) => ({
               ...prev,
-              title: prev.title + ' ' + templateTitle,
+              title: prev.title + ' ' + resolvedTitle,
             }))
           }
           const resp = await fetch(`/api/tasks/templates/${id}/apply?token=${token}`, {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -12,6 +12,15 @@ a {
   text-decoration: none;
 }
 
+.dynamic-field-token {
+  border: 1px solid #dfe1e4;
+  color: var(--text-secondary);
+  border-radius: 4px;
+  padding: 0 4px;
+  white-space: nowrap;
+  font-weight: 500;
+}
+
 .scrollhost::-webkit-scrollbar {
   display: none;
 }

--- a/src/app/manage-templates/ui/TemplateDetails.tsx
+++ b/src/app/manage-templates/ui/TemplateDetails.tsx
@@ -2,7 +2,7 @@
 
 import { StyledModal } from '@/app/detail/ui/styledComponent'
 import AttachmentLayout from '@/components/AttachmentLayout'
-import { StyledTextField } from '@/components/inputs/TextField'
+import { TokenizedInput, restoreCursorOffset } from '@/components/inputs/TokenizedInput'
 import { ConfirmDeleteUI } from '@/components/layouts/ConfirmDeleteUI'
 import { MAX_UPLOAD_LIMIT } from '@/constants/attachments'
 import { useDebounce, useDebounceWithCancel } from '@/hooks/useDebounce'
@@ -42,6 +42,7 @@ export default function TemplateDetails({
   const { activeTemplate, targetTemplateId, taskName } = useSelector(selectCreateTemplate)
   const [isUserTyping, setIsUserTyping] = useState(false)
   const [activeUploads, setActiveUploads] = useState(0)
+  const titleRef = useRef<HTMLDivElement>(null)
 
   const { showConfirmDeleteModal } = useSelector(selectTaskDetails)
 
@@ -73,8 +74,7 @@ export default function TemplateDetails({
   const [debouncedResetTypingFlag, _cancelDebouncedResetTypingFlag] = useDebounceWithCancel(resetTypingFlag, 1500)
   const [debouncedResetTypingFlagTitle, cancelDebouncedResetTypingFlagTitle] = useDebounceWithCancel(resetTypingFlag, 2500)
 
-  const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const newTitle = e.target.value
+  const handleTitleChange = (newTitle: string) => {
     setUpdateTitle(newTitle)
     if (newTitle.trim() == '') {
       cancelTitleUpdateDebounced()
@@ -93,6 +93,21 @@ export default function TemplateDetails({
         setUpdateTitle(currentTask?.title ?? '')
       }, 300)
     }
+  }
+
+  const handleDynamicFieldInsert = (newValue: string, cursorPos: number) => {
+    setUpdateTitle(newValue)
+    if (newValue.trim() !== '') {
+      setIsUserTyping(true)
+      titleUpdateDebounced(newValue)
+      debouncedResetTypingFlagTitle()
+    }
+    setTimeout(() => {
+      if (titleRef.current) {
+        titleRef.current.focus()
+        restoreCursorOffset(titleRef.current, cursorPos)
+      }
+    }, 0)
   }
 
   const handleDetailChange = (content: string) => {
@@ -121,38 +136,16 @@ export default function TemplateDetails({
 
   return (
     <>
-      <StyledTextField
-        type="text"
-        multiline
-        borderLess
-        sx={{
-          width: '100%',
-          '& .MuiInputBase-input': {
-            fontSize: '20px',
-            lineHeight: '28px',
-            color: (theme) => theme.color.gray[600],
-            fontWeight: 500,
-          },
-          '& .MuiInputBase-input.Mui-disabled': {
-            WebkitTextFillColor: (theme) => theme.color.gray[600],
-          },
-          '& .MuiInputBase-root': {
-            padding: '0px 0px',
-          },
-        }}
+      <TokenizedInput
+        ref={titleRef}
         value={updateTitle}
         onChange={handleTitleChange}
-        inputProps={{ maxLength: 255 }}
-        padding="0px"
+        onInsert={handleDynamicFieldInsert}
         onBlur={handleTitleBlur}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter') {
-            e.preventDefault() //prevent users from breaking line
-          }
-        }}
+        style={{ fontSize: '20px', lineHeight: '28px', fontWeight: 500 }}
       />
 
-      <Box mt="12px" sx={{ height: '100%', width: '100%' }}>
+      <Box sx={{ height: '100%', width: '100%' }}>
         <Tapwrite
           content={updateDetail}
           getContent={(content: string) => {
@@ -183,7 +176,7 @@ export default function TemplateDetails({
             handleDeleteTemplate(targetTemplateId)
             store.dispatch(clearTemplateFields())
           }}
-          description={`“${taskName}” will be permanently deleted.`}
+          description={`"${taskName}" will be permanently deleted.`}
           customBody={'Delete template?'}
         />
       </StyledModal>

--- a/src/app/manage-templates/ui/TemplateForm.tsx
+++ b/src/app/manage-templates/ui/TemplateForm.tsx
@@ -2,13 +2,14 @@
 
 import { PrimaryBtn } from '@/components/buttons/PrimaryBtn'
 import { SecondaryBtn } from '@/components/buttons/SecondaryBtn'
-import { StyledTextField } from '@/components/inputs/TextField'
+import { TokenizedInput, restoreCursorOffset } from '@/components/inputs/TokenizedInput'
 import { AppMargin, SizeofAppMargin } from '@/hoc/AppMargin'
 import { AttachmentIcon } from '@/icons'
 import store from '@/redux/store'
 import { Close } from '@mui/icons-material'
 import { Box, Stack, Typography, styled } from '@mui/material'
 import { AttachmentTypes, createTemplateErrors, TargetMethod } from '@/types/interfaces'
+import { useRef } from 'react'
 import { useSelector } from 'react-redux'
 import { selectTaskBoard } from '@/redux/features/taskBoardSlice'
 import {
@@ -82,6 +83,7 @@ const NewTemplateFormInputs = () => {
     useSelector(selectCreateTemplate)
   const { workflowStates, token } = useSelector(selectTaskBoard)
   const { tokenPayload } = useSelector(selectAuthDetails)
+  const titleRef = useRef<HTMLDivElement>(null)
 
   const uploadFn = createUploadFn({
     token,
@@ -100,6 +102,22 @@ const NewTemplateFormInputs = () => {
   })
 
   const statusValue = _statusValue as WorkflowStateResponse //typecasting
+
+  const handleTitleChange = (newValue: string) => {
+    store.dispatch(setCreateTemplateFields({ targetField: 'taskName', value: newValue }))
+    store.dispatch(setErrors({ key: createTemplateErrors.TITLE, value: false }))
+  }
+
+  const handleDynamicFieldInsert = (newValue: string, cursorPos: number) => {
+    store.dispatch(setCreateTemplateFields({ targetField: 'taskName', value: newValue }))
+    store.dispatch(setErrors({ key: createTemplateErrors.TITLE, value: false }))
+    setTimeout(() => {
+      if (titleRef.current) {
+        titleRef.current.focus()
+        restoreCursorOffset(titleRef.current, cursorPos)
+      }
+    }, 0)
+  }
 
   const handleDescriptionChange = (content: string) => {
     store.dispatch(setCreateTemplateFields({ targetField: 'description', value: content }))
@@ -120,39 +138,24 @@ const NewTemplateFormInputs = () => {
           marginBottom: '12px',
         }}
       >
-        <StyledTextField
-          type="text"
-          padding="8px 0px 0px"
-          autoFocus={true}
+        <TokenizedInput
+          ref={titleRef}
           value={taskName}
-          borderLess
-          onChange={(e) => {
-            store.dispatch(setCreateTemplateFields({ targetField: 'taskName', value: e.target.value }))
-            store.dispatch(setErrors({ key: createTemplateErrors.TITLE, value: false }))
-          }}
-          error={errors.title}
-          helperText={errors.title && 'Enter template name'}
-          inputProps={{
-            maxLength: 255,
-          }}
-          sx={{
-            width: '100%',
-            '& .MuiInputBase-input': {
-              fontSize: '16px',
-              lineHeight: '24px',
-              color: (theme) => theme.color.gray[600],
-              fontWeight: 500,
-            },
-            '& .MuiInputBase-input.Mui-disabled': {
-              WebkitTextFillColor: (theme) => theme.color.gray[600],
-            },
-            '& .MuiInputBase-root': {
-              padding: '0px 0px',
-            },
-          }}
+          onChange={handleTitleChange}
+          onInsert={handleDynamicFieldInsert}
+          autoFocus
           placeholder="Template name"
-          multiline
+          style={{
+            fontSize: '16px',
+            lineHeight: '24px',
+            padding: '8px 0px 0px',
+          }}
         />
+        {errors.title && (
+          <Typography variant="bodySm" sx={{ color: '#d32f2f', textAlign: 'right', width: '100%', fontSize: '12px' }}>
+            Enter template name
+          </Typography>
+        )}
         <Box sx={{ height: '100%', width: '100%', overflow: 'auto' }}>
           <Tapwrite
             content={description}

--- a/src/app/ui/NewTaskForm.tsx
+++ b/src/app/ui/NewTaskForm.tsx
@@ -53,6 +53,7 @@ import {
   getSelectorAssignee,
   getSelectorAssigneeFromFilterOptions,
 } from '@/utils/selector'
+import { resolveDynamicFields } from '@/utils/dynamicFields'
 import { trimAllTags } from '@/utils/trimTags'
 import { Box, Stack, styled, Typography } from '@mui/material'
 import { marked } from 'marked'
@@ -497,11 +498,12 @@ const NewTaskHeader = ({
 
           setIsEditorReadonly?.(true)
 
-          store.dispatch(setAppliedTitle({ title: templateTitle }))
+          const resolvedTitle = resolveDynamicFields(templateTitle)
+          store.dispatch(setAppliedTitle({ title: resolvedTitle }))
           if (appliedTitle == title.trim()) {
-            store.dispatch(setCreateTaskFields({ targetField: 'title', value: templateTitle }))
+            store.dispatch(setCreateTaskFields({ targetField: 'title', value: resolvedTitle }))
           } else {
-            store.dispatch(setCreateTaskFields({ targetField: 'title', value: title + ' ' + templateTitle }))
+            store.dispatch(setCreateTaskFields({ targetField: 'title', value: title + ' ' + resolvedTitle }))
           }
 
           setSubtasksCount(subTaskTemplates.length ?? 0)

--- a/src/components/inputs/DynamicFieldsMenu.tsx
+++ b/src/components/inputs/DynamicFieldsMenu.tsx
@@ -1,0 +1,93 @@
+'use client'
+
+import { DynamicFieldPopperProps } from '@/hooks/useDynamicFieldTrigger'
+import { DYNAMIC_FIELDS } from '@/utils/dynamicFields'
+import { Label } from '@mui/icons-material'
+import { Box, ClickAwayListener, Grow, MenuItem, Popper, Stack, Typography } from '@mui/material'
+import { Icon } from 'copilot-design-system'
+
+export const DynamicFieldsPopper = ({ open, anchorEl, filterText, onSelect, onClose }: DynamicFieldPopperProps) => {
+  const filteredFields = DYNAMIC_FIELDS.filter(
+    (f) =>
+      !filterText ||
+      f.key.toLowerCase().startsWith(filterText.toLowerCase()) ||
+      f.label.toLowerCase().startsWith(filterText.toLowerCase()),
+  )
+
+  if (!open || !anchorEl || filteredFields.length === 0) return null
+
+  return (
+    <Popper
+      open={open}
+      anchorEl={anchorEl}
+      placement="bottom-start"
+      transition
+      modifiers={[{ name: 'offset', options: { offset: [0, 4] } }]}
+      sx={{ zIndex: 1300 }}
+    >
+      {({ TransitionProps }) => (
+        <Grow {...TransitionProps} style={{ transformOrigin: 'top left' }}>
+          <Box
+            sx={(theme) => ({
+              border: `1px solid ${theme.color.gray[150]}`,
+              borderRadius: '4px',
+              backgroundColor: 'white',
+              boxShadow: '0px 6px 20px 0px #00000012',
+              minWidth: '200px',
+              paddingBottom: '17px',
+            })}
+          >
+            <ClickAwayListener mouseEvent="onMouseDown" onClickAway={onClose}>
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+                <Stack
+                  sx={{
+                    padding: '8px 0px 4px 12px',
+                    fontWeight: 500,
+                    fontSize: '12px',
+                    lineHeight: '20px',
+                    verticalAlign: 'middle',
+                    color: (theme) => theme.color.gray[400],
+                  }}
+                >
+                  Dynamic fields
+                </Stack>
+                {filteredFields.map((field) => (
+                  <MenuItem
+                    key={field.key}
+                    onClick={() => onSelect(field.key)}
+                    sx={{
+                      padding: '2px 20px 2px 12px',
+                      '&:hover': {
+                        backgroundColor: (theme) => theme.color.gray[100],
+                      },
+                    }}
+                  >
+                    <Stack direction="row" alignItems="center">
+                      <DynamicFieldChip label={field.label} />
+                    </Stack>
+                  </MenuItem>
+                ))}
+              </Box>
+            </ClickAwayListener>
+          </Box>
+        </Grow>
+      )}
+    </Popper>
+  )
+}
+
+export const DynamicFieldChip = ({ label }: { label: string }) => (
+  <Box
+    component="span"
+    sx={{
+      display: 'inline-flex',
+      alignItems: 'center',
+      fontSize: '14px',
+      lineHeight: '22px',
+      color: (theme) => theme.color.gray[600],
+    }}
+  >
+    <Icon icon="Time" height={10} width={10} style={{ marginRight: '9px', color: 'var(--text-secondary)' }} />
+    {label}
+  </Box>
+)

--- a/src/components/inputs/TokenizedInput.tsx
+++ b/src/components/inputs/TokenizedInput.tsx
@@ -1,0 +1,231 @@
+'use client'
+
+import { DynamicFieldsPopper } from '@/components/inputs/DynamicFieldsMenu'
+import { normalizeBraces, useDynamicFieldTrigger } from '@/hooks/useDynamicFieldTrigger'
+import { htmlToTokens, tokensToHtml } from '@/utils/dynamicFields'
+import { Box, styled } from '@mui/material'
+import { Ref, useCallback, useEffect, useImperativeHandle, useRef } from 'react'
+
+interface TokenizedInputProps {
+  ref: Ref<HTMLDivElement>
+  value: string
+  onChange: (newValue: string) => void
+  onInsert: (newValue: string, cursorPos: number) => void
+  onBlur?: () => void
+  placeholder?: string
+  maxLength?: number
+  autoFocus?: boolean
+  style?: React.CSSProperties
+}
+
+/**
+ * Get the cursor offset as a plain-text character index within a contentEditable element.
+ */
+function getCursorOffset(container: HTMLElement): number {
+  const sel = window.getSelection()
+  if (!sel || sel.rangeCount === 0) return -1
+
+  const range = sel.getRangeAt(0)
+  const preRange = document.createRange()
+  preRange.selectNodeContents(container)
+  preRange.setEnd(range.startContainer, range.startOffset)
+
+  const fragment = preRange.cloneContents()
+  const temp = document.createElement('div')
+  temp.appendChild(fragment)
+  return htmlToTokens(temp).length
+}
+
+/**
+ * Restore cursor to a plain-text character offset within a contentEditable element.
+ */
+export function restoreCursorOffset(container: HTMLElement, targetOffset: number) {
+  let remaining = targetOffset
+
+  function walk(node: Node): { node: Node; offset: number } | null {
+    if (node.nodeType === Node.TEXT_NODE) {
+      const len = (node.textContent ?? '').length
+      if (remaining <= len) {
+        return { node, offset: remaining }
+      }
+      remaining -= len
+      return null
+    }
+
+    if (node instanceof HTMLElement && node.dataset.token) {
+      const tokenLen = `{{${node.dataset.token}}}`.length
+      if (remaining <= tokenLen) {
+        const parent = node.parentNode!
+        const index = Array.from(parent.childNodes).indexOf(node as ChildNode)
+        return { node: parent, offset: index + 1 }
+      }
+      remaining -= tokenLen
+      return null
+    }
+
+    for (const child of Array.from(node.childNodes)) {
+      const result = walk(child)
+      if (result) return result
+    }
+    return null
+  }
+
+  const pos = walk(container)
+  if (pos) {
+    const sel = window.getSelection()
+    if (sel) {
+      const range = document.createRange()
+      range.setStart(pos.node, pos.offset)
+      range.collapse(true)
+      sel.removeAllRanges()
+      sel.addRange(range)
+    }
+  }
+}
+
+export const TokenizedInput = ({
+  ref,
+  value,
+  onChange,
+  onInsert,
+  onBlur,
+  placeholder,
+  maxLength = 255,
+  autoFocus,
+  style,
+}: TokenizedInputProps) => {
+  const divRef = useRef<HTMLDivElement>(null)
+  const isComposingRef = useRef(false)
+
+  useImperativeHandle(ref, () => divRef.current as HTMLDivElement)
+
+  const getCursorPos = useCallback(() => {
+    const div = divRef.current
+    if (!div) return 0
+    return getCursorOffset(div)
+  }, [])
+
+  const {
+    popperProps,
+    handleKeyDown: dynamicFieldKeyDown,
+    handleChange: dynamicFieldHandleChange,
+  } = useDynamicFieldTrigger({
+    getCursorPos,
+    value,
+    onInsert,
+  })
+
+  // Sync innerHTML when value changes externally (not from user typing)
+  useEffect(() => {
+    const div = divRef.current
+    if (!div) return
+
+    const currentText = htmlToTokens(div)
+    if (currentText !== value) {
+      const offset = getCursorOffset(div)
+      div.innerHTML = tokensToHtml(value) || ''
+      if (document.activeElement === div && offset >= 0) {
+        restoreCursorOffset(div, Math.min(offset, value.length))
+      }
+    }
+  }, [value])
+
+  useEffect(() => {
+    if (autoFocus && divRef.current) {
+      divRef.current.focus()
+    }
+  }, [autoFocus])
+
+  const handleInput = useCallback(() => {
+    if (isComposingRef.current) return
+    const div = divRef.current
+    if (!div) return
+
+    let newText = htmlToTokens(div)
+
+    // Auto-normalize multiple braces to double braces
+    const normalized = normalizeBraces(newText)
+    if (normalized !== newText) {
+      const offset = getCursorOffset(div)
+      const diff = newText.length - normalized.length
+      newText = normalized
+      div.innerHTML = tokensToHtml(newText)
+      restoreCursorOffset(div, Math.max(0, offset - diff))
+    }
+
+    if (newText.length > maxLength) {
+      const offset = getCursorOffset(div)
+      newText = newText.slice(0, maxLength)
+      div.innerHTML = tokensToHtml(newText)
+      restoreCursorOffset(div, Math.min(offset, newText.length))
+    }
+
+    onChange(newText)
+    dynamicFieldHandleChange(newText)
+  }, [onChange, dynamicFieldHandleChange, maxLength])
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      dynamicFieldKeyDown(e)
+    },
+    [dynamicFieldKeyDown],
+  )
+
+  const handlePaste = useCallback((e: React.ClipboardEvent<HTMLDivElement>) => {
+    e.preventDefault()
+    const text = e.clipboardData.getData('text/plain').replace(/\n/g, ' ')
+    const sel = window.getSelection()
+    if (!sel || sel.rangeCount === 0) return
+    const range = sel.getRangeAt(0)
+    range.deleteContents()
+    range.insertNode(document.createTextNode(text))
+    range.collapse(false)
+    sel.removeAllRanges()
+    sel.addRange(range)
+    // Trigger input handler to sync state
+    divRef.current?.dispatchEvent(new Event('input', { bubbles: true }))
+  }, [])
+
+  return (
+    <Box sx={{ position: 'relative', width: '100%' }}>
+      <StyledEditableDiv
+        ref={divRef}
+        contentEditable
+        suppressContentEditableWarning
+        onInput={handleInput}
+        onKeyDown={handleKeyDown}
+        onBlur={onBlur}
+        onPaste={handlePaste}
+        onCompositionStart={() => {
+          isComposingRef.current = true
+        }}
+        onCompositionEnd={() => {
+          isComposingRef.current = false
+          handleInput()
+        }}
+        data-placeholder={placeholder}
+        style={style}
+      />
+      <DynamicFieldsPopper {...popperProps} />
+    </Box>
+  )
+}
+
+TokenizedInput.displayName = 'TokenizedInput'
+
+const StyledEditableDiv = styled('div')(({ theme }) => ({
+  width: '100%',
+  outline: 'none',
+  border: 'none',
+  whiteSpace: 'pre-wrap',
+  wordWrap: 'break-word',
+  overflowWrap: 'break-word',
+  color: theme.color.gray[600],
+  fontFamily: 'inherit',
+  minHeight: '1em',
+  '&:empty::before': {
+    content: 'attr(data-placeholder)',
+    color: theme.color.gray[400],
+    pointerEvents: 'none',
+  },
+}))

--- a/src/hooks/useDynamicFieldTrigger.ts
+++ b/src/hooks/useDynamicFieldTrigger.ts
@@ -1,0 +1,159 @@
+import { DYNAMIC_FIELDS } from '@/utils/dynamicFields'
+import { PopperProps as MuiPopperProps } from '@mui/material'
+import { useCallback, useRef, useState } from 'react'
+
+type VirtualElement = Exclude<MuiPopperProps['anchorEl'], null | undefined | HTMLElement>
+
+interface UseDynamicFieldTriggerOptions {
+  /** Return the current cursor offset as a plain-text character index */
+  getCursorPos: () => number
+  value: string
+  onInsert: (newValue: string, cursorPos: number) => void
+}
+
+export interface DynamicFieldPopperProps {
+  open: boolean
+  anchorEl: HTMLElement | VirtualElement | null
+  filterText: string
+  onSelect: (fieldKey: string) => void
+  onClose: () => void
+}
+
+function getCursorVirtualElement(): VirtualElement | null {
+  const sel = window.getSelection()
+  if (!sel || sel.rangeCount === 0) return null
+  const range = sel.getRangeAt(0)
+  const rect = range.getBoundingClientRect()
+  return {
+    getBoundingClientRect: () => rect,
+  }
+}
+
+/**
+ * Normalize multiple consecutive curly braces to exactly double braces.
+ * E.g. `{{{Current Week}}}` → `{{Current Week}}`, `{{{{Current Year}}` → `{{Current Year}}`
+ */
+export function normalizeBraces(text: string): string {
+  return text.replace(/\{{2,}([^{}]+)\}{2,}/g, '{{$1}}')
+}
+
+export function useDynamicFieldTrigger({ getCursorPos, value, onInsert }: UseDynamicFieldTriggerOptions) {
+  const [open, setOpen] = useState(false)
+  const [filterText, setFilterText] = useState('')
+  const triggerCursorPos = useRef<number>(-1)
+  const cursorAnchorRef = useRef<VirtualElement | null>(null)
+  const valueRef = useRef(value)
+  valueRef.current = value
+
+  const close = useCallback(() => {
+    setOpen(false)
+    setFilterText('')
+    triggerCursorPos.current = -1
+    cursorAnchorRef.current = null
+  }, [])
+
+  const dismiss = useCallback(() => {
+    const start = triggerCursorPos.current
+    if (start >= 0) {
+      const currentValue = valueRef.current
+      const cursorPos = getCursorPos()
+      const newValue = currentValue.slice(0, start) + currentValue.slice(cursorPos)
+      close()
+      onInsert(newValue, start)
+    } else {
+      close()
+    }
+  }, [close, getCursorPos, onInsert])
+
+  const onSelect = useCallback(
+    (fieldKey: string) => {
+      const currentValue = valueRef.current
+      const token = `{{${fieldKey}}}`
+      const start = triggerCursorPos.current
+      // Use trigger position + 2 (for `{{`) + filter text length instead of live cursor,
+      // because clicking the menu item may move focus away from the contentEditable div
+      const end = start + 2 + filterText.length
+
+      const newValue = currentValue.slice(0, start) + token + currentValue.slice(end)
+      const newCursorPos = start + token.length
+
+      close()
+      onInsert(newValue, newCursorPos)
+    },
+    [filterText, onInsert, close],
+  )
+
+  const handleChange = useCallback(
+    (newValue: string) => {
+      const cursorPos = getCursorPos()
+
+      if (!open) {
+        // Trigger on `{{` — two consecutive opening braces
+        if (cursorPos >= 2 && newValue[cursorPos - 1] === '{' && newValue[cursorPos - 2] === '{') {
+          triggerCursorPos.current = cursorPos - 2
+          cursorAnchorRef.current = getCursorVirtualElement()
+          setFilterText('')
+          setOpen(true)
+        }
+      } else {
+        const start = triggerCursorPos.current
+        if (cursorPos < start || start < 0) {
+          close()
+          return
+        }
+
+        // Check that the opening `{{` is still intact
+        const currentBefore = newValue.slice(start, start + 2)
+        if (currentBefore !== '{{') {
+          close()
+          return
+        }
+
+        const textAfterTrigger = newValue.slice(start + 2, cursorPos)
+
+        if (textAfterTrigger.includes('}')) {
+          close()
+          return
+        }
+
+        const matches = DYNAMIC_FIELDS.filter(
+          (f) =>
+            f.key.toLowerCase().startsWith(textAfterTrigger.toLowerCase()) ||
+            f.label.toLowerCase().startsWith(textAfterTrigger.toLowerCase()),
+        )
+
+        if (matches.length === 0) {
+          close()
+          return
+        }
+
+        setFilterText(textAfterTrigger)
+      }
+    },
+    [getCursorPos, open, close],
+  )
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter') {
+        e.preventDefault()
+      }
+      if (open && e.key === 'Escape') {
+        e.preventDefault()
+        e.stopPropagation()
+        dismiss()
+      }
+    },
+    [open, dismiss],
+  )
+
+  const popperProps: DynamicFieldPopperProps = {
+    open,
+    anchorEl: cursorAnchorRef.current,
+    filterText,
+    onSelect,
+    onClose: dismiss,
+  }
+
+  return { popperProps, handleKeyDown, handleChange }
+}

--- a/src/utils/dynamicFields.ts
+++ b/src/utils/dynamicFields.ts
@@ -1,0 +1,102 @@
+import dayjs from 'dayjs'
+
+export enum DynamicFieldKey {
+  CurrentWeek = 'Current Week',
+  CurrentMonth = 'Current Month',
+  CurrentQuarter = 'Current Quarter',
+  CurrentYear = 'Current Year',
+}
+
+export interface DynamicField {
+  key: DynamicFieldKey
+  label: string
+}
+
+export const DYNAMIC_FIELDS: DynamicField[] = [
+  { key: DynamicFieldKey.CurrentWeek, label: 'Current Week' },
+  { key: DynamicFieldKey.CurrentMonth, label: 'Current Month' },
+  { key: DynamicFieldKey.CurrentQuarter, label: 'Current Quarter' },
+  { key: DynamicFieldKey.CurrentYear, label: 'Current Year' },
+]
+
+function getQuarter(date: dayjs.Dayjs): string {
+  const month = date.month() // 0-indexed
+  return `Q${Math.floor(month / 3) + 1}`
+}
+
+export function resolveDynamicField(key: DynamicFieldKey, now: dayjs.Dayjs = dayjs()): string {
+  switch (key) {
+    case DynamicFieldKey.CurrentWeek:
+      return `Week of ${now.format('MMMM D')}`
+    case DynamicFieldKey.CurrentMonth:
+      return now.format('MMMM')
+    case DynamicFieldKey.CurrentQuarter:
+      return getQuarter(now)
+    case DynamicFieldKey.CurrentYear:
+      return now.format('YYYY')
+  }
+}
+
+/**
+ * Resolves all dynamic field tokens in a string.
+ * Tokens are in the format {{fieldKey}}, e.g. {{Current Month}}, {{Current Year}}
+ */
+export function resolveDynamicFields(text: string): string {
+  const now = dayjs()
+  return text.replace(/\{\{([^}]+)\}\}/g, (match, key) => {
+    const field = DYNAMIC_FIELDS.find((f) => f.key === key)
+    if (!field) return match
+    return resolveDynamicField(field.key, now)
+  })
+}
+
+function escapeHtml(text: string): string {
+  return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}
+
+export const DYNAMIC_FIELD_TOKEN_CLASS = 'dynamic-field-token'
+
+/**
+ * Convert plain text with {{tokens}} to HTML with styled spans.
+ * Token spans have contenteditable="false" so the browser treats them as atomic units.
+ * Normalizes multiple braces to exactly double braces before converting.
+ */
+export function tokensToHtml(text: string): string {
+  // Normalize any excess braces (e.g. {{{Current Year}}} → {{Current Year}})
+  text = text.replace(/\{{2,}([^{}]+)\}{2,}/g, '{{$1}}')
+  return text.replace(/(\{\{[^}]+\}\})/g, (match) => {
+    const key = match.slice(2, -2)
+    return `<span data-token="${escapeHtml(key)}" contenteditable="false" class="${DYNAMIC_FIELD_TOKEN_CLASS}">${escapeHtml(match)}</span>`
+  })
+}
+
+/**
+ * Extract plain text from a contentEditable div, converting token spans back to {{key}} text.
+ * Strips stray braces adjacent to tokens to prevent accumulation.
+ */
+export function htmlToTokens(element: HTMLElement): string {
+  let result = ''
+  const nodes = Array.from(element.childNodes)
+  for (let i = 0; i < nodes.length; i++) {
+    const node = nodes[i]
+    if (node.nodeType === Node.TEXT_NODE) {
+      let text = node.textContent ?? ''
+      // Strip trailing `{` characters if next sibling is a token span
+      const next = nodes[i + 1]
+      if (next instanceof HTMLElement && next.dataset.token) {
+        text = text.replace(/\{+$/, '')
+      }
+      // Strip leading `}` characters if previous sibling is a token span
+      const prev = nodes[i - 1]
+      if (prev instanceof HTMLElement && prev.dataset.token) {
+        text = text.replace(/^\}+/, '')
+      }
+      result += text
+    } else if (node instanceof HTMLElement && node.dataset.token) {
+      result += `{{${node.dataset.token}}}`
+    } else if (node instanceof HTMLElement) {
+      result += htmlToTokens(node)
+    }
+  }
+  return result
+}

--- a/src/utils/dynamicFields.ts
+++ b/src/utils/dynamicFields.ts
@@ -27,7 +27,7 @@ function getQuarter(date: dayjs.Dayjs): string {
 export function resolveDynamicField(key: DynamicFieldKey, now: dayjs.Dayjs = dayjs()): string {
   switch (key) {
     case DynamicFieldKey.CurrentWeek:
-      return `Week of ${now.format('MMMM D')}`
+      return `Week of ${now.format('MMMM D, YYYY')}`
     case DynamicFieldKey.CurrentMonth:
       return now.format('MMMM')
     case DynamicFieldKey.CurrentQuarter:


### PR DESCRIPTION
## Changes

- [x] Typing { in the template title opens a dropdown with 4 dynamic field options: Current Week, Current Month, Current Quarter, Current Year
- [x] Selecting a field inserts {{Field Name}} token into the title at cursor position
- [x] Dynamic field tokens display with a light gray border (#D0D4DA), background (#F5F5F5), and text color (#6B6F76) — visually distinct from normal text
- [x] Tokens behave as atomic units — backspace deletes the entire token, not individual characters
- [x] Dismissing the dropdown (click outside / Escape) removes the trigger { character from the field
- [x] Typing after { filters the dropdown options; closes if no match
- [x] Dynamic fields work in both template editing (/manage-templates) and template creation modal
- [x] When creating a task from a template, tokens resolve to current values: {{Current Month}} → "March", {{Current Quarter}} → "Q1", {{Current Week}} → "Week of March 24", {{Current Year}} → "2026"
- [x] Resolution applies to both task creation and subtask creation from templates 

### Note

#### What cursor position does in this PR?                                                                                                                                                                                
Cursor position tracking (getCursorOffset / restoreCursorOffset) solves a fundamental problem with contentEditable + React:                                                                                  

The problem: When we update innerHTML (e.g., after token insertion or brace normalization), the browser resets the cursor to the beginning. The user would lose their place every time.
