### PR TITLE
Support drag and drop functionality for dynamic fields from template sidebar

### DIFF
--- a/src/app/manage-templates/ui/TemplateDetails.tsx
+++ b/src/app/manage-templates/ui/TemplateDetails.tsx
@@ -133,7 +133,8 @@ export default function TemplateDetails({
       e.stopPropagation()
 
       const range = document.caretRangeFromPoint(e.clientX, e.clientY)
-      if (!range || !el.contains(range.startContainer)) return
+      const proseMirrorEl = el.querySelector('.ProseMirror')
+      if (!range || !proseMirrorEl?.contains(range.startContainer)) return
 
       const autofillEl = document.createElement('autofill-field')
       autofillEl.setAttribute('data-value', fieldKey)

--- a/src/app/manage-templates/ui/TemplateDetails.tsx
+++ b/src/app/manage-templates/ui/TemplateDetails.tsx
@@ -97,40 +97,76 @@ export default function TemplateDetails({
   }
   const titleEditorRef = useRef<Editor | null>(null)
   const tapwriteEditorRef = useRef<HTMLDivElement>(null) as React.RefObject<HTMLDivElement>
+  const tapwriteWrapperRef = useRef<HTMLDivElement>(null)
+  const lastFocusedRef = useRef<'title' | 'description' | null>(null)
 
-  // Tapwrite's internal EditorContent wrapper has onFocus={() => editor.commands.focus("end")}
-  // which overrides ProseMirror's click-based cursor placement when the editor gains focus.
-  // Suppress that by stopping focusin propagation when focus was triggered by a mouse click.
   useEffect(() => {
-    const el = tapwriteEditorRef.current
+    const el = tapwriteWrapperRef.current
     if (!el) return
+
+    // Suppress Tapwrite's onFocus={() => editor.commands.focus("end")} which overrides
+    // cursor placement. Capture phase intercepts before React's event delegation.
     let mouseDownInside = false
     const onMouseDown = () => {
       mouseDownInside = true
+      requestAnimationFrame(() => {
+        mouseDownInside = false
+      })
     }
     const onFocusIn = (e: Event) => {
-      if (mouseDownInside) {
+      if (mouseDownInside || lastFocusedRef.current === 'description') {
         e.stopPropagation()
-        mouseDownInside = false
       }
     }
-    el.addEventListener('mousedown', onMouseDown)
-    el.addEventListener('focusin', onFocusIn)
+
+    // Handle dynamic field drops manually so ProseMirror doesn't create a NodeSelection.
+    const onDragOver = (e: DragEvent) => {
+      if (e.dataTransfer?.types.includes('application/x-dynamic-field')) {
+        e.preventDefault()
+        e.dataTransfer.dropEffect = 'copy'
+      }
+    }
+    const onDrop = (e: DragEvent) => {
+      const fieldKey = e.dataTransfer?.getData('application/x-dynamic-field')
+      if (!fieldKey) return
+      e.preventDefault()
+      e.stopPropagation()
+
+      const range = document.caretRangeFromPoint(e.clientX, e.clientY)
+      if (!range || !el.contains(range.startContainer)) return
+
+      const autofillEl = document.createElement('autofill-field')
+      autofillEl.setAttribute('data-value', fieldKey)
+      const spaceNode = document.createTextNode('\u00A0')
+      range.collapse(true)
+      range.insertNode(spaceNode)
+      range.insertNode(autofillEl)
+      range.setStartAfter(spaceNode)
+      range.collapse(true)
+      const sel = window.getSelection()
+      sel?.removeAllRanges()
+      sel?.addRange(range)
+    }
+
+    el.addEventListener('mousedown', onMouseDown, true)
+    el.addEventListener('focusin', onFocusIn, true)
+    el.addEventListener('dragover', onDragOver)
+    el.addEventListener('drop', onDrop, true)
     return () => {
-      el.removeEventListener('mousedown', onMouseDown)
-      el.removeEventListener('focusin', onFocusIn)
+      el.removeEventListener('mousedown', onMouseDown, true)
+      el.removeEventListener('focusin', onFocusIn, true)
+      el.removeEventListener('dragover', onDragOver)
+      el.removeEventListener('drop', onDrop, true)
     }
   }, [])
 
   const updateDetailRef = useRef(updateDetail)
   updateDetailRef.current = updateDetail
 
-  // Insert a dynamic field from the sidebar panel into the title or Tapwrite body.
-  // mousedown preventDefault on the sidebar card keeps the active editor focused.
   const handleSidebarFieldInsert = useCallback((fieldKey: string) => {
-    // 1. If title TipTap editor is focused, insert there at cursor
+    // 1. Title was last focused — TipTap's .focus() restores its stored cursor position
     const titleEditor = titleEditorRef.current
-    if (titleEditor?.isFocused) {
+    if (lastFocusedRef.current === 'title' && titleEditor) {
       titleEditor
         .chain()
         .focus()
@@ -142,13 +178,12 @@ export default function TemplateDetails({
       return
     }
 
-    // 2. If cursor is inside Tapwrite (still focused thanks to mousedown preventDefault),
-    //    insert at cursor position via DOM — ProseMirror's mutation observer will pick it up.
+    // 2. Description was last focused — insert at cursor via DOM
     if (tapwriteEditorRef.current && insertAutofillAtCursor(tapwriteEditorRef.current, fieldKey)) {
       return
     }
 
-    // 3. Nothing focused — insert at the end of the Description body
+    // 3. Both blurred — append to end of description
     const newBody = insertAutofillIntoHtml(updateDetailRef.current, fieldKey)
     setUpdateDetail(newBody)
     setIsUserTyping(true)
@@ -194,16 +229,22 @@ export default function TemplateDetails({
         onChange={handleTitleChange}
         onEditorReady={(editor) => {
           titleEditorRef.current = editor
+          editor.on('focus', () => {
+            lastFocusedRef.current = 'title'
+          })
         }}
         fontSize="20px"
         lineHeight="28px"
         fontWeight={500}
       />
 
-      <Box sx={{ height: '100%', width: '100%' }}>
+      <Box ref={tapwriteWrapperRef} sx={{ height: '100%', width: '100%' }}>
         <Tapwrite
           editorRef={tapwriteEditorRef}
           content={updateDetail}
+          onFocus={() => {
+            lastFocusedRef.current = 'description'
+          }}
           getContent={(content: string) => {
             if (updateDetail !== '') {
               handleDetailChange(content)

--- a/src/app/manage-templates/ui/TemplateDetails.tsx
+++ b/src/app/manage-templates/ui/TemplateDetails.tsx
@@ -136,6 +136,16 @@ export default function TemplateDetails({
       const proseMirrorEl = el.querySelector('.ProseMirror')
       if (!range || !proseMirrorEl?.contains(range.startContainer)) return
 
+      // If the caret landed inside a node-view, move insertion after the outermost node-view DOM element.
+      // Structure: <span class="node-*"> (dom) > <span data-node-view-wrapper> > content
+      // We must insert after the outer "dom" span so ProseMirror detects the mutation.
+      const caretNode = range.startContainer instanceof Element ? range.startContainer : range.startContainer.parentElement
+      const nodeViewWrapper = caretNode?.closest('[data-node-view-wrapper]')
+      if (nodeViewWrapper?.parentElement) {
+        range.setStartAfter(nodeViewWrapper.parentElement)
+        range.collapse(true)
+      }
+
       const autofillEl = document.createElement('autofill-field')
       autofillEl.setAttribute('data-value', fieldKey)
       const spaceNode = document.createTextNode('\u00A0')

--- a/src/app/manage-templates/ui/TemplateDetails.tsx
+++ b/src/app/manage-templates/ui/TemplateDetails.tsx
@@ -132,7 +132,17 @@ export default function TemplateDetails({
       e.preventDefault()
       e.stopPropagation()
 
-      const range = document.caretRangeFromPoint(e.clientX, e.clientY)
+      let range: Range | null = null
+      if (document.caretRangeFromPoint) {
+        range = document.caretRangeFromPoint(e.clientX, e.clientY)
+      } else if ((document as any).caretPositionFromPoint) {
+        const pos = (document as any).caretPositionFromPoint(e.clientX, e.clientY)
+        if (pos) {
+          range = document.createRange()
+          range.setStart(pos.offsetNode, pos.offset)
+          range.collapse(true)
+        }
+      }
       const proseMirrorEl = el.querySelector('.ProseMirror')
       if (!range || !proseMirrorEl?.contains(range.startContainer)) return
 

--- a/src/app/manage-templates/ui/TemplateSidebar.tsx
+++ b/src/app/manage-templates/ui/TemplateSidebar.tsx
@@ -188,6 +188,7 @@ export const TemplateSidebar = ({
                 key={field.key}
                 label={`{{${field.label}}}`}
                 preview={resolveDynamicField(field.key)}
+                fieldKey={field.key}
                 onClick={() => dynamicFieldInsertCtx?.insertField(field.key)}
               />
             ))}
@@ -198,9 +199,24 @@ export const TemplateSidebar = ({
   )
 }
 
-const DynamicFieldCard = ({ label, preview, onClick }: { label: string; preview: string; onClick: () => void }) => (
+const DynamicFieldCard = ({
+  label,
+  preview,
+  fieldKey,
+  onClick,
+}: {
+  label: string
+  preview: string
+  fieldKey: string
+  onClick: () => void
+}) => (
   <Box
-    onMouseDown={(e) => e.preventDefault()}
+    draggable
+    onDragStart={(e) => {
+      e.dataTransfer.setData('text/html', `<autofill-field data-value="${fieldKey}"></autofill-field>\u00A0`)
+      e.dataTransfer.setData('application/x-dynamic-field', fieldKey)
+      e.dataTransfer.effectAllowed = 'copy'
+    }}
     onClick={onClick}
     sx={{
       border: (theme) => `1px solid ${theme.color.borders.border}`,
@@ -209,10 +225,10 @@ const DynamicFieldCard = ({ label, preview, onClick }: { label: string; preview:
       '&:hover': {
         backgroundColor: (theme) => theme.color.gray[100],
       },
-      cursor: 'pointer',
-      // '&:active': {
-      //   cursor: 'grabbing',
-      // },
+      cursor: 'grab',
+      '&:active': {
+        cursor: 'grabbing',
+      },
     }}
   >
     <Typography

--- a/src/app/manage-templates/ui/TemplateSidebar.tsx
+++ b/src/app/manage-templates/ui/TemplateSidebar.tsx
@@ -225,10 +225,7 @@ const DynamicFieldCard = ({
       '&:hover': {
         backgroundColor: (theme) => theme.color.gray[100],
       },
-      cursor: 'grab',
-      '&:active': {
-        cursor: 'grabbing',
-      },
+      cursor: 'pointer',
     }}
   >
     <Typography

--- a/src/components/inputs/tiptap/useTitleEditor.ts
+++ b/src/components/inputs/tiptap/useTitleEditor.ts
@@ -9,6 +9,8 @@ import Paragraph from '@tiptap/extension-paragraph'
 import Placeholder from '@tiptap/extension-placeholder'
 import Text from '@tiptap/extension-text'
 import { Editor, useEditor } from '@tiptap/react'
+import { TextSelection } from '@tiptap/pm/state'
+import { Fragment } from '@tiptap/pm/model'
 import { AutofillExtension } from 'tapwrite'
 import { useEffect, useRef } from 'react'
 
@@ -83,6 +85,23 @@ export function useTitleEditor({ value, onChange, placeholder = '', autoFocus, o
           if (!dropdownOpen) return true
         }
         return false
+      },
+      handleDrop: (view, event) => {
+        const fieldKey = event.dataTransfer?.getData('application/x-dynamic-field')
+        if (!fieldKey) return false
+
+        event.preventDefault()
+        const pos = view.posAtCoords({ left: event.clientX, top: event.clientY })
+        if (!pos) return true
+
+        const { schema } = view.state
+        const node = schema.nodes.autofillField.create({ value: fieldKey })
+        const space = schema.text(' ')
+        const tr = view.state.tr.insert(pos.pos, Fragment.from([node, space]))
+        tr.setSelection(TextSelection.create(tr.doc, pos.pos + node.nodeSize + space.nodeSize))
+        view.dispatch(tr)
+        view.focus()
+        return true
       },
     },
   })


### PR DESCRIPTION
## Summary
- Add drag-and-drop support for sidebar dynamic field cards into both title and description editors
- Drop handling is done manually (intercepting ProseMirror's native drop) to prevent node highlight/selection after drop, placing cursor beside the inserted node
- Fix description editor cursor placement — clicks now land where clicked, not at end of line
- Preserve click-to-insert behavior using last-focused editor tracking (`lastFocusedRef`)

## Changes
- **TemplateSidebar.tsx**: Make `DynamicFieldCard` draggable with `onDragStart` setting `text/html` and custom MIME type
- **useTitleEditor.ts**: Add `handleDrop` in `editorProps` to intercept dynamic field drops, insert via ProseMirror transaction with `TextSelection` (no `NodeSelection`)
- **TemplateDetails.tsx**: Stable wrapper ref with capture-phase listeners for focus fix; manual drop handler using `caretRangeFromPoint` for description; `lastFocusedRef` to route click-to-insert to the correct editor after blur

## Test plan
- [x] Drag a dynamic field card from sidebar into description — field appears at drop point with cursor beside it
- [x] Drag a dynamic field card from sidebar into title — same behavior
- [x] Click a dynamic field card with cursor in title — field inserts at cursor position in title
- [x] Click a dynamic field card with cursor in description — field inserts at cursor position in description
- [x] Click a dynamic field card with both editors blurred — field appends to end of description
- [x] Click inside description editor — cursor lands where clicked (not at end of line)
- [x] Normal text editing in both editors still works as expected

## Testing Criteria 

- [LOOM](https://www.loom.com/share/0453792964d34e1aa1cecca25d5080c8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)