### PR TITLE
OUT-3501: fix deleted parent comment avatar size mismatch

### DIFF
--- a/src/app/detail/ui/Comments.tsx
+++ b/src/app/detail/ui/Comments.tsx
@@ -1,6 +1,5 @@
 import { CopilotAvatar } from '@/components/atoms/CopilotAvatar'
 import { CommentCard } from '@/components/cards/CommentCard'
-import { TrashIcon2 } from '@/icons'
 import { selectTaskBoard } from '@/redux/features/taskBoardSlice'
 import { CreateComment } from '@/types/dto/comment.dto'
 import { OptimisticUpdate } from '@/utils/optimisticCommentUtils'
@@ -8,6 +7,7 @@ import { LogResponse } from '@api/activity-logs/schemas/LogResponseSchema'
 import { Stack } from '@mui/material'
 import { useSelector } from 'react-redux'
 import { VerticalLine } from './styledComponent'
+import { Icon } from 'copilot-design-system'
 
 interface Prop {
   token: string
@@ -32,7 +32,7 @@ export const Comments = ({ token, comment, createComment, deleteComment, task_id
           style={{
             marginTop: '8px',
           }}
-          icon={comment.details.deletedAt ? <TrashIcon2 /> : undefined}
+          icon={comment.details.deletedAt ? <Icon icon="Trash" width={10} height={10} /> : undefined}
         />
 
         <CommentCard

--- a/src/components/atoms/CopilotAvatar.tsx
+++ b/src/components/atoms/CopilotAvatar.tsx
@@ -33,8 +33,14 @@ export const CopilotAvatar = ({ currentAssignee, alt, size = 'sm', icon, classNa
   }, [currentAssignee?.name, currentAssignee?.familyName, currentAssignee?.givenName])
 
   if (icon) {
+    const sizeMap: Record<string, number> = { '3xs': 12, '2xs': 16, xs: 20 }
+    const dimension = sizeMap[size]
     return (
-      <Avatar sx={avatarSx} variant={avatarVariant}>
+      <Avatar
+        sx={{ ...avatarSx, ...(dimension ? { width: dimension, height: dimension } : {}) }}
+        variant={avatarVariant}
+        style={style}
+      >
         {icon}
       </Avatar>
     )


### PR DESCRIPTION
## Changes

The CopilotAvatar icon branch rendered a default MUI Avatar (40x40px) while normal comment avatars use AssemblyAvatar xs size (20x20px). This caused deleted parent comments to appear out of place. Map the size prop to correct pixel dimensions for the icon avatar variant.

## Testing Criteria

<img width="734" height="463" alt="image" src="https://github.com/user-attachments/assets/71f1f652-7920-4ec1-8a47-8fa3e4c68675" />

