### PR TITLE
fix(OUT-3188): better Escape logic for back navigation

### DIFF
--- a/src/hooks/app-bridge/useActionsMenu.tsx
+++ b/src/hooks/app-bridge/useActionsMenu.tsx
@@ -36,6 +36,7 @@ export function useActionsMenu(actions: Clickable[], config?: Configurable) {
         callbackRefs[event.data.id]
       ) {
         callbackRefs[event.data.id]()
+        window.focus() // Reclaim focus from parent so keyboard events (e.g. Escape) fire in the iframe
       }
     }
 

--- a/src/hooks/app-bridge/useBreadcrumbs.tsx
+++ b/src/hooks/app-bridge/useBreadcrumbs.tsx
@@ -35,6 +35,7 @@ export const useBreadcrumbs = (breadcrumbs: Clickable[], config?: Configurable) 
         callbackRefs[event.data.id]
       ) {
         callbackRefs[event.data.id]()
+        window.focus() // Reclaim focus from parent so keyboard events (e.g. Escape) fire in the iframe
       }
     }
 

--- a/src/hooks/app-bridge/usePrimaryCta.tsx
+++ b/src/hooks/app-bridge/usePrimaryCta.tsx
@@ -23,6 +23,7 @@ export const usePrimaryCta = (primaryCta: Clickable | null, config?: Configurabl
     const handleMessage = (event: MessageEvent) => {
       if (event.data.type === 'header.primaryCta.onClick' && typeof event.data.id === 'string' && primaryCta?.onClick) {
         primaryCta.onClick()
+        window.focus() // Reclaim focus from parent so keyboard events (e.g. Escape) fire in the iframe
       }
     }
 

--- a/src/hooks/app-bridge/useSecondaryCta.tsx
+++ b/src/hooks/app-bridge/useSecondaryCta.tsx
@@ -23,6 +23,7 @@ export const useSecondaryCta = (secondaryCta: Clickable | null, config?: Configu
     const handleMessage = (event: MessageEvent) => {
       if (event.data.type === 'header.secondaryCta.onClick' && typeof event.data.id === 'string' && secondaryCta?.onClick) {
         secondaryCta.onClick()
+        window.focus() // Reclaim focus from parent so keyboard events (e.g. Escape) fire in the iframe
       }
     }
 

--- a/src/utils/escapeHandler.ts
+++ b/src/utils/escapeHandler.ts
@@ -1,49 +1,20 @@
 'use client'
 
-import { selectTaskBoard } from '@/redux/features/taskBoardSlice'
-import { selectTaskDetails } from '@/redux/features/taskDetailsSlice'
 import { useEffect } from 'react'
-import { useSelector } from 'react-redux'
-import { usePathname, useRouter } from 'next/navigation'
+import { useRouter } from 'next/navigation'
 
 const EscapeHandler = () => {
   const router = useRouter()
-  const pathname = usePathname()
-  const { activeTask, accessibleTasks, token } = useSelector(selectTaskBoard)
-  const { fromNotificationCenter } = useSelector(selectTaskDetails)
 
   useEffect(() => {
     const handleEsc = (event: KeyboardEvent) => {
-      if (event.key !== 'Escape') return
-
       if (document.querySelector('.tippy-box')) {
         return
       }
 
-      // Don't navigate when embedded in notification center view
-      if (fromNotificationCenter) return
-
-      // Task detail page: navigate to parent task or board
-      if (pathname.includes('/detail/')) {
-        const isClientUser = pathname.includes('/cu')
-        const isAccessibleSubtask = activeTask?.parentId && accessibleTasks.some((task) => task.id === activeTask.parentId)
-
-        if (isClientUser) {
-          router.push(isAccessibleSubtask ? `/detail/${activeTask.parentId}/cu?token=${token}` : `/client?token=${token}`)
-        } else {
-          router.push(isAccessibleSubtask ? `/detail/${activeTask.parentId}/iu/?token=${token}` : `/?token=${token}`)
-        }
-        return
+      if (event.key === 'Escape') {
+        router.back()
       }
-
-      // Template detail page: navigate back to templates list
-      if (pathname.includes('/manage-templates/')) {
-        router.push(`/manage-templates?token=${token}`)
-        return
-      }
-
-      // Fallback for any other page
-      router.back()
     }
 
     window.addEventListener('keydown', handleEsc)
@@ -51,7 +22,7 @@ const EscapeHandler = () => {
     return () => {
       window.removeEventListener('keydown', handleEsc)
     }
-  }, [router, pathname, activeTask, accessibleTasks, token, fromNotificationCenter])
+  }, [router])
 
   return null
 }

--- a/src/utils/escapeHandler.ts
+++ b/src/utils/escapeHandler.ts
@@ -1,20 +1,49 @@
 'use client'
 
+import { selectTaskBoard } from '@/redux/features/taskBoardSlice'
+import { selectTaskDetails } from '@/redux/features/taskDetailsSlice'
 import { useEffect } from 'react'
-import { useRouter } from 'next/navigation'
+import { useSelector } from 'react-redux'
+import { usePathname, useRouter } from 'next/navigation'
 
 const EscapeHandler = () => {
   const router = useRouter()
+  const pathname = usePathname()
+  const { activeTask, accessibleTasks, token } = useSelector(selectTaskBoard)
+  const { fromNotificationCenter } = useSelector(selectTaskDetails)
 
   useEffect(() => {
     const handleEsc = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return
+
       if (document.querySelector('.tippy-box')) {
         return
       }
 
-      if (event.key === 'Escape') {
-        router.back()
+      // Don't navigate when embedded in notification center view
+      if (fromNotificationCenter) return
+
+      // Task detail page: navigate to parent task or board
+      if (pathname.includes('/detail/')) {
+        const isClientUser = pathname.includes('/cu')
+        const isAccessibleSubtask = activeTask?.parentId && accessibleTasks.some((task) => task.id === activeTask.parentId)
+
+        if (isClientUser) {
+          router.push(isAccessibleSubtask ? `/detail/${activeTask.parentId}/cu?token=${token}` : `/client?token=${token}`)
+        } else {
+          router.push(isAccessibleSubtask ? `/detail/${activeTask.parentId}/iu/?token=${token}` : `/?token=${token}`)
+        }
+        return
       }
+
+      // Template detail page: navigate back to templates list
+      if (pathname.includes('/manage-templates/')) {
+        router.push(`/manage-templates?token=${token}`)
+        return
+      }
+
+      // Fallback for any other page
+      router.back()
     }
 
     window.addEventListener('keydown', handleEsc)
@@ -22,7 +51,7 @@ const EscapeHandler = () => {
     return () => {
       window.removeEventListener('keydown', handleEsc)
     }
-  }, [router])
+  }, [router, pathname, activeTask, accessibleTasks, token, fromNotificationCenter])
 
   return null
 }


### PR DESCRIPTION
## Summary

**Root cause**: In the iframe context, `router.back()` / `history.back()` is unreliable — if the dashboard loaded the iframe directly at the detail URL (or after certain interactions), there is no previous history entry, and `back()` navigates to an unexpected state causing the parent dashboard to show the home page.

**Fixes:**

- **Replaced `router.back()` with deterministic `router.push()` in `EscapeHandler`** — Escape now navigates to the parent task (for subtasks) or the board page based on current route context, instead of relying on browser history.
- **Added `window.focus()` after app bridge callbacks** — After the parent dashboard's menu actions (Archive, Delete, etc.) execute via postMessage, focus is reclaimed to the iframe so subsequent keyboard events fire in the correct context.

Resolves [OUT-3188](https://linear.app/assemblycom/issue/OUT-3188)

## Changes

| File | Change |
|------|--------|
| `src/utils/escapeHandler.ts` | Replace `router.back()` with `router.push()` to board/parent task based on route context |
| `src/hooks/app-bridge/useActionsMenu.tsx` | `window.focus()` after callback |
| `src/hooks/app-bridge/usePrimaryCta.tsx` | `window.focus()` after callback |
| `src/hooks/app-bridge/useSecondaryCta.tsx` | `window.focus()` after callback |
| `src/hooks/app-bridge/useBreadcrumbs.tsx` | `window.focus()` after callback |

## Test plan

- [ ] Open a task from the board → press Escape → navigates back to board
- [ ] Open a task → archive it → press Escape → navigates back to board (not dashboard home)
- [ ] Click outside the iframe → press Escape → navigates correctly within iframe
- [ ] Open a subtask → press Escape → navigates to parent task detail
- [ ] Open a template detail → press Escape → navigates to manage-templates list
- [ ] Open a task via notification center → press Escape → no navigation
- [ ] Click "..." menu → Archive task → press Escape → navigates back within iframe
- [ ] Test in both internal (IU) and client (CU) experiences

🤖 Generated with [Claude Code](https://claude.com/claude-code)