### PR TITLE
OUT-3200 | Improve experience when no templates exist while creating a task

### DIFF
--- a/src/components/inputs/Selector.tsx
+++ b/src/components/inputs/Selector.tsx
@@ -448,7 +448,7 @@ export default function Selector<T extends keyof SelectorOptionsType>({
 
             return <></>
           }}
-          noOptionsText={endOption && <ListWithEndOption />}
+          noOptionsText={endOption && <ListWithEndOption endOption={endOption} endOptionHref={endOptionHref} />}
         />
       </Popper>
     </Stack>


### PR DESCRIPTION
## Summary
- Fix "Manage templates" button not appearing in the template selector dropdown when no templates exist
- Pass `endOption` and `endOptionHref` props to `ListWithEndOption` in the `noOptionsText` render so the navigation button is visible even with an empty template list

## Test plan
- [x] Open new task form or new task card with no templates in the store
- [x] Click the template selector dropdown
- [x] Verify the "Manage templates" button is visible and navigates to the templates page
- [x] Verify the button still appears correctly when templates do exist

## Testing Criteria 

<img width="623" height="234" alt="image" src="https://github.com/user-attachments/assets/319c0977-f120-4917-bb31-c451ddf8f6d7" />
<img width="572" height="212" alt="image" src="https://github.com/user-attachments/assets/a459af25-acd3-4b5c-88b6-367e0bbf660c" />
<img width="631" height="202" alt="image" src="https://github.com/user-attachments/assets/056b88db-0daf-4475-b045-a2b6e49c4596" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)