### PR TITLE
OUT-3453: insert token only if cursor is active in template title

### DIFF
--- a/src/app/manage-templates/ui/TemplateDetails.tsx
+++ b/src/app/manage-templates/ui/TemplateDetails.tsx
@@ -96,8 +96,16 @@ export default function TemplateDetails({
   }
 
   const lastCursorPosRef = useRef<number>(-1)
+  const titleBlurTimestampRef = useRef<number>(0)
+  const titleIsFocusedRef = useRef(false)
+
+  const handleTitleFocus = () => {
+    titleIsFocusedRef.current = true
+  }
 
   const handleTitleBlur = () => {
+    titleIsFocusedRef.current = false
+    titleBlurTimestampRef.current = Date.now()
     // Save cursor position before blur so sidebar clicks can insert at last position
     if (titleRef.current) {
       const pos = getCursorOffset(titleRef.current)
@@ -126,19 +134,21 @@ export default function TemplateDetails({
     }, 0)
   }
 
-  // Insert a dynamic field from the sidebar panel
-  const handleSidebarFieldInsert = useCallback(
-    (fieldKey: string) => {
-      const token = `{{${fieldKey}}}`
-      const pos = lastCursorPosRef.current >= 0 ? lastCursorPosRef.current : updateTitle.length
-      const newValue = updateTitle.slice(0, pos) + token + updateTitle.slice(pos)
-      const newCursorPos = pos + token.length
-      handleDynamicFieldInsert(newValue, newCursorPos)
-      lastCursorPosRef.current = newCursorPos
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [updateTitle],
-  )
+  const updateTitleRef = useRef(updateTitle)
+  updateTitleRef.current = updateTitle
+
+  // Insert a dynamic field from the sidebar panel — only if title is focused or was recently focused
+  const handleSidebarFieldInsert = useCallback((fieldKey: string) => {
+    const titleIsActive = titleIsFocusedRef.current || Date.now() - titleBlurTimestampRef.current < 500
+    if (!titleIsActive) return
+    const token = `{{${fieldKey}}}`
+    const currentTitle = updateTitleRef.current
+    const pos = lastCursorPosRef.current >= 0 ? lastCursorPosRef.current : currentTitle.length
+    const newValue = currentTitle.slice(0, pos) + token + currentTitle.slice(pos)
+    const newCursorPos = pos + token.length
+    handleDynamicFieldInsert(newValue, newCursorPos)
+    lastCursorPosRef.current = newCursorPos
+  }, [])
 
   const dynamicFieldInsertCtx = useDynamicFieldInsert()
 
@@ -178,6 +188,7 @@ export default function TemplateDetails({
         onChange={handleTitleChange}
         onInsert={handleDynamicFieldInsert}
         onBlur={handleTitleBlur}
+        onFocus={handleTitleFocus}
         style={{ fontSize: '20px', lineHeight: '28px', fontWeight: 500 }}
       />
 

--- a/src/app/manage-templates/ui/TemplateDetails.tsx
+++ b/src/app/manage-templates/ui/TemplateDetails.tsx
@@ -148,6 +148,7 @@ export default function TemplateDetails({
     const newCursorPos = pos + token.length
     handleDynamicFieldInsert(newValue, newCursorPos)
     lastCursorPosRef.current = newCursorPos
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   const dynamicFieldInsertCtx = useDynamicFieldInsert()

--- a/src/components/inputs/TokenizedInput.tsx
+++ b/src/components/inputs/TokenizedInput.tsx
@@ -12,6 +12,7 @@ interface TokenizedInputProps {
   onChange: (newValue: string) => void
   onInsert: (newValue: string, cursorPos: number) => void
   onBlur?: () => void
+  onFocus?: () => void
   placeholder?: string
   maxLength?: number
   autoFocus?: boolean
@@ -89,6 +90,7 @@ export const TokenizedInput = ({
   onChange,
   onInsert,
   onBlur,
+  onFocus,
   placeholder,
   maxLength = 255,
   autoFocus,
@@ -195,6 +197,7 @@ export const TokenizedInput = ({
         onInput={handleInput}
         onKeyDown={handleKeyDown}
         onBlur={onBlur}
+        onFocus={onFocus}
         onPaste={handlePaste}
         onCompositionStart={() => {
           isComposingRef.current = true


### PR DESCRIPTION
## Changes

- [x] insert dynamic field token only when cursor is active in title
- [x] no effect when cursor is not active on title. This behavior is resolved in next ticket. When no cursor is active, it should insert dynamic field on the description content on click. 

## Testing Criteria

[Loom](https://www.loom.com/share/949bf9e5f69340768f5538cc2f0d004c)