### PR TITLE
fix (POR-19165): remove unintended left border from FilterBar

### DIFF
--- a/src/components/layouts/FilterBar.tsx
+++ b/src/components/layouts/FilterBar.tsx
@@ -81,8 +81,7 @@ export const FilterBar = ({ mode }: FilterBarProps) => {
         previewMode
           ? { borderBottom: (theme) => `1px solid ${theme.color.borders.borderDisabled}` }
           : {
-              border: (theme) => `1px solid ${theme.color.borders.borderDisabled}`,
-              borderTop: 'none',
+              borderBottom: (theme) => `1px solid ${theme.color.borders.borderDisabled}`,
             }
       }
     >


### PR DESCRIPTION
## Summary
- Removed unintended left border from the FilterBar component
- The FilterBar was using border (all sides) with borderTop: 'none' instead of just borderBottom, which caused a visible left border on the Tasks page
- Changed to borderBottom only, matching the existing previewMode style

## Test plan
- [ ] Verify the left-side border is no longer visible on the Tasks page
- [ ] Verify the bottom border divider is still present under the filter bar
- [ ] Check both list and board views

Before:
<img width="2662" height="552" alt="image" src="https://github.com/user-attachments/assets/d6d63a49-7352-4dbb-b6a0-7438da7324ef" />

After:
<img width="2540" height="224" alt="Screenshot 2026-04-03 at 8 54 30 PM" src="https://github.com/user-attachments/assets/70596030-a38e-4028-a5c8-70bda2a7e07d" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)