### PR TITLE
feat(OUT-3453): add dynamic fields panel in template detail sidebar

### DIFF
--- a/src/app/manage-templates/[template_id]/page.tsx
+++ b/src/app/manage-templates/[template_id]/page.tsx
@@ -10,6 +10,7 @@ import TemplateDetails from '@/app/manage-templates/ui/TemplateDetails'
 import { deleteTemplate, editTemplate } from '@/app/manage-templates/actions'
 import { UpdateTemplateRequest } from '@/types/dto/templates.dto'
 import { StyledBox, StyledTiptapDescriptionWrapper, TaskDetailsContainer } from '@/app/detail/ui/styledComponent'
+import { DynamicFieldInsertProvider } from '@/context/provider/DynamicFieldInsertProvider'
 import { TemplateSidebar } from '@/app/manage-templates/ui/TemplateSidebar'
 import { Subtemplates } from '@/app/manage-templates/ui/Subtemplates'
 import { HeaderBreadcrumbs } from '@/components/layouts/HeaderBreadcrumbs'
@@ -69,59 +70,61 @@ export default async function TaskDetailPage(props: {
       {token && <OneTemplateDataFetcher token={token} template_id={template_id} initialTemplate={template} />}
       <RealTimeTemplates tokenPayload={tokenPayload} token={token}>
         <EscapeHandler />
-        <ResponsiveStack fromNotificationCenter={false}>
-          <Box sx={{ width: '100%', display: 'flex', flex: 1, flexDirection: 'column', overflow: 'auto' }}>
-            <StyledBox>
-              {isPreviewMode ? (
-                <AppMargin size={SizeofAppMargin.HEADER} py="17.5px">
+        <DynamicFieldInsertProvider>
+          <ResponsiveStack fromNotificationCenter={false}>
+            <Box sx={{ width: '100%', display: 'flex', flex: 1, flexDirection: 'column', overflow: 'auto' }}>
+              <StyledBox>
+                {isPreviewMode ? (
+                  <AppMargin size={SizeofAppMargin.HEADER} py="17.5px">
+                    <HeaderBreadcrumbs token={token} items={breadcrumbItems} userType={UserType.INTERNAL_USER} />
+                  </AppMargin>
+                ) : (
                   <HeaderBreadcrumbs token={token} items={breadcrumbItems} userType={UserType.INTERNAL_USER} />
-                </AppMargin>
-              ) : (
-                <HeaderBreadcrumbs token={token} items={breadcrumbItems} userType={UserType.INTERNAL_USER} />
-              )}
-            </StyledBox>
-            <ManageTemplateDetailsAppBridge portalUrl={workspace.portalUrl} template={template} />
-            <TaskDetailsContainer
-              sx={{
-                padding: { xs: '20px 16px ', sm: '30px 20px' },
-              }}
-            >
-              <StyledTiptapDescriptionWrapper>
-                <TemplateDetails
-                  template={template}
-                  template_id={template_id}
-                  handleDeleteTemplate={async (templateId: string) => {
-                    'use server'
-                    await deleteTemplate(token, templateId)
-                  }}
-                  handleEditTemplate={async (payload: UpdateTemplateRequest, templateId: string) => {
-                    'use server'
-                    await editTemplate(token, templateId, payload)
-                  }}
-                  updateTemplateDetail={async (detail: string) => {
-                    'use server'
-                    await editTemplate(token, template_id, { body: detail })
-                  }}
-                  updateTemplateTitle={async (title: string) => {
-                    'use server'
-                    title.trim() != '' && (await editTemplate(token, template_id, { title }))
-                  }}
-                  token={token}
-                />
-              </StyledTiptapDescriptionWrapper>
-              {!template.parentId && <Subtemplates template_id={template_id} token={token} />}
-            </TaskDetailsContainer>
-          </Box>
+                )}
+              </StyledBox>
+              <ManageTemplateDetailsAppBridge portalUrl={workspace.portalUrl} template={template} />
+              <TaskDetailsContainer
+                sx={{
+                  padding: { xs: '20px 16px ', sm: '30px 20px' },
+                }}
+              >
+                <StyledTiptapDescriptionWrapper>
+                  <TemplateDetails
+                    template={template}
+                    template_id={template_id}
+                    handleDeleteTemplate={async (templateId: string) => {
+                      'use server'
+                      await deleteTemplate(token, templateId)
+                    }}
+                    handleEditTemplate={async (payload: UpdateTemplateRequest, templateId: string) => {
+                      'use server'
+                      await editTemplate(token, templateId, payload)
+                    }}
+                    updateTemplateDetail={async (detail: string) => {
+                      'use server'
+                      await editTemplate(token, template_id, { body: detail })
+                    }}
+                    updateTemplateTitle={async (title: string) => {
+                      'use server'
+                      title.trim() != '' && (await editTemplate(token, template_id, { title }))
+                    }}
+                    token={token}
+                  />
+                </StyledTiptapDescriptionWrapper>
+                {!template.parentId && <Subtemplates template_id={template_id} token={token} />}
+              </TaskDetailsContainer>
+            </Box>
 
-          <TemplateSidebar
-            template_id={template_id}
-            // selectedWorkflowState={task?.workflowState}
-            updateWorkflowState={async (workflowState) => {
-              'use server'
-              await editTemplate(token, template_id, { workflowStateId: workflowState?.id })
-            }}
-          />
-        </ResponsiveStack>
+            <TemplateSidebar
+              template_id={template_id}
+              // selectedWorkflowState={task?.workflowState}
+              updateWorkflowState={async (workflowState) => {
+                'use server'
+                await editTemplate(token, template_id, { workflowStateId: workflowState?.id })
+              }}
+            />
+          </ResponsiveStack>
+        </DynamicFieldInsertProvider>
       </RealTimeTemplates>
     </ClientSideStateUpdate>
   )

--- a/src/app/manage-templates/ui/TemplateDetails.tsx
+++ b/src/app/manage-templates/ui/TemplateDetails.tsx
@@ -62,6 +62,7 @@ export default function TemplateDetails({
         setUpdateDetail(currentTemplate.body ?? '')
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeTemplate?.title, activeTemplate?.body, template_id, activeUploads, template])
 
   const _titleUpdateDebounced = async (title: string) => updateTemplateTitle(title)
@@ -130,7 +131,8 @@ export default function TemplateDetails({
       handleDynamicFieldInsert(newValue, newCursorPos)
       lastCursorPosRef.current = newCursorPos
     },
-    [updateTitle, handleDynamicFieldInsert],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [updateTitle],
   )
 
   const dynamicFieldInsertCtx = useDynamicFieldInsert()

--- a/src/app/manage-templates/ui/TemplateDetails.tsx
+++ b/src/app/manage-templates/ui/TemplateDetails.tsx
@@ -2,9 +2,10 @@
 
 import { StyledModal } from '@/app/detail/ui/styledComponent'
 import AttachmentLayout from '@/components/AttachmentLayout'
-import { TokenizedInput, restoreCursorOffset } from '@/components/inputs/TokenizedInput'
+import { TokenizedInput, restoreCursorOffset, getCursorOffset } from '@/components/inputs/TokenizedInput'
 import { ConfirmDeleteUI } from '@/components/layouts/ConfirmDeleteUI'
 import { MAX_UPLOAD_LIMIT } from '@/constants/attachments'
+import { useDynamicFieldInsert } from '@/context/hooks/useDynamicFieldInsert'
 import { useDebounce, useDebounceWithCancel } from '@/hooks/useDebounce'
 import { selectTaskDetails, setOpenImage, setShowConfirmDeleteModal } from '@/redux/features/taskDetailsSlice'
 import { clearTemplateFields, selectCreateTemplate } from '@/redux/features/templateSlice'
@@ -17,6 +18,8 @@ import { Box } from '@mui/material'
 import { MouseEvent, useCallback, useEffect, useRef, useState } from 'react'
 import { useSelector } from 'react-redux'
 import { Tapwrite } from 'tapwrite'
+
+export type DynamicFieldInsertFn = (fieldKey: string) => void
 
 interface TemplateDetailsProps {
   template: ITemplate
@@ -86,7 +89,14 @@ export default function TemplateDetails({
     debouncedResetTypingFlagTitle()
   }
 
+  const lastCursorPosRef = useRef<number>(-1)
+
   const handleTitleBlur = () => {
+    // Save cursor position before blur so sidebar clicks can insert at last position
+    if (titleRef.current) {
+      const pos = getCursorOffset(titleRef.current)
+      if (pos >= 0) lastCursorPosRef.current = pos
+    }
     if (updateTitle.trim() == '') {
       setTimeout(() => {
         const currentTask = activeTemplate
@@ -109,6 +119,25 @@ export default function TemplateDetails({
       }
     }, 0)
   }
+
+  // Insert a dynamic field from the sidebar panel
+  const handleSidebarFieldInsert = useCallback(
+    (fieldKey: string) => {
+      const token = `{{${fieldKey}}}`
+      const pos = lastCursorPosRef.current >= 0 ? lastCursorPosRef.current : updateTitle.length
+      const newValue = updateTitle.slice(0, pos) + token + updateTitle.slice(pos)
+      const newCursorPos = pos + token.length
+      handleDynamicFieldInsert(newValue, newCursorPos)
+      lastCursorPosRef.current = newCursorPos
+    },
+    [updateTitle],
+  )
+
+  const dynamicFieldInsertCtx = useDynamicFieldInsert()
+
+  useEffect(() => {
+    dynamicFieldInsertCtx?.registerHandler(handleSidebarFieldInsert)
+  }, [handleSidebarFieldInsert, dynamicFieldInsertCtx])
 
   const handleDetailChange = (content: string) => {
     if (!didMount.current) {

--- a/src/app/manage-templates/ui/TemplateDetails.tsx
+++ b/src/app/manage-templates/ui/TemplateDetails.tsx
@@ -130,7 +130,7 @@ export default function TemplateDetails({
       handleDynamicFieldInsert(newValue, newCursorPos)
       lastCursorPosRef.current = newCursorPos
     },
-    [updateTitle],
+    [updateTitle, handleDynamicFieldInsert],
   )
 
   const dynamicFieldInsertCtx = useDynamicFieldInsert()

--- a/src/app/manage-templates/ui/TemplateSidebar.tsx
+++ b/src/app/manage-templates/ui/TemplateSidebar.tsx
@@ -12,11 +12,14 @@ import { selectTaskBoard } from '@/redux/features/taskBoardSlice'
 import { selectTaskDetails, setShowSidebar } from '@/redux/features/taskDetailsSlice'
 import { selectCreateTemplate } from '@/redux/features/templateSlice'
 import store from '@/redux/store'
+import { DYNAMIC_FIELDS, resolveDynamicField } from '@/utils/dynamicFields'
 import { WorkflowStateResponse } from '@/types/dto/workflowStates.dto'
 import { Sizes } from '@/types/interfaces'
-import { Box, Stack, Typography } from '@mui/material'
+import { Box, Divider, Stack, Typography } from '@mui/material'
+import { Icon } from 'copilot-design-system'
 import { useEffect } from 'react'
 import { useSelector } from 'react-redux'
+import { useDynamicFieldInsert } from '@/context/hooks/useDynamicFieldInsert'
 
 export const TemplateSidebar = ({
   template_id,
@@ -25,6 +28,7 @@ export const TemplateSidebar = ({
   template_id: string
   updateWorkflowState: (workflowState: WorkflowStateResponse) => void
 }) => {
+  const dynamicFieldInsertCtx = useDynamicFieldInsert()
   const { workflowStates } = useSelector(selectTaskBoard)
   const { showSidebar } = useSelector(selectTaskDetails)
   const { activeTemplate } = useSelector(selectCreateTemplate)
@@ -121,8 +125,8 @@ export const TemplateSidebar = ({
         </AppMargin>
       </StyledBox>
 
-      <AppMargin size={SizeofAppMargin.HEADER} py={'0px'}>
-        <Stack direction="row" alignItems="center" m="0px 0px 8px" columnGap="8px">
+      <AppMargin size={SizeofAppMargin.HEADER} py="0px 20px 20px">
+        <Stack direction="row" alignItems="center" m="0px 0px" columnGap="8px">
           <Typography
             sx={{
               color: (theme) => theme.color.gray[500],
@@ -164,6 +168,80 @@ export const TemplateSidebar = ({
           )}
         </Stack>
       </AppMargin>
+
+      <Divider />
+
+      <AppMargin size={SizeofAppMargin.HEADER} py="0px 29px 0px">
+        <Stack direction="column" m="16px 0px 8px" gap="20px">
+          <Typography
+            variant="sm"
+            lineHeight={'24px'}
+            fontSize={'16px'}
+            fontWeight={500}
+            color={(theme) => theme.color.text.text}
+          >
+            Dynamic Fields
+          </Typography>
+          <Stack direction="column" gap="12px">
+            {DYNAMIC_FIELDS.map((field) => (
+              <DynamicFieldCard
+                key={field.key}
+                label={`{{${field.label}}}`}
+                preview={resolveDynamicField(field.key)}
+                onClick={() => dynamicFieldInsertCtx?.insertField(field.key)}
+              />
+            ))}
+          </Stack>
+        </Stack>
+      </AppMargin>
     </Box>
   )
 }
+
+const DynamicFieldCard = ({ label, preview, onClick }: { label: string; preview: string; onClick: () => void }) => (
+  <Box
+    // draggable
+    // onDragStart={(e) => {
+    //   e.dataTransfer.setData('text/plain', label)
+    //   e.dataTransfer.effectAllowed = 'copy'
+    // }}
+    onClick={onClick}
+    sx={{
+      border: (theme) => `1px solid ${theme.color.borders.border}`,
+      borderRadius: '4px',
+      padding: '6px 12px',
+      '&:hover': {
+        backgroundColor: (theme) => theme.color.gray[100],
+      },
+      cursor: 'pointer',
+      // '&:active': {
+      //   cursor: 'grabbing',
+      // },
+    }}
+  >
+    <Typography
+      variant="bodySm"
+      sx={{
+        fontSize: '13px',
+        lineHeight: '20px',
+        fontWeight: 500,
+        color: (theme) => theme.color.gray[600],
+      }}
+    >
+      {label}
+    </Typography>
+    <Stack direction="row" alignItems="center" gap="6px" mt="4px">
+      <Icon icon="Time" height={10} width={10} style={{ color: 'var(--text-secondary)', flexShrink: 0 }} />
+      <Typography
+        variant="bodySm"
+        sx={{
+          fontSize: '12px',
+          lineHeight: '20px',
+          color: (theme) => theme.color.gray[400],
+        }}
+      >
+        {preview}
+      </Typography>
+    </Stack>
+  </Box>
+)

--- a/src/components/inputs/TokenizedInput.tsx
+++ b/src/components/inputs/TokenizedInput.tsx
@@ -21,7 +21,7 @@ interface TokenizedInputProps {
 /**
  * Get the cursor offset as a plain-text character index within a contentEditable element.
  */
-function getCursorOffset(container: HTMLElement): number {
+export function getCursorOffset(container: HTMLElement): number {
   const sel = window.getSelection()
   if (!sel || sel.rangeCount === 0) return -1
 

--- a/src/context/hooks/useDynamicFieldInsert.ts
+++ b/src/context/hooks/useDynamicFieldInsert.ts
@@ -1,0 +1,12 @@
+import { DynamicFieldInsertContext } from '@/context/provider/DynamicFieldInsertProvider'
+import { useContext } from 'react'
+
+export function useDynamicFieldInsert() {
+  const context = useContext(DynamicFieldInsertContext)
+
+  if (!context) {
+    throw new Error('useDynamicFieldInsert must be used within DynamicFieldInsertProvider')
+  }
+
+  return context
+}

--- a/src/context/provider/DynamicFieldInsertProvider.tsx
+++ b/src/context/provider/DynamicFieldInsertProvider.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+import { DynamicFieldInsertFn } from '@/app/manage-templates/ui/TemplateDetails'
+import { createContext, ReactNode, useCallback, useContext, useRef } from 'react'
+
+interface DynamicFieldInsertContextValue {
+  registerHandler: (handler: DynamicFieldInsertFn) => void
+  insertField: (fieldKey: string) => void
+}
+
+export const DynamicFieldInsertContext = createContext<DynamicFieldInsertContextValue | null>(null)
+
+export function DynamicFieldInsertProvider({ children }: { children: ReactNode }) {
+  const handlerRef = useRef<DynamicFieldInsertFn | null>(null)
+
+  const registerHandler = useCallback((handler: DynamicFieldInsertFn) => {
+    handlerRef.current = handler
+  }, [])
+
+  const insertField = useCallback((fieldKey: string) => {
+    handlerRef.current?.(fieldKey)
+  }, [])
+
+  return (
+    <DynamicFieldInsertContext.Provider value={{ registerHandler, insertField }}>
+      {children}
+    </DynamicFieldInsertContext.Provider>
+  )
+}


### PR DESCRIPTION
## Changes

- [x] add a "Dynamic Fields" section to the right sidebar of the template detail page. 
- [x] clicking a field chip inserts the token at the last cursor position in the title. 
- [x] uses a context provider to connect TemplateDetails insert handler with TemplateSidebar.

## Testing Criteria

[Loom](https://www.loom.com/share/b57b78017dc14c12979cd20e131d1472)
