### PR TITLE
OUT-3175 | Unable to Add Due Date to Task on iPhone Mobile Web App

### DIFF
--- a/src/app/ui/NewTaskForm.tsx
+++ b/src/app/ui/NewTaskForm.tsx
@@ -336,7 +336,7 @@ export const NewTaskForm = ({ handleCreate, handleClose }: NewTaskFormProps) => 
                   textOverflow: 'ellipsis',
                   whiteSpace: 'nowrap',
                   overflow: 'hidden',
-                  maxWidth: { xs: '102px', sm: 'none' },
+                  maxWidth: { xs: '150px', sm: 'none' },
                 }}
               >
                 <DatePickerComponent

--- a/src/hooks/useClickOutside.ts
+++ b/src/hooks/useClickOutside.ts
@@ -30,8 +30,10 @@ export default function useClickOutside<T extends HTMLElement>(
     const listener = (event: Event) => {
       const path = getEventPath(event)
 
-      if (path.some((el) => (el as HTMLElement)?.classList?.contains('MuiPickersPopper-root'))) {
-        return // don't close if the element has MUI classes. This prevent popper to not close when clicking on the date picker
+      if (
+        (event.target as HTMLElement)?.closest?.('.MuiPickersPopper-root, .MuiPickersLayout-root, .MuiDateCalendar-root')
+      ) {
+        return // don't close if the click is inside the MUI date picker (covers both desktop popper and mobile dialog)
       }
 
       for (const r of refArray) {


### PR DESCRIPTION
## Changes

- [x] useClickOutside component : The old check used composedPath() to look for MuiPickersPopper-root — this only matches the desktop variant. On mobile, MUI renders the calendar inside a Dialog, not a Popper, so the class never matched.

  The new check uses .closest() on event.target and looks for:
  - .MuiPickersPopper-root — desktop popup
  - .MuiPickersLayout-root — the picker layout (present in both desktop and mobile)
  - .MuiDateCalendar-root — the calendar itself (present in both)
  
- [x] maxWidth constraint on new task form due date button fixed. 

## Testing Criteria

- [LOOM](https://www.loom.com/share/5f3eefda622e4d84bde6d09973cd6249)
