### PR TITLE
OUT-3477 | Truncate title on manage templates details page (app bridge)

### DIFF
--- a/src/app/manage-templates/[template_id]/page.tsx
+++ b/src/app/manage-templates/[template_id]/page.tsx
@@ -58,7 +58,7 @@ export default async function TaskDetailPage(props: {
   const breadcrumbItems: { label: string; href: string }[] = [
     { label: 'Manage templates', href: `/manage-templates?token=${token}` },
     ...breadcrumbTemplates.map((template) => ({
-      label: template.title,
+      label: template.title.length > 40 ? `${template.title.slice(0, 30)}...` : template.title,
       href: `/manage-templates/${template.id}?token=${token}`,
     })),
   ]


### PR DESCRIPTION
## Changes

- [x] truncated title on manage-templates/[id] route in app-bridge header breadcrumbs to max 40 char limit.

## Testing Criteria

<img width="943" height="541" alt="image" src="https://github.com/user-attachments/assets/47afb72f-ef41-47cf-ad4e-d9d2106ba5fc" />
