### PR TITLE
OUT-3478: support dynamic fields in sub-template creation and display

### DIFF
--- a/src/app/api/tasks/tasksShared.service.ts
+++ b/src/app/api/tasks/tasksShared.service.ts
@@ -10,6 +10,7 @@ import {
   AssociationsSchema,
 } from '@/types/dto/tasks.dto'
 import { getFileNameFromPath } from '@/utils/attachmentUtils'
+import { resolveDynamicFields, resolveAutofillTags } from '@/utils/dynamicFields'
 import { buildLtree, buildLtreeNodeString } from '@/utils/ltree'
 import { getFilePathFromUrl } from '@/utils/signedUrlReplacer'
 import { getSignedUrl } from '@/utils/signUrl'
@@ -511,8 +512,8 @@ export abstract class TasksSharedService extends BaseService {
 
     try {
       const createTaskPayload = CreateTaskRequestSchema.parse({
-        title,
-        body,
+        title: resolveDynamicFields(title),
+        body: body ? resolveAutofillTags(body) : body,
         workspaceId,
         workflowStateId,
         parentId,

--- a/src/app/manage-templates/ui/NewTemplateCard.tsx
+++ b/src/app/manage-templates/ui/NewTemplateCard.tsx
@@ -5,7 +5,7 @@ import { PrimaryBtn } from '@/components/buttons/PrimaryBtn'
 import { SecondaryBtn } from '@/components/buttons/SecondaryBtn'
 import { SelectorType } from '@/components/inputs/Selector'
 import { WorkflowStateSelector } from '@/components/inputs/Selector-WorkflowState'
-import { StyledTextField } from '@/components/inputs/TextField'
+import { TitleEditor } from '@/components/inputs/tiptap/TitleEditor'
 import { MAX_UPLOAD_LIMIT } from '@/constants/attachments'
 import { useHandleSelectorComponent } from '@/hooks/useHandleSelectorComponent'
 import { selectAuthDetails } from '@/redux/features/authDetailsSlice'
@@ -22,7 +22,7 @@ import {
   tapwriteDynamicFields,
 } from '@/components/inputs/TapwriteDynamicFieldDropdown'
 import { Box, Stack, Typography } from '@mui/material'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useSelector } from 'react-redux'
 import { Tapwrite } from 'tapwrite'
 
@@ -48,7 +48,6 @@ export const NewTemplateCard = ({
     description: '',
     workflowStateId: '',
   })
-  const inputRef = useRef<HTMLInputElement>(null)
   const [isUploading, setIsUploading] = useState(false)
 
   const clearSubTaskFields = () => {
@@ -119,41 +118,17 @@ export const NewTemplateCard = ({
         direction="column"
         sx={{ display: 'flex', padding: '0px 12px 12px', alignItems: 'center', gap: '4px', alignSelf: 'stretch' }}
       >
-        <Stack direction="row" sx={{ display: 'flex', alignItems: 'flex-end', gap: '4px', alignSelf: 'stretch' }}>
-          <StyledTextField
-            inputRef={inputRef}
-            type="text"
-            multiline
-            autoFocus={true}
-            borderLess
-            sx={{
-              width: '100%',
-              '& .MuiInputBase-input': {
-                fontSize: '16px',
-                lineHeight: '24px',
-                color: (theme) => theme.color.gray[600],
-                fontWeight: 500,
-              },
-              '& .MuiInputBase-input.Mui-disabled': {
-                WebkitTextFillColor: (theme) => theme.color.gray[600],
-              },
-              '& .MuiInputBase-root': {
-                padding: '0px 0px',
-              },
-            }}
-            placeholder="Task name"
+        <Box sx={{ padding: '0px', width: '100%' }}>
+          <TitleEditor
             value={subtemplateFields.title}
-            onChange={(event) => {
-              handleFieldChange('title', event.target.value)
-            }}
-            inputProps={{ maxLength: 255 }}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') {
-                e.preventDefault() //prevent users from breaking line
-              }
-            }}
+            onChange={(value) => handleFieldChange('title', value)}
+            placeholder="Task name"
+            autoFocus
+            fontSize="16px"
+            lineHeight="24px"
+            fontWeight={500}
           />
-        </Stack>
+        </Box>
         <Box sx={{ height: '100%', width: '100%' }}>
           <Tapwrite
             content={subtemplateFields.description}

--- a/src/app/manage-templates/ui/SubtemplatesList.tsx
+++ b/src/app/manage-templates/ui/SubtemplatesList.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import TaskTitle from '@/components/atoms/TaskTitle'
+import DynamicFieldTitle from '@/components/atoms/DynamicFieldTitle'
 import { SelectorType } from '@/components/inputs/Selector'
 import { WorkflowStateSelector } from '@/components/inputs/Selector-WorkflowState'
 import { CustomLink } from '@/hoc/CustomLink'
@@ -102,7 +102,7 @@ export const SubtemplatesList = ({ template, workflowState, isTemp }: Subtemplat
                 flexShrink: 1,
               }}
             >
-              <TaskTitle variant={'subtasks'} title={template.title} />
+              <DynamicFieldTitle title={template.title} variant="subtasks" />
             </Stack>
           </div>
         ) : (
@@ -127,7 +127,7 @@ export const SubtemplatesList = ({ template, workflowState, isTemp }: Subtemplat
                 flexShrink: 1,
               }}
             >
-              <TaskTitle variant={'subtasks'} title={template.title} />
+              <DynamicFieldTitle title={template.title} variant="subtasks" />
             </Stack>
           </CustomLink>
         )}

