### PR TITLE
OUT-3454 | Insert dynamic fields token in template description on click

### DIFF
--- a/src/app/manage-templates/ui/TemplateDetails.tsx
+++ b/src/app/manage-templates/ui/TemplateDetails.tsx
@@ -134,20 +134,68 @@ export default function TemplateDetails({
     }, 0)
   }
 
+  const tapwriteEditorRef = useRef<HTMLDivElement>(null) as React.RefObject<HTMLDivElement>
+
   const updateTitleRef = useRef(updateTitle)
   updateTitleRef.current = updateTitle
 
-  // Insert a dynamic field from the sidebar panel — only if title is focused or was recently focused
+  const updateDetailRef = useRef(updateDetail)
+  updateDetailRef.current = updateDetail
+
+  // Insert a dynamic field from the sidebar panel into the title or Tapwrite body.
+  // mousedown preventDefault on the sidebar card keeps the active editor focused.
   const handleSidebarFieldInsert = useCallback((fieldKey: string) => {
-    const titleIsActive = titleIsFocusedRef.current || Date.now() - titleBlurTimestampRef.current < 500
-    if (!titleIsActive) return
-    const token = `{{${fieldKey}}}`
-    const currentTitle = updateTitleRef.current
-    const pos = lastCursorPosRef.current >= 0 ? lastCursorPosRef.current : currentTitle.length
-    const newValue = currentTitle.slice(0, pos) + token + currentTitle.slice(pos)
-    const newCursorPos = pos + token.length
-    handleDynamicFieldInsert(newValue, newCursorPos)
-    lastCursorPosRef.current = newCursorPos
+    // 1. If title is focused, insert in title at cursor
+    if (titleIsFocusedRef.current) {
+      const token = `{{${fieldKey}}}`
+      const currentTitle = updateTitleRef.current
+      const pos = lastCursorPosRef.current >= 0 ? lastCursorPosRef.current : currentTitle.length
+      const newValue = currentTitle.slice(0, pos) + token + currentTitle.slice(pos)
+      const newCursorPos = pos + token.length
+      handleDynamicFieldInsert(newValue, newCursorPos)
+      lastCursorPosRef.current = newCursorPos
+      return
+    }
+
+    // 2. If cursor is inside Tapwrite (still focused thanks to mousedown preventDefault),
+    //    insert at cursor position via DOM — ProseMirror's mutation observer will pick it up.
+    const sel = window.getSelection()
+    if (sel && sel.rangeCount > 0 && tapwriteEditorRef.current) {
+      const range = sel.getRangeAt(0)
+      if (tapwriteEditorRef.current.contains(range.commonAncestorContainer)) {
+        const autofillEl = document.createElement('autofill-field')
+        autofillEl.setAttribute('data-value', fieldKey)
+        const spaceNode = document.createTextNode('\u00A0')
+        range.collapse(false)
+        range.insertNode(spaceNode)
+        range.insertNode(autofillEl)
+        // Move cursor after inserted content
+        range.setStartAfter(spaceNode)
+        range.collapse(true)
+        sel.removeAllRanges()
+        sel.addRange(range)
+        return
+      }
+    }
+
+    // 3. Nothing focused — insert at the end of the Description body
+    const tag = `<autofill-field data-value="${fieldKey}"></autofill-field>`
+    const currentBody = updateDetailRef.current
+    let newBody: string
+    if (!currentBody || currentBody === '<p></p>' || currentBody.trim() === '') {
+      newBody = `<p>${tag} </p>`
+    } else {
+      const lastPIndex = currentBody.lastIndexOf('</p>')
+      if (lastPIndex !== -1) {
+        newBody = currentBody.slice(0, lastPIndex) + tag + ' ' + currentBody.slice(lastPIndex)
+      } else {
+        newBody = currentBody + `<p>${tag} </p>`
+      }
+    }
+    setUpdateDetail(newBody)
+    setIsUserTyping(true)
+    detailsUpdateDebounced(newBody)
+    debouncedResetTypingFlag()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
@@ -195,6 +243,7 @@ export default function TemplateDetails({
 
       <Box sx={{ height: '100%', width: '100%' }}>
         <Tapwrite
+          editorRef={tapwriteEditorRef}
           content={updateDetail}
           getContent={(content: string) => {
             if (updateDetail !== '') {

--- a/src/app/manage-templates/ui/TemplateDetails.tsx
+++ b/src/app/manage-templates/ui/TemplateDetails.tsx
@@ -13,6 +13,7 @@ import store from '@/redux/store'
 import { CreateTemplateRequest } from '@/types/dto/templates.dto'
 import { AttachmentTypes, ITemplate } from '@/types/interfaces'
 import { deleteEditorAttachmentsHandler, uploadAttachmentHandler } from '@/utils/attachmentUtils'
+import { insertTokenInTitle, insertAutofillAtCursor, insertAutofillIntoHtml } from '@/utils/sidebarFieldInsert'
 import { createUploadFn } from '@/utils/createUploadFn'
 import {
   TapwriteDynamicFieldDropdown,
@@ -136,6 +137,30 @@ export default function TemplateDetails({
 
   const tapwriteEditorRef = useRef<HTMLDivElement>(null) as React.RefObject<HTMLDivElement>
 
+  // Tapwrite's internal EditorContent wrapper has onFocus={() => editor.commands.focus("end")}
+  // which overrides ProseMirror's click-based cursor placement when the editor gains focus.
+  // Suppress that by stopping focusin propagation when focus was triggered by a mouse click.
+  useEffect(() => {
+    const el = tapwriteEditorRef.current
+    if (!el) return
+    let mouseDownInside = false
+    const onMouseDown = () => {
+      mouseDownInside = true
+    }
+    const onFocusIn = (e: Event) => {
+      if (mouseDownInside) {
+        e.stopPropagation()
+        mouseDownInside = false
+      }
+    }
+    el.addEventListener('mousedown', onMouseDown)
+    el.addEventListener('focusin', onFocusIn)
+    return () => {
+      el.removeEventListener('mousedown', onMouseDown)
+      el.removeEventListener('focusin', onFocusIn)
+    }
+  }, [])
+
   const updateTitleRef = useRef(updateTitle)
   updateTitleRef.current = updateTitle
 
@@ -147,11 +172,7 @@ export default function TemplateDetails({
   const handleSidebarFieldInsert = useCallback((fieldKey: string) => {
     // 1. If title is focused, insert in title at cursor
     if (titleIsFocusedRef.current) {
-      const token = `{{${fieldKey}}}`
-      const currentTitle = updateTitleRef.current
-      const pos = lastCursorPosRef.current >= 0 ? lastCursorPosRef.current : currentTitle.length
-      const newValue = currentTitle.slice(0, pos) + token + currentTitle.slice(pos)
-      const newCursorPos = pos + token.length
+      const { newValue, newCursorPos } = insertTokenInTitle(updateTitleRef.current, fieldKey, lastCursorPosRef.current)
       handleDynamicFieldInsert(newValue, newCursorPos)
       lastCursorPosRef.current = newCursorPos
       return
@@ -159,39 +180,12 @@ export default function TemplateDetails({
 
     // 2. If cursor is inside Tapwrite (still focused thanks to mousedown preventDefault),
     //    insert at cursor position via DOM — ProseMirror's mutation observer will pick it up.
-    const sel = window.getSelection()
-    if (sel && sel.rangeCount > 0 && tapwriteEditorRef.current) {
-      const range = sel.getRangeAt(0)
-      if (tapwriteEditorRef.current.contains(range.commonAncestorContainer)) {
-        const autofillEl = document.createElement('autofill-field')
-        autofillEl.setAttribute('data-value', fieldKey)
-        const spaceNode = document.createTextNode('\u00A0')
-        range.collapse(false)
-        range.insertNode(spaceNode)
-        range.insertNode(autofillEl)
-        // Move cursor after inserted content
-        range.setStartAfter(spaceNode)
-        range.collapse(true)
-        sel.removeAllRanges()
-        sel.addRange(range)
-        return
-      }
+    if (tapwriteEditorRef.current && insertAutofillAtCursor(tapwriteEditorRef.current, fieldKey)) {
+      return
     }
 
     // 3. Nothing focused — insert at the end of the Description body
-    const tag = `<autofill-field data-value="${fieldKey}"></autofill-field>`
-    const currentBody = updateDetailRef.current
-    let newBody: string
-    if (!currentBody || currentBody === '<p></p>' || currentBody.trim() === '') {
-      newBody = `<p>${tag} </p>`
-    } else {
-      const lastPIndex = currentBody.lastIndexOf('</p>')
-      if (lastPIndex !== -1) {
-        newBody = currentBody.slice(0, lastPIndex) + tag + ' ' + currentBody.slice(lastPIndex)
-      } else {
-        newBody = currentBody + `<p>${tag} </p>`
-      }
-    }
+    const newBody = insertAutofillIntoHtml(updateDetailRef.current, fieldKey)
     setUpdateDetail(newBody)
     setIsUserTyping(true)
     detailsUpdateDebounced(newBody)

--- a/src/app/manage-templates/ui/TemplateSidebar.tsx
+++ b/src/app/manage-templates/ui/TemplateSidebar.tsx
@@ -200,11 +200,7 @@ export const TemplateSidebar = ({
 
 const DynamicFieldCard = ({ label, preview, onClick }: { label: string; preview: string; onClick: () => void }) => (
   <Box
-    // draggable
-    // onDragStart={(e) => {
-    //   e.dataTransfer.setData('text/plain', label)
-    //   e.dataTransfer.effectAllowed = 'copy'
-    // }}
+    onMouseDown={(e) => e.preventDefault()}
     onClick={onClick}
     sx={{
       border: (theme) => `1px solid ${theme.color.borders.border}`,

--- a/src/utils/sidebarFieldInsert.ts
+++ b/src/utils/sidebarFieldInsert.ts
@@ -1,0 +1,71 @@
+/**
+ * Pure helper functions for inserting dynamic field tokens from the sidebar
+ * into the template title (TokenizedInput) or description (Tapwrite).
+ */
+
+/**
+ * Build a new title string with the {{token}} spliced in at the given cursor position.
+ */
+export function insertTokenInTitle(
+  currentTitle: string,
+  fieldKey: string,
+  cursorPos: number,
+): { newValue: string; newCursorPos: number } {
+  const token = `{{${fieldKey}}}`
+  const pos = cursorPos >= 0 ? cursorPos : currentTitle.length
+  const newValue = currentTitle.slice(0, pos) + token + currentTitle.slice(pos)
+  return { newValue, newCursorPos: pos + token.length }
+}
+
+/**
+ * Insert an `<autofill-field>` element at the current DOM selection inside a
+ * container element.  Returns `true` if the insertion happened (i.e. the
+ * selection was inside the container), `false` otherwise.
+ *
+ * Because `mousedown` on the sidebar card calls `preventDefault()`, the
+ * Tapwrite editor keeps focus and the browser selection stays intact.
+ * ProseMirror's MutationObserver picks up the DOM change and converts it
+ * into the matching schema node.
+ */
+export function insertAutofillAtCursor(container: HTMLElement, fieldKey: string): boolean {
+  const sel = window.getSelection()
+  if (!sel || sel.rangeCount === 0) return false
+
+  const range = sel.getRangeAt(0)
+  if (!container.contains(range.commonAncestorContainer)) return false
+
+  const autofillEl = document.createElement('autofill-field')
+  autofillEl.setAttribute('data-value', fieldKey)
+  const spaceNode = document.createTextNode('\u00A0')
+
+  range.collapse(false)
+  range.insertNode(spaceNode)
+  range.insertNode(autofillEl)
+
+  // Move cursor after the inserted content
+  range.setStartAfter(spaceNode)
+  range.collapse(true)
+  sel.removeAllRanges()
+  sel.addRange(range)
+
+  return true
+}
+
+/**
+ * Return a new HTML string with an `<autofill-field>` tag appended at the end
+ * of the body content.
+ */
+export function insertAutofillIntoHtml(html: string, fieldKey: string): string {
+  const tag = `<autofill-field data-value="${fieldKey}"></autofill-field>`
+
+  if (!html || html === '<p></p>' || html.trim() === '') {
+    return `<p>${tag} </p>`
+  }
+
+  const lastPIndex = html.lastIndexOf('</p>')
+  if (lastPIndex !== -1) {
+    return html.slice(0, lastPIndex) + tag + ' ' + html.slice(lastPIndex)
+  }
+
+  return html + `<p>${tag} </p>`
+}


### PR DESCRIPTION
## Summary
- Clicking a dynamic field card in the template sidebar now inserts the field into the Tapwrite description editor
- If the description editor is focused, the field is inserted at the cursor position
- If nothing is focused, the field is appended at the end of the description body
- Added `mousedown` preventDefault on sidebar cards to preserve cursor position in the active editor

## Test plan
- [x] Open a template detail page
- [x] Click a dynamic field card when description is focused — verify field inserts at cursor
- [x] Click a dynamic field card when nothing is focused — verify field appends at end of description
- [x] Click a dynamic field card when title is focused — verify field still inserts in title at cursor
- [x] Verify the inserted field renders correctly and persists after save

🤖 Generated with [Claude Code](https://claude.com/claude-code)