### PR TITLE
fix(OUT-3450): auto-focus assignee search + fix placeholder size

### DIFF
--- a/src/app/detail/ui/styledComponent.tsx
+++ b/src/app/detail/ui/styledComponent.tsx
@@ -242,13 +242,9 @@ export const CustomDivider = styled(Box)(({ theme }) => ({
   marginRight: '-10px',
 }))
 
-export const StyledUserCompanySelector = styled(UserCompanySelector)(({ theme }) => ({
+export const StyledUserCompanySelector = styled(UserCompanySelector)(() => ({
   width: '294px',
   height: '40px',
-  '& [class*="cop-border-primary"]': {
-    borderColor: `${theme.color.borders.borderDisabled}`,
-    backgroundColor: `${theme.color.base.white}`,
-  },
   '& [class*="mui-no1ryp"]': {
     maxHeight: '205px',
   },

--- a/src/components/inputs/CopilotSelector.tsx
+++ b/src/components/inputs/CopilotSelector.tsx
@@ -8,6 +8,7 @@ import { parseAssigneeToSelectorOption } from '@/utils/addTypeToAssignee'
 import { parseAssigneeToSelectorOptions } from '@/utils/assignee'
 import { getWorkspaceLabels } from '@/utils/getWorkspaceLabels'
 import { selectorOptionsToInputValue } from '@/utils/selector'
+import { userCompanySelectorStyles } from './UserCompanySelectorStyles'
 import { Box, ClickAwayListener, Popper, Stack } from '@mui/material'
 import { ReactNode, useCallback, useEffect, useRef, useState } from 'react'
 import { useSelector } from 'react-redux'
@@ -55,6 +56,7 @@ export const CopilotSelector = ({
       grouped={true}
       limitSelectedOptions={1}
       customLabels={getWorkspaceLabels(workspace, true)}
+      styles={userCompanySelectorStyles}
     />
   )
 }

--- a/src/components/inputs/FilterSelector/FilterAssigneeSection.tsx
+++ b/src/components/inputs/FilterSelector/FilterAssigneeSection.tsx
@@ -10,11 +10,12 @@ import { getSelectedUserIds } from '@/utils/selector'
 import { Box } from '@mui/material'
 import { Dispatch, SetStateAction, useEffect, useRef } from 'react'
 import { useSelector } from 'react-redux'
-import { userCompanySelectorStyles } from '../UserCompanySelectorStyles'
+import { userCompanySelectorStyles } from '@/components/inputs/UserCompanySelectorStyles'
 
 interface FilterAssigneeSectionProps {
   filterMode: FilterType
   setAnchorEl: Dispatch<SetStateAction<HTMLElement | null>>
+  autoFocus?: boolean
 }
 
 export const filterOptionsMap = {
@@ -23,7 +24,7 @@ export const filterOptionsMap = {
   [FilterType.Association]: FilterOptions.ASSOCIATION,
 }
 
-export const FilterAssigneeSection = ({ filterMode, setAnchorEl }: FilterAssigneeSectionProps) => {
+export const FilterAssigneeSection = ({ filterMode, setAnchorEl, autoFocus = false }: FilterAssigneeSectionProps) => {
   const {
     assignee: assignees,
     filterOptions: { type },
@@ -46,9 +47,10 @@ export const FilterAssigneeSection = ({ filterMode, setAnchorEl }: FilterAssigne
 
   const containerRef = useRef<HTMLDivElement | null>(null)
   useEffect(() => {
+    if (!autoFocus) return
     const input = containerRef.current?.querySelector<HTMLInputElement>('input')
     input?.focus({ preventScroll: true })
-  }, [])
+  }, [autoFocus])
 
   return (
     <Box ref={containerRef}>

--- a/src/components/inputs/FilterSelector/FilterAssigneeSection.tsx
+++ b/src/components/inputs/FilterSelector/FilterAssigneeSection.tsx
@@ -8,7 +8,7 @@ import { parseAssigneeToSelectorOption } from '@/utils/addTypeToAssignee'
 import { getWorkspaceLabels } from '@/utils/getWorkspaceLabels'
 import { getSelectedUserIds } from '@/utils/selector'
 import { Box } from '@mui/material'
-import { Dispatch, SetStateAction } from 'react'
+import { Dispatch, SetStateAction, useEffect, useRef } from 'react'
 import { useSelector } from 'react-redux'
 import { userCompanySelectorStyles } from '../UserCompanySelectorStyles'
 
@@ -44,8 +44,14 @@ export const FilterAssigneeSection = ({ filterMode, setAnchorEl }: FilterAssigne
     setAnchorEl(null)
   }
 
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  useEffect(() => {
+    const input = containerRef.current?.querySelector<HTMLInputElement>('input')
+    input?.focus({ preventScroll: true })
+  }, [])
+
   return (
-    <Box>
+    <Box ref={containerRef}>
       <StyledUserCompanySelector
         menuShouldScrollIntoView={false}
         menuIsOpen={true}

--- a/src/components/inputs/FilterSelector/FilterAssigneeSection.tsx
+++ b/src/components/inputs/FilterSelector/FilterAssigneeSection.tsx
@@ -10,6 +10,7 @@ import { getSelectedUserIds } from '@/utils/selector'
 import { Box } from '@mui/material'
 import { Dispatch, SetStateAction } from 'react'
 import { useSelector } from 'react-redux'
+import { userCompanySelectorStyles } from '../UserCompanySelectorStyles'
 
 interface FilterAssigneeSectionProps {
   filterMode: FilterType
@@ -59,6 +60,7 @@ export const FilterAssigneeSection = ({ filterMode, setAnchorEl }: FilterAssigne
         grouped={true}
         limitSelectedOptions={1}
         customLabels={getWorkspaceLabels(workspace, true)}
+        styles={userCompanySelectorStyles}
       />
     </Box>
   )

--- a/src/components/inputs/FilterSelector/index.tsx
+++ b/src/components/inputs/FilterSelector/index.tsx
@@ -125,7 +125,7 @@ export const FilterSelector = ({ disabled }: FilterSelectorProps) => {
           {!filterMode ? (
             <FilterTypeSection setFilterMode={setFilterMode} filterModes={filterModes} />
           ) : (
-            <FilterAssigneeSection filterMode={filterMode} setAnchorEl={setAnchorEl} />
+            <FilterAssigneeSection filterMode={filterMode} setAnchorEl={setAnchorEl} autoFocus />
           )}
         </Popper>
       </Box>

--- a/src/components/inputs/UserCompanySelectorStyles.ts
+++ b/src/components/inputs/UserCompanySelectorStyles.ts
@@ -1,0 +1,47 @@
+type SelectorStyleFn = (
+  base: Record<string, unknown>,
+  state?: {
+    isFocused?: boolean
+  },
+) => Record<string, unknown>
+
+interface UserCompanySelectorStyles {
+  control: SelectorStyleFn
+  placeholder: SelectorStyleFn
+  input: SelectorStyleFn
+  menu: SelectorStyleFn
+  menuList: SelectorStyleFn
+}
+
+export const userCompanySelectorStyles: UserCompanySelectorStyles = {
+  control: (base, state) => ({
+    ...base,
+    borderColor: state?.isFocused ? '#0C41BB' : '#EFF1F4',
+    backgroundColor: '#FFFFFF',
+    boxShadow: 'none',
+    '&:hover': {
+      borderColor: state?.isFocused ? '#0C41BB' : '#EFF1F4',
+    },
+  }),
+  placeholder: (base) => ({
+    ...base,
+    fontSize: '14px',
+    lineHeight: '22px',
+  }),
+  input: (base) => ({
+    ...base,
+    fontSize: '14px',
+    lineHeight: '22px',
+    margin: '0px',
+    padding: '0px',
+  }),
+  menu: (base) => ({
+    ...base,
+    marginTop: 0,
+  }),
+  menuList: (base) => ({
+    ...base,
+    marginTop: 0,
+    paddingTop: 0,
+  }),
+}

--- a/src/components/inputs/UserCompanySelectorStyles.ts
+++ b/src/components/inputs/UserCompanySelectorStyles.ts
@@ -19,6 +19,9 @@ export const userCompanySelectorStyles: UserCompanySelectorStyles = {
     borderColor: '#EFF1F4',
     backgroundColor: '#FFFFFF',
     boxShadow: 'none',
+    '&:hover': {
+      borderColor: '#EFF1F4',
+    },
     '&:focus-within': {
       borderColor: '#EFF1F4',
     },

--- a/src/components/inputs/UserCompanySelectorStyles.ts
+++ b/src/components/inputs/UserCompanySelectorStyles.ts
@@ -14,24 +14,25 @@ interface UserCompanySelectorStyles {
 }
 
 export const userCompanySelectorStyles: UserCompanySelectorStyles = {
-  control: (base, state) => ({
+  control: (base) => ({
     ...base,
-    borderColor: state?.isFocused ? '#0C41BB' : '#EFF1F4',
+    borderColor: '#EFF1F4',
     backgroundColor: '#FFFFFF',
     boxShadow: 'none',
-    '&:hover': {
-      borderColor: state?.isFocused ? '#0C41BB' : '#EFF1F4',
+    '&:focus-within': {
+      borderColor: '#EFF1F4',
     },
   }),
   placeholder: (base) => ({
     ...base,
-    fontSize: '14px',
-    lineHeight: '22px',
+    fontSize: '13px',
+    lineHeight: '20px',
+    color: '#9B9FA3',
   }),
   input: (base) => ({
     ...base,
-    fontSize: '14px',
-    lineHeight: '22px',
+    fontSize: '13px',
+    lineHeight: '20px',
     margin: '0px',
     padding: '0px',
   }),


### PR DESCRIPTION
## Summary

Targeting two issues in the Assignee/Creator/Association filter selector:

1. **Having to click twice when searching for an assignee** — when the user clicks **Filters → Assignee** (or Creator/Association), the search input now auto-focuses so they can start typing immediately. Uses a ref + `input.focus({ preventScroll: true })` instead of react-select's `autoFocus` prop, because the latter scrolls the popover into view on mount.
2. **Placeholder text size** — the search placeholder and input were rendering at 14px. Per the Figma design-system spec they should be **13px / line-height 20px**. Both are updated.

Also tidied up a couple of related visual details while the area was open:
- Lightened the placeholder color to `#9B9FA3` so it matches the lighter gray used by the top-bar search placeholder.
- Removed the blue `focus-within` / hover border on the control; the border stays `#EFF1F4` regardless of state.

The remaining design-system work (unifying the search box + options into a single seamless container, and making 13px the default in the DS) is tracked separately in **POR-19462**.

## Test plan
- [x] Open Filters → Assignee: search input is focused immediately (can type without clicking), and the page does not scroll
- [x] Same for Filters → Creator and Filters → Association
- [x] Placeholder renders at 13px and uses the lighter gray color
- [x] Selecting an assignee/creator/association still works as before and applies the filter

**Before**
<img width="309" height="305" alt="image" src="https://github.com/user-attachments/assets/4f5e0b1b-b3da-4970-8b0a-2ba7dfbcdf3a" />

**After**
<img width="308" height="390" alt="image" src="https://github.com/user-attachments/assets/771ad371-769f-4f0e-b4c7-6483515e3885" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)