--- a/src/components/atoms/DynamicFieldTitle.tsx
+++ b/src/components/atoms/DynamicFieldTitle.tsx
@@ -1,0 +1,98 @@
+import { DYNAMIC_FIELDS } from '@/utils/dynamicFields'
+import { Typography, Box, SxProps, Theme } from '@mui/material'
+import React from 'react'
+
+type DynamicFieldTitleVariant = 'subtasks' | 'card'
+
+const variantStyles: Record<DynamicFieldTitleVariant, { typographyVariant: 'bodySm' | 'bodyMd'; sx: SxProps<Theme> }> = {
+  subtasks: {
+    typographyVariant: 'bodySm',
+    sx: {
+      lineHeight: '21px',
+      fontSize: '13px',
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap',
+      flexShrink: 1,
+      flexGrow: 0,
+      minWidth: 0,
+    },
+  },
+  card: {
+    typographyVariant: 'bodyMd',
+    sx: {
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap',
+    },
+  },
+}
+
+interface DynamicFieldTitleProps {
+  title: string
+  variant: DynamicFieldTitleVariant
+}
+
+/**
+ * Renders a title string with {{dynamic field}} tokens styled as inline chips,
+ * matching the TapwriteDynamicFieldTemplate styling.
+ */
+const DynamicFieldTitle = ({ title, variant }: DynamicFieldTitleProps) => {
+  const parts = parseDynamicFieldTokens(title)
+  const { typographyVariant, sx } = variantStyles[variant]
+
+  return (
+    <Typography component="span" variant={typographyVariant} sx={sx}>
+      {parts.map((part, index) =>
+        part.isDynamic ? (
+          <Box
+            key={index}
+            component="span"
+            sx={{
+              border: '1px solid #DFE1E4',
+              color: 'var(--text-secondary)',
+              borderRadius: '4px',
+              padding: '0 4px',
+              whiteSpace: 'nowrap',
+              fontSize: 'inherit',
+              lineHeight: 'inherit',
+            }}
+          >
+            {`{{${part.text}}}`}
+          </Box>
+        ) : (
+          <React.Fragment key={index}>{part.text}</React.Fragment>
+        ),
+      )}
+    </Typography>
+  )
+}
+
+function parseDynamicFieldTokens(text: string): { text: string; isDynamic: boolean }[] {
+  const parts: { text: string; isDynamic: boolean }[] = []
+  const regex = /\{\{([^}]+)\}\}/g
+  let lastIndex = 0
+  let match
+
+  while ((match = regex.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      parts.push({ text: text.slice(lastIndex, match.index), isDynamic: false })
+    }
+    const key = match[1]
+    const isDynamic = DYNAMIC_FIELDS.some((f) => f.key === key)
+    if (isDynamic) {
+      parts.push({ text: key, isDynamic: true })
+    } else {
+      parts.push({ text: match[0], isDynamic: false })
+    }
+    lastIndex = regex.lastIndex
+  }
+
+  if (lastIndex < text.length) {
+    parts.push({ text: text.slice(lastIndex), isDynamic: false })
+  }
+
+  return parts
+}
+
+export default DynamicFieldTitle


### PR DESCRIPTION
## Changes

- Replace plain text input with TitleEditor in NewTemplateCard so sub-template titles support dynamic field tokens ({{Current Month}}, etc.)
- Resolve dynamic field tokens in subtask titles and body when tasks are created from templates via the internal and public API (tasksShared.service.ts)
- Add DynamicFieldTitle component to render {{token}} patterns as styled inline chips in the sub-templates list on the template detail page

## Testing Criteria

[Loom UI](https://www.loom.com/share/fc11bf2eeb1849c5a6d5fe785f657bbf)

[Loom public api)(https://www.loom.com/share/7e7cec47b3a04cb1bb54ef6c2edb0a9c)