### PR TITLE
Fix dropped title saves during rapid edits

### DIFF
--- a/src/app/detail/[task_id]/[user_type]/actions.ts
+++ b/src/app/detail/[task_id]/[user_type]/actions.ts
@@ -30,6 +30,25 @@ export const updateTaskDetail = async ({
   })
 }
 
+export const updateTaskTitle = async ({
+  token,
+  taskId,
+  title,
+}: {
+  token: string
+  taskId: string
+  title: string
+}) => {
+  const response = await fetch(`${apiUrl}/api/tasks/${taskId}?token=${token}`, {
+    method: 'PATCH',
+    body: JSON.stringify({ title }),
+  })
+
+  if (!response.ok) {
+    throw new Error(`Failed to save task title (${response.status})`)
+  }
+}
+
 /**
  * Use the new update task function instead. This will be completely removed in the upcoming PRs.
  */

--- a/src/app/detail/[task_id]/[user_type]/page.tsx
+++ b/src/app/detail/[task_id]/[user_type]/page.tsx
@@ -14,6 +14,7 @@ import {
   postAttachment,
   updateAssignee,
   updateTaskDetail,
+  updateTaskTitle,
   updateWorkflowStateIdOfTask,
 } from '@/app/detail/[task_id]/[user_type]/actions'
 import { DetailStateUpdate } from '@/app/detail/[task_id]/[user_type]/DetailStateUpdate'
