### PR TITLE
OUT-3457: enforce 255-char title limit for templates with dynamic fields

### DIFF
--- a/src/components/inputs/tiptap/TitleEditor.tsx
+++ b/src/components/inputs/tiptap/TitleEditor.tsx
@@ -4,8 +4,6 @@ import { useTitleEditor } from '@/components/inputs/tiptap/useTitleEditor'
 import { Box, styled } from '@mui/material'
 import { Editor, EditorContent } from '@tiptap/react'
 
-const TITLE_MAX_LENGTH = 255
-
 interface TitleEditorProps {
   value: string
   onChange: (plainText: string) => void
@@ -15,7 +13,6 @@ interface TitleEditorProps {
   lineHeight?: string
   fontWeight?: number
   onEditorReady?: (editor: Editor) => void
-  maxLength?: number
 }
 
 export const TitleEditor = ({
@@ -27,9 +24,8 @@ export const TitleEditor = ({
   lineHeight = '24px',
   fontWeight = 500,
   onEditorReady,
-  maxLength = TITLE_MAX_LENGTH,
 }: TitleEditorProps) => {
-  const editor = useTitleEditor({ value, onChange, placeholder, autoFocus, onEditorReady, maxLength })
+  const editor = useTitleEditor({ value, onChange, placeholder, autoFocus, onEditorReady })
 
   return (
     <StyledEditorWrapper

--- a/src/components/inputs/tiptap/TitleEditor.tsx
+++ b/src/components/inputs/tiptap/TitleEditor.tsx
@@ -4,6 +4,8 @@ import { useTitleEditor } from '@/components/inputs/tiptap/useTitleEditor'
 import { Box, styled } from '@mui/material'
 import { Editor, EditorContent } from '@tiptap/react'
 
+const TITLE_MAX_LENGTH = 255
+
 interface TitleEditorProps {
   value: string
   onChange: (plainText: string) => void
@@ -13,6 +15,7 @@ interface TitleEditorProps {
   lineHeight?: string
   fontWeight?: number
   onEditorReady?: (editor: Editor) => void
+  maxLength?: number
 }
 
 export const TitleEditor = ({
@@ -24,8 +27,9 @@ export const TitleEditor = ({
   lineHeight = '24px',
   fontWeight = 500,
   onEditorReady,
+  maxLength = TITLE_MAX_LENGTH,
 }: TitleEditorProps) => {
-  const editor = useTitleEditor({ value, onChange, placeholder, autoFocus, onEditorReady })
+  const editor = useTitleEditor({ value, onChange, placeholder, autoFocus, onEditorReady, maxLength })
 
   return (
     <StyledEditorWrapper

--- a/src/components/inputs/tiptap/useTitleEditor.ts
+++ b/src/components/inputs/tiptap/useTitleEditor.ts
@@ -3,14 +3,16 @@ import {
   TapwriteDynamicFieldTemplate,
   tapwriteDynamicFields,
 } from '@/components/inputs/TapwriteDynamicFieldDropdown'
+import { getWorstCaseResolvedLength } from '@/utils/dynamicFields'
 import Document from '@tiptap/extension-document'
 import History from '@tiptap/extension-history'
 import Paragraph from '@tiptap/extension-paragraph'
 import Placeholder from '@tiptap/extension-placeholder'
 import Text from '@tiptap/extension-text'
+import { Extension } from '@tiptap/core'
 import { Editor, useEditor } from '@tiptap/react'
-import { TextSelection } from '@tiptap/pm/state'
-import { Fragment } from '@tiptap/pm/model'
+import { Plugin, PluginKey, TextSelection } from '@tiptap/pm/state'
+import { Fragment, Node } from '@tiptap/pm/model'
 import { AutofillExtension } from 'tapwrite'
 import { useEffect, useRef } from 'react'
 
@@ -46,9 +48,47 @@ interface UseTitleEditorOptions {
   placeholder?: string
   autoFocus?: boolean
   onEditorReady?: (editor: Editor) => void
+  maxLength?: number
 }
 
-export function useTitleEditor({ value, onChange, placeholder = '', autoFocus, onEditorReady }: UseTitleEditorOptions) {
+function extractTextFromDoc(doc: Node): string {
+  let result = ''
+  doc.descendants((node) => {
+    if (node.type.name === 'autofillField' && node.attrs.value) {
+      result += `{{${node.attrs.value}}}`
+    } else if (node.isText) {
+      result += node.text ?? ''
+    }
+  })
+  return result
+}
+
+function createMaxLengthExtension(maxLength: number) {
+  return Extension.create({
+    name: 'maxLength',
+    addProseMirrorPlugins() {
+      return [
+        new Plugin({
+          key: new PluginKey('maxLength'),
+          filterTransaction(tr) {
+            if (!tr.docChanged) return true
+            const newText = extractTextFromDoc(tr.doc)
+            return newText.length <= maxLength && getWorstCaseResolvedLength(newText) <= maxLength
+          },
+        }),
+      ]
+    },
+  })
+}
+
+export function useTitleEditor({
+  value,
+  onChange,
+  placeholder = '',
+  autoFocus,
+  onEditorReady,
+  maxLength,
+}: UseTitleEditorOptions) {
   const isInternalRef = useRef(false)
 
   const editor = useEditor({
@@ -65,6 +105,7 @@ export function useTitleEditor({ value, onChange, placeholder = '', autoFocus, o
         CustomDropdown: TapwriteDynamicFieldDropdown,
         TemplateComponent: TapwriteDynamicFieldTemplate,
       }),
+      ...(maxLength !== undefined ? [createMaxLengthExtension(maxLength)] : []),
     ],
     content: plainTextToHtml(value),
     immediatelyRender: false,

--- a/src/components/inputs/tiptap/useTitleEditor.ts
+++ b/src/components/inputs/tiptap/useTitleEditor.ts
@@ -42,13 +42,14 @@ export function plainTextToHtml(text: string): string {
   return `<p>${html}</p>`
 }
 
+const TITLE_MAX_LENGTH = 255
+
 interface UseTitleEditorOptions {
   value: string
   onChange: (plainText: string) => void
   placeholder?: string
   autoFocus?: boolean
   onEditorReady?: (editor: Editor) => void
-  maxLength?: number
 }
 
 function extractTextFromDoc(doc: Node): string {
@@ -81,14 +82,7 @@ function createMaxLengthExtension(maxLength: number) {
   })
 }
 
-export function useTitleEditor({
-  value,
-  onChange,
-  placeholder = '',
-  autoFocus,
-  onEditorReady,
-  maxLength,
-}: UseTitleEditorOptions) {
+export function useTitleEditor({ value, onChange, placeholder = '', autoFocus, onEditorReady }: UseTitleEditorOptions) {
   const isInternalRef = useRef(false)
 
   const editor = useEditor({
@@ -105,7 +99,7 @@ export function useTitleEditor({
         CustomDropdown: TapwriteDynamicFieldDropdown,
         TemplateComponent: TapwriteDynamicFieldTemplate,
       }),
-      ...(maxLength !== undefined ? [createMaxLengthExtension(maxLength)] : []),
+      createMaxLengthExtension(TITLE_MAX_LENGTH),
     ],
     content: plainTextToHtml(value),
     immediatelyRender: false,

--- a/src/utils/dynamicFields.ts
+++ b/src/utils/dynamicFields.ts
@@ -37,6 +37,29 @@ export function resolveDynamicField(key: DynamicFieldKey, now: dayjs.Dayjs = day
   }
 }
 
+// Maximum possible resolved length for each dynamic field.
+// Used to compute worst-case task title length when tokens are present.
+// "Week of September 30, 2026" is the longest possible resolution for CurrentWeek (26 chars).
+const DYNAMIC_FIELD_MAX_RESOLVED_LENGTHS: Record<DynamicFieldKey, number> = {
+  [DynamicFieldKey.CurrentWeek]: 26,
+  [DynamicFieldKey.CurrentMonth]: 9, // "September"
+  [DynamicFieldKey.CurrentQuarter]: 2, // "Q4"
+  [DynamicFieldKey.CurrentYear]: 4, // "2026"
+}
+
+/**
+ * Returns the worst-case resolved length of a template title string.
+ * Each {{token}} is replaced by its maximum possible resolved value so the result
+ * represents the longest task title that could be generated from this template.
+ */
+export function getWorstCaseResolvedLength(text: string): number {
+  return text.replace(/\{\{([^}]+)\}\}/g, (match, key) => {
+    const field = DYNAMIC_FIELDS.find((f) => f.key === key)
+    if (!field) return match
+    return 'x'.repeat(DYNAMIC_FIELD_MAX_RESOLVED_LENGTHS[field.key])
+  }).length
+}
+
 /**
  * Resolves all dynamic field tokens in a string.
  * Tokens are in the format {{fieldKey}}, e.g. {{Current Month}}, {{Current Year}}


### PR DESCRIPTION
## Summary

- Add `getWorstCaseResolvedLength()` to dynamicFields.ts — replaces each {{token}} with its maximum possible resolved value (e.g. {{Current Week}} → "Week of September 30, 2026" = 26 chars) to compute the longest task title that could be generated from a template
- Add `createMaxLengthExtension()` — a ProseMirror plugin via TipTap's `addProseMirrorPlugins()` that runs `filterTransaction` to silently block any change that would violate either limit:
    1. Raw stored length > 255 (template VARCHAR(255) column)
    2. Worst-case resolved length > 255 (task VARCHAR(255) column)
- Wire `maxLength` prop through TitleEditor → useTitleEditor, defaulting to 255 so all template title editors are protected automatically

## Testing Criteria

[Loom](https://www.loom.com/share/8e1cdd26b2d84f108a849e30090a2380)

### Notes

There are mainly two constraints/ validation in frontend:

- newText.length > 255 — prevents the stored template title from exceeding the VARCHAR(255) DB column                                                                                                        
- getWorstCaseResolvedLength(newText) > 255 — prevents the resolved task title from exceeding the task VARCHAR(255) DB column