### PR TITLE
OUT-2668, OUT-3181 | Show subtasks IU is assigned to in "My Tasks"

### DIFF
--- a/src/app/ui/TaskBoard.tsx
+++ b/src/app/ui/TaskBoard.tsx
@@ -106,6 +106,8 @@ export const TaskBoard = ({ mode, workspace, token }: TaskBoardProps) => {
 
     accessibleTasks.forEach((item) => {
       if (!item.parentId) return
+      if (item.isArchived && !showArchived) return
+      if (!item.isArchived && !showUnarchived) return
       if (!grouped[item.parentId]) grouped[item.parentId] = []
       grouped[item.parentId].push(item)
     })
@@ -115,7 +117,7 @@ export const TaskBoard = ({ mode, workspace, token }: TaskBoardProps) => {
     })
 
     return grouped
-  }, [accessibleTasks, showSubtasks])
+  }, [accessibleTasks, showSubtasks, showArchived, showUnarchived])
 
   if (!hasInitialized) {
     return <TaskDataFetcher token={token} />

--- a/src/hooks/useFilter.tsx
+++ b/src/hooks/useFilter.tsx
@@ -149,31 +149,49 @@ export const useFilter = (filterOptions: IFilterOptions, isPreviewMode: boolean)
   const { tasks, accessibleTasks, assignee } = useSelector(selectTaskBoard)
   const [_, startTransition] = useTransition()
 
-  function applyFilter(tasks: TaskResponse[], filterOptions: IFilterOptions) {
+  function applyFilters(tasks: TaskResponse[], filterOptions: IFilterOptions) {
     let filteredTasks = [...tasks]
     for (const [filterType, filterValue] of Object.entries(filterOptions)) {
       if (!filterValue) continue
-      if (filterType === FilterOptions.ASSIGNEE && !isPreviewMode) {
-        // there is no filter by assignee in preview mode
-        const assigneeFilterValue = UserIdsSchema.parse(filterValue)
-        filteredTasks = FilterFunctions[FilterOptions.ASSIGNEE](filteredTasks, assigneeFilterValue)
-      }
-      if (filterType === FilterOptions.CREATOR || filterType === FilterOptions.ASSOCIATION) {
-        const assigneeFilterValue = UserIdsSchema.parse(filterValue)
-        filteredTasks = FilterFunctions[filterType](filteredTasks, assigneeFilterValue)
-      }
-      if (filterType === FilterOptions.KEYWORD) {
-        filteredTasks = FilterFunctions[FilterOptions.KEYWORD](
-          filteredTasks,
-          filterValue as string,
-          accessibleTasks,
-          assignee,
-        )
-      }
-      if (filterType === FilterOptions.TYPE) {
-        filteredTasks = FilterFunctions[FilterOptions.TYPE](filteredTasks, filterValue as string)
-      }
+      filteredTasks = applyOneFilter(filteredTasks, filterType, filterValue)
     }
+    return filteredTasks
+  }
+
+  function applyOneFilter(tasks: TaskResponse[], filterType: string, filterValue: unknown): TaskResponse[] {
+    if (filterType === FilterOptions.ASSIGNEE && !isPreviewMode) {
+      const assigneeFilterValue = UserIdsSchema.parse(filterValue)
+      return FilterFunctions[FilterOptions.ASSIGNEE](tasks, assigneeFilterValue)
+    }
+    if (filterType === FilterOptions.CREATOR || filterType === FilterOptions.ASSOCIATION) {
+      const assigneeFilterValue = UserIdsSchema.parse(filterValue)
+      return FilterFunctions[filterType](tasks, assigneeFilterValue)
+    }
+    if (filterType === FilterOptions.KEYWORD) {
+      return FilterFunctions[FilterOptions.KEYWORD](tasks, filterValue as string, accessibleTasks, assignee)
+    }
+    if (filterType === FilterOptions.TYPE) {
+      return FilterFunctions[FilterOptions.TYPE](tasks, filterValue as string)
+    }
+    return tasks
+  }
+
+  function applyFilter(tasks: TaskResponse[], filterOptions: IFilterOptions) {
+    const filteredParentTasks = applyFilters(tasks, filterOptions)
+    const filteredParentIds = new Set(filteredParentTasks.map((t) => t.id))
+
+    // Find subtasks that match all filters but whose parent didn't
+    const hasActiveFilter = Object.values(filterOptions).some((v) => !!v)
+    let standaloneSubtasks: TaskResponse[] = []
+
+    if (hasActiveFilter) {
+      const subtasks = accessibleTasks.filter((t) => !!t.parentId)
+      const matchingSubtasks = applyFilters(subtasks, filterOptions)
+      standaloneSubtasks = matchingSubtasks.filter((t) => !filteredParentIds.has(t.parentId!))
+    }
+
+    const filteredTasks = [...filteredParentTasks, ...standaloneSubtasks]
+
     startTransition(() => {
       store.dispatch(setFilteredTasks(filteredTasks))
     })
@@ -181,7 +199,7 @@ export const useFilter = (filterOptions: IFilterOptions, isPreviewMode: boolean)
 
   useEffect(() => {
     applyFilter(tasks, filterOptions)
-  }, [tasks, filterOptions])
+  }, [tasks, accessibleTasks, filterOptions])
 
   useEffect(() => {
     if (assignee?.length) {

--- a/src/hooks/useFilter.tsx
+++ b/src/hooks/useFilter.tsx
@@ -146,7 +146,7 @@ function filterByType(filteredTasks: TaskResponse[], filterValue: string): TaskR
 }
 
 export const useFilter = (filterOptions: IFilterOptions, isPreviewMode: boolean) => {
-  const { tasks, accessibleTasks, assignee } = useSelector(selectTaskBoard)
+  const { tasks, accessibleTasks, assignee, showArchived, showUnarchived } = useSelector(selectTaskBoard)
   const [_, startTransition] = useTransition()
 
   function applyFilters(tasks: TaskResponse[], filterOptions: IFilterOptions) {
@@ -185,7 +185,7 @@ export const useFilter = (filterOptions: IFilterOptions, isPreviewMode: boolean)
     let standaloneSubtasks: TaskResponse[] = []
 
     if (hasActiveFilter) {
-      const subtasks = accessibleTasks.filter((t) => !!t.parentId)
+      const subtasks = accessibleTasks.filter((t) => !!t.parentId && (t.isArchived ? showArchived : showUnarchived))
       const matchingSubtasks = applyFilters(subtasks, filterOptions)
       standaloneSubtasks = matchingSubtasks.filter((t) => !filteredParentIds.has(t.parentId!))
     }


### PR DESCRIPTION
## Summary
- Subtasks now appear as standalone items in filtered views (e.g. "My Tasks") when they match the active filter but their parent task does not
- Refactored `useFilter` hook to reuse filter logic across both parent tasks and subtasks via `applyFilters`/`applyOneFilter` helpers
- Added `accessibleTasks` to the `useEffect` dependency array so realtime subtask changes trigger re-filtering
- Rendered subtasks on task board according to its archived, unarchived states. 

## Test plan
- [x] Apply "My Tasks" filter → verify subtasks assigned to you appear standalone when their parent is assigned to someone else
- [x] Apply other filters (assignee, creator, association, type, keyword) → verify subtasks are promoted to standalone when matching
- [x] Verify parent tasks with matching subtasks still show those subtasks nested (not duplicated as standalone)
- [x] Verify realtime: another user assigns a subtask to you → it appears in your "My Tasks" view without refresh
- [x] Verify no filter active → board behaves as before (no standalone subtasks injected)


## Testing Criteria 

- [LOOM](https://www.loom.com/share/d3b9a501c7df43789599546c7cdfb388?focus_title=1&muted=1&from_recorder=1)

- OUT-3181 : [LOOM](https://www.loom.com/share/bdee8a617a0b45d7ae6c08b38ed1405f)

🤖 Generated with [Claude Code](https://claude.com/claude-code)