@@ -188,7 +189,7 @@ export default async function TaskDetailPage(props: {
                     }}
                     updateTaskTitle={async (title) => {
                       'use server'
-                      title.trim() != '' && (await updateTaskDetail({ token, taskId: task_id, payload: { title } }))
+                      title.trim() != '' && (await updateTaskTitle({ token, taskId: task_id, title }))
                     }}
                     deleteTask={async () => {
                       'use server'

--- a/src/app/detail/ui/TaskEditor.tsx
+++ b/src/app/detail/ui/TaskEditor.tsx
@@ -27,7 +27,7 @@ interface Prop {
   // attachment: AttachmentResponseSchema[]
   isEditable: boolean
   updateTaskDetail: (detail: string) => void
-  updateTaskTitle: (title: string) => void
+  updateTaskTitle: (title: string) => Promise<void>
   deleteTask: () => void
   postAttachment: (postAttachmentPayload: CreateAttachmentRequest) => void
   deleteAttachment: (id: string) => void
@@ -50,10 +50,14 @@ export const TaskEditor = ({
 }: Prop) => {
   const [updateTitle, setUpdateTitle] = useState('')
   const [updateDetail, setUpdateDetail] = useState('')
+  const [titleSaveError, setTitleSaveError] = useState<string | null>(null)
   const { showConfirmDeleteModal, openImage } = useSelector(selectTaskDetails)
   const { activeTask } = useSelector(selectTaskBoard)
   const [isUserTyping, setIsUserTyping] = useState(false)
   const [activeUploads, setActiveUploads] = useState(0)
+  const lastSavedTitleRef = useRef(task.title || '')
+  const queuedTitleRef = useRef<string | null>(null)
+  const isTitleSaveInFlightRef = useRef(false)
 
   const handleImagePreview = (e: MouseEvent<unknown>) => {
     store.dispatch(setOpenImage((e.target as HTMLImageElement).src))
@@ -79,13 +83,50 @@ export const TaskEditor = ({
     if (!isUserTyping && activeUploads === 0) {
       const currentTask = activeTask?.id === task_id ? activeTask : task
       if (currentTask) {
-        setUpdateTitle(currentTask.title || '')
+        if (!queuedTitleRef.current && !isTitleSaveInFlightRef.current) {
+          const syncedTitle = currentTask.title || ''
+          setUpdateTitle(syncedTitle)
+          lastSavedTitleRef.current = syncedTitle
+        }
         setUpdateDetail(currentTask.body ?? '')
       }
     }
   }, [activeTask?.title, activeTask?.body, task_id, activeUploads, task])
 
-  const _titleUpdateDebounced = async (title: string) => updateTaskTitle(title)
+  const flushQueuedTitleSave = useCallback(async () => {
+    if (isTitleSaveInFlightRef.current) return
+    if (!queuedTitleRef.current) return
+
+    isTitleSaveInFlightRef.current = true
+    while (queuedTitleRef.current) {
+      const nextTitle = queuedTitleRef.current
+      queuedTitleRef.current = null
+      try {
+        await updateTaskTitle(nextTitle)
+        lastSavedTitleRef.current = nextTitle
+        setTitleSaveError(null)
+      } catch (error) {
+        const rollbackTitle = lastSavedTitleRef.current
+        queuedTitleRef.current = null
+        setUpdateTitle(rollbackTitle)
+        setIsUserTyping(false)
+        setTitleSaveError('Could not save title. Your latest edit was reverted.')
+        isTitleSaveInFlightRef.current = false
+        return
+      }
+    }
+    isTitleSaveInFlightRef.current = false
+  }, [updateTaskTitle])
+
+  const queueTitleSave = useCallback(
+    (title: string) => {
+      queuedTitleRef.current = title
+      void flushQueuedTitleSave()
+    },
+    [flushQueuedTitleSave],
+  )
+
+  const _titleUpdateDebounced = (title: string) => queueTitleSave(title)
 
   const [titleUpdateDebounced, cancelTitleUpdateDebounced] = useDebounceWithCancel(_titleUpdateDebounced, 1500)
 
@@ -102,6 +143,7 @@ export const TaskEditor = ({
   const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newTitle = e.target.value
     setUpdateTitle(newTitle)
+    setTitleSaveError(null)
     if (newTitle.trim() == '') {
       cancelTitleUpdateDebounced()
       cancelDebouncedResetTypingFlagTitle()
@@ -118,7 +160,14 @@ export const TaskEditor = ({
         const currentTask = activeTask
         setUpdateTitle(currentTask?.title ?? '')
       }, 300)
+      return
     }
+
+    cancelTitleUpdateDebounced()
+    if (updateTitle !== lastSavedTitleRef.current) {
+      queueTitleSave(updateTitle)
+    }
+    setIsUserTyping(false)
   }
 
   const handleDetailChange = (content: string) => {
@@ -175,6 +224,8 @@ export const TaskEditor = ({
         disabled={!isEditable}
         padding="0px"
         onBlur={handleTitleBlur}
+        error={!!titleSaveError}
+        helperText={titleSaveError}
         onKeyDown={(e) => {
           if (e.key === 'Enter') {
             e.preventDefault() //prevent users from breaking line

--- a/src/app/manage-templates/[template_id]/page.tsx
+++ b/src/app/manage-templates/[template_id]/page.tsx
@@ -7,7 +7,7 @@ import { ITemplate, UserType } from '@/types/interfaces'
 import EscapeHandler from '@/utils/escapeHandler'
 import { Box } from '@mui/material'
 import TemplateDetails from '@/app/manage-templates/ui/TemplateDetails'
-import { deleteTemplate, editTemplate } from '@/app/manage-templates/actions'
+import { deleteTemplate, editTemplate, updateTemplateTitle } from '@/app/manage-templates/actions'
 import { UpdateTemplateRequest } from '@/types/dto/templates.dto'
 import { StyledBox, StyledTiptapDescriptionWrapper, TaskDetailsContainer } from '@/app/detail/ui/styledComponent'
 import { DynamicFieldInsertProvider } from '@/context/provider/DynamicFieldInsertProvider'
@@ -106,7 +106,7 @@ export default async function TaskDetailPage(props: {
                     }}
                     updateTemplateTitle={async (title: string) => {
                       'use server'
-                      title.trim() != '' && (await editTemplate(token, template_id, { title }))
+                      title.trim() != '' && (await updateTemplateTitle({ token, templateId: template_id, title }))
                     }}
                     token={token}
                   />

--- a/src/app/manage-templates/actions.ts
+++ b/src/app/manage-templates/actions.ts
@@ -32,3 +32,22 @@ export async function editTemplate(token: string, templateId: string, payload: U
     body: JSON.stringify(payload),
   })
 }
+
+export async function updateTemplateTitle({
+  token,
+  templateId,
+  title,
+}: {
+  token: string
+  templateId: string
+  title: string
+}) {
+  const response = await fetch(`${apiUrl}/api/tasks/templates/${templateId}?token=${token}`, {
+    method: 'PATCH',
+    body: JSON.stringify({ title }),
+  })
+
+  if (!response.ok) {
+    throw new Error(`Failed to save template title (${response.status})`)
+  }
+}

--- a/src/app/manage-templates/ui/TemplateDetails.tsx
+++ b/src/app/manage-templates/ui/TemplateDetails.tsx
@@ -34,7 +34,7 @@ interface TemplateDetailsProps {
   handleDeleteTemplate: (templateId: string) => void
   handleEditTemplate: (payload: CreateTemplateRequest, templateId: string) => void
   updateTemplateDetail: (detail: string) => void
-  updateTemplateTitle: (title: string) => void
+  updateTemplateTitle: (title: string) => Promise<void>
   token: string
 }
 
@@ -49,9 +49,13 @@ export default function TemplateDetails({
 }: TemplateDetailsProps) {
   const [updateTitle, setUpdateTitle] = useState('')
   const [updateDetail, setUpdateDetail] = useState('')
+  const [titleSaveError, setTitleSaveError] = useState<string | null>(null)
   const { activeTemplate, targetTemplateId, taskName } = useSelector(selectCreateTemplate)
   const [isUserTyping, setIsUserTyping] = useState(false)
   const [activeUploads, setActiveUploads] = useState(0)
+  const lastSavedTitleRef = useRef(template.title || '')
+  const queuedTitleRef = useRef<string | null>(null)
+  const isTitleSaveInFlightRef = useRef(false)
 
   const { showConfirmDeleteModal } = useSelector(selectTaskDetails)
 
@@ -64,14 +68,51 @@ export default function TemplateDetails({
     if (!isUserTyping && activeUploads === 0) {
       const currentTemplate = activeTemplate?.id === template_id ? activeTemplate : template
       if (currentTemplate) {
-        setUpdateTitle(currentTemplate.title || '')
+        if (!queuedTitleRef.current && !isTitleSaveInFlightRef.current) {
+          const syncedTitle = currentTemplate.title || ''
+          setUpdateTitle(syncedTitle)
+          lastSavedTitleRef.current = syncedTitle
+        }
         setUpdateDetail(currentTemplate.body ?? '')
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeTemplate?.title, activeTemplate?.body, template_id, activeUploads, template])
 
-  const _titleUpdateDebounced = async (title: string) => updateTemplateTitle(title)
+  const flushQueuedTitleSave = useCallback(async () => {
+    if (isTitleSaveInFlightRef.current) return
+    if (!queuedTitleRef.current) return
+
+    isTitleSaveInFlightRef.current = true
+    while (queuedTitleRef.current) {
+      const nextTitle = queuedTitleRef.current
+      queuedTitleRef.current = null
+      try {
+        await updateTemplateTitle(nextTitle)
+        lastSavedTitleRef.current = nextTitle
+        setTitleSaveError(null)
+      } catch (error) {
+        const rollbackTitle = lastSavedTitleRef.current
+        queuedTitleRef.current = null
+        setUpdateTitle(rollbackTitle)
+        setIsUserTyping(false)
+        setTitleSaveError('Could not save title. Your latest edit was reverted.')
+        isTitleSaveInFlightRef.current = false
+        return
+      }
+    }
+    isTitleSaveInFlightRef.current = false
+  }, [updateTemplateTitle])
+
+  const queueTitleSave = useCallback(
+    (title: string) => {
+      queuedTitleRef.current = title
+      void flushQueuedTitleSave()
+    },
+    [flushQueuedTitleSave],
+  )
+
+  const _titleUpdateDebounced = (title: string) => queueTitleSave(title)
   const [titleUpdateDebounced, cancelTitleUpdateDebounced] = useDebounceWithCancel(_titleUpdateDebounced, 1500)
 
   const _detailsUpdateDebounced = async (details: string) => updateTemplateDetail(details)
@@ -86,6 +127,7 @@ export default function TemplateDetails({
 
   const handleTitleChange = (newTitle: string) => {
     setUpdateTitle(newTitle)
+    setTitleSaveError(null)
     if (newTitle.trim() == '') {
       cancelTitleUpdateDebounced()
       cancelDebouncedResetTypingFlagTitle()
@@ -94,6 +136,18 @@ export default function TemplateDetails({
     setIsUserTyping(true)
     titleUpdateDebounced(newTitle)
     debouncedResetTypingFlagTitle()
+  }
+
+  const handleTitleBlur = () => {
+    if (updateTitle.trim() == '') {
+      return
+    }
+
+    cancelTitleUpdateDebounced()
+    if (updateTitle !== lastSavedTitleRef.current) {
+      queueTitleSave(updateTitle)
+    }
+    setIsUserTyping(false)
   }
   const titleEditorRef = useRef<Editor | null>(null)
   const tapwriteEditorRef = useRef<HTMLDivElement>(null) as React.RefObject<HTMLDivElement>
@@ -254,6 +308,8 @@ export default function TemplateDetails({
       <TitleEditor
         value={updateTitle}
         onChange={handleTitleChange}
+        onBlur={handleTitleBlur}
+        errorMessage={titleSaveError}
         onEditorReady={(editor) => {
           titleEditorRef.current = editor
           editor.on('focus', () => {

--- a/src/components/inputs/tiptap/TitleEditor.tsx
+++ b/src/components/inputs/tiptap/TitleEditor.tsx
@@ -13,6 +13,8 @@ interface TitleEditorProps {
   lineHeight?: string
   fontWeight?: number
   onEditorReady?: (editor: Editor) => void
+  onBlur?: () => void
+  errorMessage?: string | null
 }
 
 export const TitleEditor = ({
@@ -24,21 +26,26 @@ export const TitleEditor = ({
   lineHeight = '24px',
   fontWeight = 500,
   onEditorReady,
+  onBlur,
+  errorMessage,
 }: TitleEditorProps) => {
-  const editor = useTitleEditor({ value, onChange, placeholder, autoFocus, onEditorReady })
+  const editor = useTitleEditor({ value, onChange, placeholder, autoFocus, onEditorReady, onBlur })
 
   return (
-    <StyledEditorWrapper
-      sx={{
-        '& .tiptap-title-editor p': {
-          fontSize: `${fontSize} !important`,
-          lineHeight: `${lineHeight} !important`,
-          fontWeight: `${fontWeight} !important`,
-        },
-      }}
-    >
-      <EditorContent editor={editor} />
-    </StyledEditorWrapper>
+    <>
+      <StyledEditorWrapper
+        sx={{
+          '& .tiptap-title-editor p': {
+            fontSize: `${fontSize} !important`,
+            lineHeight: `${lineHeight} !important`,
+            fontWeight: `${fontWeight} !important`,
+          },
+        }}
+      >
+        <EditorContent editor={editor} />
+      </StyledEditorWrapper>
+      {errorMessage && <ErrorText role="alert">{errorMessage}</ErrorText>}
+    </>
   )
 }
 
@@ -65,4 +72,11 @@ const StyledEditorWrapper = styled(Box)(({ theme }) => ({
     outline: '1px solid #DFE1E4',
     outlineOffset: '-1px', // This pulls the outline inward so it sits exactly where the border was
   },
+}))
+
+const ErrorText = styled('p')(({ theme }) => ({
+  margin: '4px 0 0',
+  color: theme.palette.error.main,
+  fontSize: '12px',
+  lineHeight: '18px',
 }))

--- a/src/components/inputs/tiptap/useTitleEditor.ts
+++ b/src/components/inputs/tiptap/useTitleEditor.ts
@@ -50,6 +50,7 @@ interface UseTitleEditorOptions {
   placeholder?: string
   autoFocus?: boolean
   onEditorReady?: (editor: Editor) => void
+  onBlur?: () => void
 }
 
 function extractTextFromDoc(doc: Node): string {
@@ -82,7 +83,14 @@ function createMaxLengthExtension(maxLength: number) {
   })
 }
 
-export function useTitleEditor({ value, onChange, placeholder = '', autoFocus, onEditorReady }: UseTitleEditorOptions) {
+export function useTitleEditor({
+  value,
+  onChange,
+  placeholder = '',
+  autoFocus,
+  onEditorReady,
+  onBlur,
+}: UseTitleEditorOptions) {
   const isInternalRef = useRef(false)
 
   const editor = useEditor({
@@ -113,6 +121,12 @@ export function useTitleEditor({ value, onChange, placeholder = '', autoFocus, o
     editorProps: {
       attributes: {
         class: 'tiptap-title-editor',
+      },
+      handleDOMEvents: {
+        blur: () => {
+          onBlur?.()
+          return false
+        },
       },
       handleKeyDown: (_view, event) => {
         if (event.key === 'Enter') {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Changes

- [x] Added dedicated `updateTaskTitle` and `updateTemplateTitle` server actions that throw on non-OK responses so title save failures are surfaced to the UI.
- [x] Reworked task and template title editors to use a latest-only queued save flow:
  - debounce user input,
  - serialize network writes,
  - ensure stale in-flight requests cannot overwrite newer title edits.
- [x] Added blur-time flush so the latest title is persisted immediately when users click away during fast edits.
- [x] Added explicit rollback/error indicator behavior when title save fails (revert to last confirmed title + inline error message).
- [x] Extended TipTap title editor to support `onBlur` and inline error messaging for template title failures.
- [x] Wired detail pages to use new title-only update actions.

## Testing Criteria

- [x] `yarn lint:check src/app/detail/ui/TaskEditor.tsx src/app/manage-templates/ui/TemplateDetails.tsx src/components/inputs/tiptap/TitleEditor.tsx src/components/inputs/tiptap/useTitleEditor.ts src/app/detail/[task_id]/[user_type]/actions.ts src/app/manage-templates/actions.ts src/app/detail/[task_id]/[user_type]/page.tsx src/app/manage-templates/[template_id]/page.tsx`
  - Result: pass (repo has pre-existing warnings only, no new errors).
- [x] Code-path verification for fast edit flows:
  - rapid task title edits now coalesce to last-write-wins and cannot be overwritten by older in-flight saves,
  - rapid template title edits follow the same behavior,
  - blur forces a final flush,
  - failed saves roll back to last confirmed value with visible inline error text.

## Notes

- Scope intentionally limited to title-save reliability paths (task + template detail editors).

## Impact & Surface Area of Change

- Task details title editing (`TaskEditor`) save semantics and error handling.
- Template details title editing (`TemplateDetails` + shared `TitleEditor`) save semantics and error handling.
- Server action boundary for title updates (`actions.ts` for task + template).
- Minimal shared editor API expansion (`onBlur`, `errorMessage`) used by template details only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-42e848d3-1d66-4fa4-84f1-86c944231fd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-42e848d3-1d66-4fa4-84f1-86c944231fd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

