### PR TITLE
OUT-3480: prevent layout shift when inserting dynamic field in template title

### DIFF
--- a/src/components/inputs/tiptap/TitleEditor.tsx
+++ b/src/components/inputs/tiptap/TitleEditor.tsx
@@ -57,4 +57,12 @@ const StyledEditorWrapper = styled(Box)(({ theme }) => ({
     float: 'left',
     height: 0,
   },
+  // The chip border (1px top + 1px bottom) makes the inline-flex node view taller than
+  // the paragraph line-height, expanding the line box. Swapping to outline within this
+  // context fixes it — outline is cosmetically identical but has no effect on layout.
+  '& .tiptap-title-editor [data-node-view-wrapper] > span': {
+    border: 'none !important',
+    outline: '1px solid #DFE1E4',
+    outlineOffset: '-1px', // This pulls the outline inward so it sits exactly where the border was
+  },
 }))


### PR DESCRIPTION
## Summary

- The autofill chip renders inside an inline-flex node view. Its border (1px top + 1px bottom) causes the flex item's box to exceed the paragraph line-height, expanding the line box by 2px on every chip insertion.

- Replace the chip's border with an outline scoped to the title editor context. Outline is cosmetically identical (same color, follows border-radius in modern browsers) but has no effect on layout, eliminating the shift without changing the chip's size or padding.

## Testing Criteria

[Loom](https://www.loom.com/share/917b654d357c497daaab95accc048ca6)
