### PR TITLE
OUT-3495: Inherit parent fields for new subtasks

### DIFF
--- a/src/app/detail/ui/NewTaskCard.tsx
+++ b/src/app/detail/ui/NewTaskCard.tsx
@@ -29,6 +29,8 @@ import {
   getSelectedUserIds,
   getSelectedViewerIds,
   getSelectorAssignee,
+  getSelectorAssigneeFromTask,
+  getSelectorAssociationFromTask,
   getSelectorAssigneeFromFilterOptions,
 } from '@/utils/selector'
 import { resolveAutofillTags, resolveDynamicFields } from '@/utils/dynamicFields'
@@ -74,13 +76,25 @@ export const NewTaskCard = ({
         [UserIds.COMPANY_ID]: null,
       }
 
+  const inheritedWorkflowState = workflowStates.find((state) => state.id === activeTask?.workflowStateId)
+  const defaultWorkflowState = inheritedWorkflowState || workflowStates.find((el) => el.key === 'todo') || workflowStates[0]
+  const inheritedAssigneeIds: UserIdsType = previewMode
+    ? assigneeIds
+    : {
+        [UserIds.INTERNAL_USER_ID]: activeTask?.internalUserId || null,
+        [UserIds.CLIENT_ID]: activeTask?.clientId || null,
+        [UserIds.COMPANY_ID]: activeTask?.companyId || null,
+      }
+
   const { tokenPayload, workspace } = useSelector(selectAuthDetails)
   const [subTaskFields, setSubTaskFields] = useState<SubTaskFields>({
     title: '',
     description: '',
-    workflowStateId: '',
-    userIds: assigneeIds,
+    workflowStateId: defaultWorkflowState?.id || '',
+    userIds: inheritedAssigneeIds,
     dueDate: null,
+    associations: !previewMode ? activeTask?.associations || [] : undefined,
+    isShared: !previewMode ? !!activeTask?.isShared : undefined,
   })
 
   const inputRef = useRef<HTMLInputElement>(null)
@@ -119,12 +133,8 @@ export const NewTaskCard = ({
 
   const todoWorkflowState = workflowStates.find((el) => el.key === 'todo') || workflowStates[0]
 
-  useEffect(() => {
-    handleFieldChange('workflowStateId', todoWorkflowState.id)
-  }, [todoWorkflowState])
-
   const { renderingItem: _statusValue, updateRenderingItem: updateStatusValue } = useHandleSelectorComponent({
-    item: todoWorkflowState,
+    item: defaultWorkflowState,
     type: SelectorType.STATUS_SELECTOR,
   })
 
@@ -145,7 +155,9 @@ export const NewTaskCard = ({
   const [assigneeValue, setAssigneeValue] = useState<IAssigneeCombined | null>(
     previewMode
       ? (getSelectorAssigneeFromFilterOptions(assignee, { internalUserId: null, ...previewClientCompany }) ?? null) // if preview mode, default select the respective client/company as assignee
-      : null,
+      : activeTask
+        ? (getSelectorAssigneeFromTask(assignee, activeTask) ?? null)
+        : null,
   )
   const previewTaskAssociation = !!previewMode
     ? (getSelectorAssigneeFromFilterOptions(
@@ -153,10 +165,18 @@ export const NewTaskCard = ({
         { internalUserId: null, ...previewClientCompany }, // if preview mode, default select the respective client/company as viewer
       ) ?? null)
     : null
-  const [taskAssociationValue, setTaskAssociationValue] = useState<IAssigneeCombined | null>(previewTaskAssociation)
-  const [isShared, setIsShared] = useState(!!previewTaskAssociation)
+  const [taskAssociationValue, setTaskAssociationValue] = useState<IAssigneeCombined | null>(
+    previewTaskAssociation || (activeTask ? (getSelectorAssociationFromTask(assignee, activeTask) ?? null) : null),
+  )
+  const [isShared, setIsShared] = useState(previewTaskAssociation ? true : !!activeTask?.isShared)
 
   const { associationLabel } = useAssociationLabelForWorkspace({ workspace, associationValue: taskAssociationValue })
+
+  useEffect(() => {
+    if (!activeTask || previewMode || !assignee.length) return
+    setAssigneeValue(getSelectorAssigneeFromTask(assignee, activeTask) ?? null)
+    setTaskAssociationValue(getSelectorAssociationFromTask(assignee, activeTask) ?? null)
+  }, [activeTask, assignee, previewMode])
 
   const applyTemplate = useCallback(
     (id: string, templateTitle: string) => {

--- a/src/app/detail/ui/NewTaskCard.tsx
+++ b/src/app/detail/ui/NewTaskCard.tsx
@@ -133,6 +133,11 @@ export const NewTaskCard = ({
 
   const todoWorkflowState = workflowStates.find((el) => el.key === 'todo') || workflowStates[0]
 
+  useEffect(() => {
+    if (!defaultWorkflowState?.id) return
+    handleFieldChange('workflowStateId', defaultWorkflowState.id)
+  }, [defaultWorkflowState?.id])
+
   const { renderingItem: _statusValue, updateRenderingItem: updateStatusValue } = useHandleSelectorComponent({
     item: defaultWorkflowState,
     type: SelectorType.STATUS_SELECTOR,
@@ -176,6 +181,17 @@ export const NewTaskCard = ({
     if (!activeTask || previewMode || !assignee.length) return
     setAssigneeValue(getSelectorAssigneeFromTask(assignee, activeTask) ?? null)
     setTaskAssociationValue(getSelectorAssociationFromTask(assignee, activeTask) ?? null)
+    setIsShared(!!activeTask.isShared)
+    setSubTaskFields((prev) => ({
+      ...prev,
+      userIds: {
+        [UserIds.INTERNAL_USER_ID]: activeTask.internalUserId || null,
+        [UserIds.CLIENT_ID]: activeTask.clientId || null,
+        [UserIds.COMPANY_ID]: activeTask.companyId || null,
+      },
+      associations: activeTask.associations || [],
+      isShared: !!activeTask.isShared,
+    }))
   }, [activeTask, assignee, previewMode])
 
   const applyTemplate = useCallback(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Changes

- [x] Default subtask status to the parent task’s current workflow status instead of always `todo`
- [x] Pre-fill subtask assignee from the parent task assignee
- [x] Pre-fill subtask client association and shared-state defaults from the parent task
- [x] Keep existing preview-mode defaults and template application behavior unchanged
- [x] Keep inherited defaults synchronized if parent task context/assignee data refreshes while the form is open

## Testing Criteria

- [x] Lint checks pass for the touched file path via `yarn lint:check src/app/detail/ui/NewTaskCard.tsx`
- [ ] Manual UI verification in task detail page:
  - Open “Create subtask” under a task assigned to IU/client/company and confirm assignee default matches parent
  - Confirm status selector default matches parent status
  - For IU parent with association/shared on, confirm association and share toggle are pre-filled
  - Confirm all defaults remain editable before clicking Create

## Notes

- Change is intentionally scoped to the subtask creation UI (`src/app/detail/ui/NewTaskCard.tsx`) where initial form defaults are assembled.
- No API schema or backend validation changes required because this ticket asks for pre-filled defaults at creation time.

## Impact & Surface Area of Change

- Subtask creation form behavior on task detail page:
  - Initial workflow status
  - Initial assignee
  - Initial association + share toggle
- Existing create flow, payload shape, and template-driven overrides remain intact.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4363d969-863a-4edc-97d1-051c926b2561"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4363d969-863a-4edc-97d1-051c926b2561"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

