### PR TITLE
OUT-2563 | Reply notification failing when reply is created from CU

### DIFF
--- a/src/jobs/notifications/send-reply-create-notifications.ts
+++ b/src/jobs/notifications/send-reply-create-notifications.ts
@@ -87,7 +87,7 @@ export const sendReplyCreateNotifications = task({
         (initiator) => initiator.initiatorId === parentComment.initiatorId,
       )
       if (!isParentCommentDeleted && !parentInitiatorIsCurrentUser && !isNotificationAlreadySent) {
-        let promise = getInitiatorNotificationPromises(
+        const typedPromise = getInitiatorNotificationPromises(
           copilot,
           parentComment,
           senderId,
@@ -97,8 +97,9 @@ export const sendReplyCreateNotifications = task({
           payload.task.companyId || undefined,
         )
         // If there is no "initiatorType" for parentComment we have to be slightly creative (coughhackycough)
-        if (!promise) {
-          promise = getNotificationToUntypedInitiator(
+        const promise =
+          typedPromise ??
+          getNotificationToUntypedInitiator(
             copilot,
             parentComment,
             payload.task,
@@ -107,7 +108,6 @@ export const sendReplyCreateNotifications = task({
             senderCompanyId,
             deliveryTargets,
           )
-        }
         queueNotificationPromise(promise)
       }
     }
@@ -232,5 +232,8 @@ const getNotificationToUntypedInitiator = async (
     deliveryTargets,
     task.companyId || undefined,
     CommentInitiator.client,
-  )!
+  )!.catch((e) => {
+    console.error(e)
+    return undefined
+  })
 }

--- a/src/jobs/notifications/send-reply-create-notifications.ts
+++ b/src/jobs/notifications/send-reply-create-notifications.ts
@@ -1,7 +1,8 @@
-import { NotificationSender, NotificationSenderSchema } from '@/types/common'
+import { NotificationRequestBody, NotificationSender } from '@/types/common'
 import { getAssigneeName } from '@/utils/assignee'
 import { copilotBottleneck } from '@/utils/bottleneck'
 import { CopilotAPI } from '@/utils/CopilotAPI'
+import { isMessagableError } from '@/utils/copilotError'
 import { CommentRepository } from '@/app/api/comments/comment.repository'
 import { CommentService } from '@/app/api/comments/comment.service'
 import User from '@api/core/models/User.model'
@@ -39,6 +40,9 @@ export const sendReplyCreateNotifications = task({
       .string()
       .uuid()
       .parse(user.internalUserId || user.clientId)
+    const senderType: NotificationSender = user.internalUserId ? CommentInitiator.internalUser : CommentInitiator.client
+    // Copilot requires senderCompanyId when the sender is a client in a multi-company workspace
+    const senderCompanyId = senderType === CommentInitiator.client ? user.companyId : undefined
 
     const deliveryTargets = await getNotificationDetails(copilot, user, comment)
 
@@ -58,6 +62,8 @@ export const sendReplyCreateNotifications = task({
         copilot,
         initiator,
         senderId,
+        senderType,
+        senderCompanyId,
         deliveryTargets,
         // NOTE: We are sending payload.task.companyId here. This might sound silly, i agree.
         // However, it is very safe to assume that client users can ONLY reply to comments in tasks
@@ -75,7 +81,7 @@ export const sendReplyCreateNotifications = task({
       // - Parent Comment hasn't been deleted yet
       // - Parent Comment initiatorId isn't this current user
       // - Parent comment hasn't been already sent a notification through a reply
-      const isParentCommentDeleted = !parentComment.deletedAt
+      const isParentCommentDeleted = !!parentComment.deletedAt
       const parentInitiatorIsCurrentUser = parentComment.initiatorId === senderId
       const isNotificationAlreadySent = threadInitiators.some(
         (initiator) => initiator.initiatorId === parentComment.initiatorId,
@@ -85,12 +91,22 @@ export const sendReplyCreateNotifications = task({
           copilot,
           parentComment,
           senderId,
+          senderType,
+          senderCompanyId,
           deliveryTargets,
           payload.task.companyId || undefined,
         )
         // If there is no "initiatorType" for parentComment we have to be slightly creative (coughhackycough)
         if (!promise) {
-          promise = getNotificationToUntypedInitiator(copilot, parentComment, payload.task, senderId, deliveryTargets)
+          promise = getNotificationToUntypedInitiator(
+            copilot,
+            parentComment,
+            payload.task,
+            senderId,
+            senderType,
+            senderCompanyId,
+            deliveryTargets,
+          )
         }
         queueNotificationPromise(promise)
       }
@@ -137,28 +153,47 @@ const getInitiatorNotificationPromises = async (
   // Initiator in this context means previous initiators that were active in the thread, NOT the currently commenting user
   initiator: { initiatorId: string; initiatorType: CommentInitiator | null },
   senderId: string,
+  senderType: NotificationSender,
+  senderCompanyId: string | undefined,
   deliveryTargets: { inProduct: Record<'title', any>; email: object },
   initiatorCompanyId?: string,
-  // Overrides the default senderType for the notification
+  // Forces recipient branch when initiator.initiatorType is unset (legacy comments)
   assume?: CommentInitiator,
 ) => {
+  let body: NotificationRequestBody
   if (initiator.initiatorType === CommentInitiator.internalUser || assume === CommentInitiator.internalUser) {
-    return copilot.createNotification({
+    body = {
       senderId,
-      senderType: assume || NotificationSenderSchema.parse(initiator.initiatorType),
+      senderType,
+      senderCompanyId,
       recipientInternalUserId: initiator.initiatorId,
       deliveryTargets: { inProduct: deliveryTargets.inProduct },
-    })
+    }
   } else if (initiator.initiatorType === CommentInitiator.client || assume === CommentInitiator.client) {
-    return copilot.createNotification({
+    body = {
       senderId,
-      senderType: assume || NotificationSenderSchema.parse(initiator.initiatorType),
+      senderType,
+      senderCompanyId,
       recipientClientId: initiator.initiatorId,
       recipientCompanyId: initiatorCompanyId,
       deliveryTargets: { email: deliveryTargets.email },
-    })
+    }
   } else {
     return null
+  }
+  return createNotificationWithCompanyFallback(copilot, body)
+}
+
+// Single-company workspaces reject senderCompanyId; retry without it on that specific error.
+// Mirrors NotificationService#handleIfSenderCompanyIdError.
+const createNotificationWithCompanyFallback = async (copilot: CopilotAPI, body: NotificationRequestBody) => {
+  try {
+    return await copilot.createNotification(body)
+  } catch (e) {
+    if (isMessagableError(e) && e.body?.message === 'sender company ID is invalid based on sender') {
+      return await copilot.createNotification({ ...body, senderCompanyId: undefined })
+    }
+    throw e
   }
 }
 
@@ -167,6 +202,8 @@ const getNotificationToUntypedInitiator = async (
   parentComment: Comment,
   task: Task,
   senderId: string,
+  senderType: NotificationSender,
+  senderCompanyId: string | undefined,
   deliveryTargets: { inProduct: Record<'title', any>; email: object },
 ) => {
   let promise
@@ -176,6 +213,8 @@ const getNotificationToUntypedInitiator = async (
       copilot,
       parentComment,
       senderId,
+      senderType,
+      senderCompanyId,
       deliveryTargets,
       task.companyId || undefined,
       CommentInitiator.internalUser,
@@ -186,6 +225,8 @@ const getNotificationToUntypedInitiator = async (
         copilot,
         parentComment,
         senderId,
+        senderType,
+        senderCompanyId,
         deliveryTargets,
         task.companyId || undefined,
         CommentInitiator.client,

--- a/src/jobs/notifications/send-reply-create-notifications.ts
+++ b/src/jobs/notifications/send-reply-create-notifications.ts
@@ -160,20 +160,17 @@ const getInitiatorNotificationPromises = (
   // Forces recipient branch when initiator.initiatorType is unset (legacy comments)
   assume?: CommentInitiator,
 ) => {
+  const base = { senderId, senderType, senderCompanyId }
   let body: NotificationRequestBody
   if (initiator.initiatorType === CommentInitiator.internalUser || assume === CommentInitiator.internalUser) {
     body = {
-      senderId,
-      senderType,
-      senderCompanyId,
+      ...base,
       recipientInternalUserId: initiator.initiatorId,
       deliveryTargets: { inProduct: deliveryTargets.inProduct },
     }
   } else if (initiator.initiatorType === CommentInitiator.client || assume === CommentInitiator.client) {
     body = {
-      senderId,
-      senderType,
-      senderCompanyId,
+      ...base,
       recipientClientId: initiator.initiatorId,
       recipientCompanyId: initiatorCompanyId,
       deliveryTargets: { email: deliveryTargets.email },

--- a/src/jobs/notifications/send-reply-create-notifications.ts
+++ b/src/jobs/notifications/send-reply-create-notifications.ts
@@ -206,10 +206,9 @@ const getNotificationToUntypedInitiator = async (
   senderCompanyId: string | undefined,
   deliveryTargets: { inProduct: Record<'title', any>; email: object },
 ) => {
-  let promise
   try {
     await copilot.getInternalUser(parentComment.initiatorId)
-    promise = getInitiatorNotificationPromises(
+    return getInitiatorNotificationPromises(
       copilot,
       parentComment,
       senderId,
@@ -220,21 +219,17 @@ const getNotificationToUntypedInitiator = async (
       CommentInitiator.internalUser,
     )
   } catch (e) {
-    try {
-      promise = getInitiatorNotificationPromises(
-        copilot,
-        parentComment,
-        senderId,
-        senderType,
-        senderCompanyId,
-        deliveryTargets,
-        task.companyId || undefined,
-        CommentInitiator.client,
-      )
-    } catch (e) {
-      console.error(e)
-      throw new Error('Unable to resolve comment initiator as IU or Client')
-    }
+    console.error(e)
   }
-  return promise
+
+  return getInitiatorNotificationPromises(
+    copilot,
+    parentComment,
+    senderId,
+    senderType,
+    senderCompanyId,
+    deliveryTargets,
+    task.companyId || undefined,
+    CommentInitiator.client,
+  )
 }

--- a/src/jobs/notifications/send-reply-create-notifications.ts
+++ b/src/jobs/notifications/send-reply-create-notifications.ts
@@ -148,7 +148,7 @@ const getNotificationDetails = async (copilot: CopilotAPI, user: User, comment: 
   return deliveryTargets
 }
 
-const getInitiatorNotificationPromises = async (
+const getInitiatorNotificationPromises = (
   copilot: CopilotAPI,
   // Initiator in this context means previous initiators that were active in the thread, NOT the currently commenting user
   initiator: { initiatorId: string; initiatorType: CommentInitiator | null },
@@ -208,6 +208,7 @@ const getNotificationToUntypedInitiator = async (
 ) => {
   try {
     await copilot.getInternalUser(parentComment.initiatorId)
+    // `assume` guarantees a non-null promise
     return getInitiatorNotificationPromises(
       copilot,
       parentComment,
@@ -217,7 +218,7 @@ const getNotificationToUntypedInitiator = async (
       deliveryTargets,
       task.companyId || undefined,
       CommentInitiator.internalUser,
-    )
+    )!
   } catch (e) {
     console.error(e)
   }
@@ -231,5 +232,5 @@ const getNotificationToUntypedInitiator = async (
     deliveryTargets,
     task.companyId || undefined,
     CommentInitiator.client,
-  )
+  )!
 }


### PR DESCRIPTION
## Summary
- Fixes reply notifications that were silently dropped for cross-type replies (IU → CU's comment and CU → IU's comment) and 400'd for any client-originated reply in a multi-company workspace.
- `senderType` is now derived from the actual sender's user role (not the recipient's `initiatorType`), and `senderCompanyId` is passed when the sender is a client. Mirrors `NotificationService.buildNotificationDetails` / `handleIfSenderCompanyIdError`, including the single-company-workspace fallback that retries without `senderCompanyId` on Copilot's `'sender company ID is invalid based on sender'` error.
- Also flips an inverted `deletedAt` check that gated the parent-comment-author notification on the parent being *deleted* instead of *live* — so parent authors never received reply notifications, even in same-type cases.

## Root cause
`getInitiatorNotificationPromises` set `senderType: NotificationSenderSchema.parse(initiator.initiatorType)` — i.e. derived from the **recipient**, not the sender. Same-type replies (IU→IU, CU→CU) happened to work because recipient type coincidentally matched sender type. Cross-type replies sent a `senderId` / `senderType` mismatch, and client senders additionally lacked `senderCompanyId`, causing Copilot to 400 (confirmed via Trigger.dev run trace).

## Test plan
- [x] Deploy to Trigger staging: `yarn trigger:deploy-staging`
- [x] IU replies to CU's comment on a task → CU receives email notification
- [x] CU replies to IU's comment on a task → IU receives in-product notification
- [x] IU replies to IU's comment → IU receives in-product notification (regression check)
- [x] CU replies to CU's comment → CU receives email (regression check)
- [x] Reply to own comment → no self-notification
- [x] Top-level comment notifications still work (regression check on sibling job)
- [x] Single-company workspace: client-originated reply still succeeds via fallback branch

## Test

<img width="360" height="72" alt="image" src="https://github.com/user-attachments/assets/faddfded-be86-4efc-9b53-c38be86b846f" />

CU replies to IU comment notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)