### PR TITLE
OUT-3456: separate dynamic fields visually by adding spaces between them

### DIFF
--- a/src/app/manage-templates/ui/TemplateDetails.tsx
+++ b/src/app/manage-templates/ui/TemplateDetails.tsx
@@ -14,6 +14,7 @@ import { CreateTemplateRequest } from '@/types/dto/templates.dto'
 import { AttachmentTypes, ITemplate } from '@/types/interfaces'
 import { deleteEditorAttachmentsHandler, uploadAttachmentHandler } from '@/utils/attachmentUtils'
 import { createUploadFn } from '@/utils/createUploadFn'
+import { insertToken } from '@/utils/dynamicFields'
 import {
   TapwriteDynamicFieldDropdown,
   TapwriteDynamicFieldTemplate,
@@ -141,11 +142,9 @@ export default function TemplateDetails({
   const handleSidebarFieldInsert = useCallback((fieldKey: string) => {
     const titleIsActive = titleIsFocusedRef.current || Date.now() - titleBlurTimestampRef.current < 500
     if (!titleIsActive) return
-    const token = `{{${fieldKey}}}`
     const currentTitle = updateTitleRef.current
     const pos = lastCursorPosRef.current >= 0 ? lastCursorPosRef.current : currentTitle.length
-    const newValue = currentTitle.slice(0, pos) + token + currentTitle.slice(pos)
-    const newCursorPos = pos + token.length
+    const { newValue, cursorPos: newCursorPos } = insertToken(currentTitle, pos, `{{${fieldKey}}}`)
     handleDynamicFieldInsert(newValue, newCursorPos)
     lastCursorPosRef.current = newCursorPos
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/inputs/TokenizedInput.tsx
+++ b/src/components/inputs/TokenizedInput.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { DynamicFieldsPopper } from '@/components/inputs/DynamicFieldsMenu'
-import { normalizeBraces, useDynamicFieldTrigger } from '@/hooks/useDynamicFieldTrigger'
+import { useDynamicFieldTrigger } from '@/hooks/useDynamicFieldTrigger'
 import { htmlToTokens, tokensToHtml } from '@/utils/dynamicFields'
 import { Box, styled } from '@mui/material'
 import { Ref, useCallback, useEffect, useImperativeHandle, useRef } from 'react'
@@ -144,16 +144,6 @@ export const TokenizedInput = ({
     if (!div) return
 
     let newText = htmlToTokens(div)
-
-    // Auto-normalize multiple braces to double braces
-    const normalized = normalizeBraces(newText)
-    if (normalized !== newText) {
-      const offset = getCursorOffset(div)
-      const diff = newText.length - normalized.length
-      newText = normalized
-      div.innerHTML = tokensToHtml(newText)
-      restoreCursorOffset(div, Math.max(0, offset - diff))
-    }
 
     if (newText.length > maxLength) {
       const offset = getCursorOffset(div)

--- a/src/hooks/useDynamicFieldTrigger.ts
+++ b/src/hooks/useDynamicFieldTrigger.ts
@@ -1,4 +1,4 @@
-import { DYNAMIC_FIELDS } from '@/utils/dynamicFields'
+import { DYNAMIC_FIELDS, insertToken } from '@/utils/dynamicFields'
 import { PopperProps as MuiPopperProps } from '@mui/material'
 import { useCallback, useRef, useState } from 'react'
 
@@ -29,14 +29,6 @@ function getCursorVirtualElement(): VirtualElement | null {
   }
 }
 
-/**
- * Normalize multiple consecutive curly braces to exactly double braces.
- * E.g. `{{{Current Week}}}` → `{{Current Week}}`, `{{{{Current Year}}` → `{{Current Year}}`
- */
-export function normalizeBraces(text: string): string {
-  return text.replace(/\{{2,}([^{}]+)\}{2,}/g, '{{$1}}')
-}
-
 export function useDynamicFieldTrigger({ getCursorPos, value, onInsert }: UseDynamicFieldTriggerOptions) {
   const [open, setOpen] = useState(false)
   const [filterText, setFilterText] = useState('')
@@ -53,17 +45,8 @@ export function useDynamicFieldTrigger({ getCursorPos, value, onInsert }: UseDyn
   }, [])
 
   const dismiss = useCallback(() => {
-    const start = triggerCursorPos.current
-    if (start >= 0) {
-      const currentValue = valueRef.current
-      const cursorPos = getCursorPos()
-      const newValue = currentValue.slice(0, start) + currentValue.slice(cursorPos)
-      close()
-      onInsert(newValue, start)
-    } else {
-      close()
-    }
-  }, [close, getCursorPos, onInsert])
+    close()
+  }, [close])
 
   const onSelect = useCallback(
     (fieldKey: string) => {
@@ -74,8 +57,8 @@ export function useDynamicFieldTrigger({ getCursorPos, value, onInsert }: UseDyn
       // because clicking the menu item may move focus away from the contentEditable div
       const end = start + 2 + filterText.length
 
-      const newValue = currentValue.slice(0, start) + token + currentValue.slice(end)
-      const newCursorPos = start + token.length
+      const stripped = currentValue.slice(0, start) + currentValue.slice(end)
+      const { newValue, cursorPos: newCursorPos } = insertToken(stripped, start, token)
 
       close()
       onInsert(newValue, newCursorPos)
@@ -88,8 +71,13 @@ export function useDynamicFieldTrigger({ getCursorPos, value, onInsert }: UseDyn
       const cursorPos = getCursorPos()
 
       if (!open) {
-        // Trigger on `{{` — two consecutive opening braces
-        if (cursorPos >= 2 && newValue[cursorPos - 1] === '{' && newValue[cursorPos - 2] === '{') {
+        // Trigger on exactly `{{` — two consecutive opening braces, not three or more
+        if (
+          cursorPos >= 2 &&
+          newValue[cursorPos - 1] === '{' &&
+          newValue[cursorPos - 2] === '{' &&
+          (cursorPos < 3 || newValue[cursorPos - 3] !== '{')
+        ) {
           triggerCursorPos.current = cursorPos - 2
           cursorAnchorRef.current = getCursorVirtualElement()
           setFilterText('')

--- a/src/utils/dynamicFields.ts
+++ b/src/utils/dynamicFields.ts
@@ -71,13 +71,10 @@ export const DYNAMIC_FIELD_TOKEN_CLASS = 'dynamic-field-token'
 /**
  * Convert plain text with {{tokens}} to HTML with styled spans.
  * Token spans have contenteditable="false" so the browser treats them as atomic units.
- * Normalizes multiple braces to exactly double braces before converting.
+ * Only exactly double braces are treated as tokens — triple or more braces are normal text.
  */
 export function tokensToHtml(text: string): string {
-  // Normalize any excess braces (e.g. {{{Current Year}}} → {{Current Year}})
-  text = text.replace(/\{{2,}([^{}]+)\}{2,}/g, '{{$1}}')
-  return text.replace(/(\{\{[^}]+\}\})/g, (match) => {
-    const key = match.slice(2, -2)
+  return text.replace(/(?<!\{)\{\{(?!\{)([^{}]+)\}\}(?!\})/g, (match, key) => {
     return `<span data-token="${escapeHtml(key)}" contenteditable="false" class="${DYNAMIC_FIELD_TOKEN_CLASS}">${escapeHtml(match)}</span>`
   })
 }
@@ -111,4 +108,16 @@ export function htmlToTokens(element: HTMLElement): string {
     }
   }
   return result
+}
+
+/**
+ * Insert a token into text at a given position, adding spaces before/after only when needed.
+ */
+export function insertToken(text: string, pos: number, token: string): { newValue: string; cursorPos: number } {
+  const before = text.slice(0, pos)
+  const after = text.slice(pos)
+  const spaceBefore = before.length > 0 && !before.endsWith(' ') ? ' ' : ''
+  const spaceAfter = after.length > 0 && !after.startsWith(' ') ? ' ' : ''
+  const insertion = spaceBefore + token + spaceAfter
+  return { newValue: before + insertion + after, cursorPos: pos + insertion.length }
 }


### PR DESCRIPTION
## Changes

- [x] add spaces when multiple tokens are selected one after another
- [x] remove brace normalize. Basically what it did was to group multiple braces into two. Example: {{{{ -> {{. That seems unnecessary.

## Testing Criteria

Screen cast

https://github.com/user-attachments/assets/e0854654-3557-4795-9b99-31debb81a8e1

