### PR TITLE
OUT-3452: support dynamic field when task is created using templateId from public API

### DIFF
--- a/src/app/api/tasks/public/public.serializer.ts
+++ b/src/app/api/tasks/public/public.serializer.ts
@@ -10,6 +10,7 @@ import {
   AssociationsSchema,
 } from '@/types/dto/tasks.dto'
 import { rfc3339ToDateString, toRFC3339 } from '@/utils/dateHelper'
+import { resolveAutofillTags, resolveDynamicFields } from '@/utils/dynamicFields'
 import { sanitizeHtml } from '@/utils/santizeContents'
 import { copyTemplateMediaToTask } from '@/utils/signedTemplateUrlReplacer'
 import { replaceImageSrc } from '@/utils/signedUrlReplacer'
@@ -139,8 +140,8 @@ export class PublicTaskSerializer {
         body,
         workflowStateId,
       )
-      title = updated.title
-      body = updated.body
+      title = resolveDynamicFields(updated.title)
+      body = resolveAutofillTags(updated.body)
       workflowStateId = updated.workflowStateId
     }
 


### PR DESCRIPTION
## Changes

- [x] resolve dynamic tokens using existing `resolveDynamicFields` and `resolveAutofillTags` when deserializing payload

## Testing Criteria

[Loom](https://www.loom.com/share/fce96d5abaec44d19283f399aa59c00e)