### PR TITLE
OUT-3648 | Tasks created in the webapp should not have the user agent as "node"

### DIFF
--- a/src/app/(home)/actions.ts
+++ b/src/app/(home)/actions.ts
@@ -4,6 +4,13 @@ import { apiUrl } from '@/config'
 import { CreateAttachmentRequest } from '@/types/dto/attachments.dto'
 import { CreateTaskRequest, UpdateTaskRequest } from '@/types/dto/tasks.dto'
 import { CreateViewSettingsDTO } from '@/types/dto/viewSettings.dto'
+import { headers } from 'next/headers'
+
+const getForwardedAssemblyHeaders = async (): Promise<Record<string, string>> => {
+  const h = await headers()
+  const userAgent = h.get('user-agent')
+  return userAgent ? { 'x-assembly-user-agent': userAgent } : {}
+}
 
 export const handleCreate = async (
   token: string,
@@ -15,6 +22,7 @@ export const handleCreate = async (
       `${apiUrl}/api/tasks?token=${token}&disableSubtaskTemplates=${opts?.disableSubtaskTemplates}`,
       {
         method: 'POST',
+        headers: await getForwardedAssemblyHeaders(),
         body: JSON.stringify(payload),
       },
     )
@@ -36,6 +44,7 @@ export const updateTask = async ({
 }) => {
   await fetch(`${apiUrl}/api/tasks/${taskId}?token=${token}`, {
     method: 'PATCH',
+    headers: await getForwardedAssemblyHeaders(),
     body: JSON.stringify({
       workflowStateId: payload.workflowStateId,
       internalUserId: payload.internalUserId,

--- a/src/app/(home)/actions.ts
+++ b/src/app/(home)/actions.ts
@@ -4,17 +4,7 @@ import { apiUrl } from '@/config'
 import { CreateAttachmentRequest } from '@/types/dto/attachments.dto'
 import { CreateTaskRequest, UpdateTaskRequest } from '@/types/dto/tasks.dto'
 import { CreateViewSettingsDTO } from '@/types/dto/viewSettings.dto'
-import { headers } from 'next/headers'
-
-const getForwardedAssemblyHeaders = async (): Promise<Record<string, string>> => {
-  const h = await headers()
-  const forwarded: Record<string, string> = {}
-  const userAgent = h.get('user-agent')
-  if (userAgent) forwarded['x-assembly-user-agent'] = userAgent
-  const clientIp = h.get('x-real-ip') ?? h.get('x-forwarded-for')?.split(',')[0]?.trim()
-  if (clientIp) forwarded['x-assembly-client-ip'] = clientIp
-  return forwarded
-}
+import { getForwardedAssemblyHeaders } from '@/utils/serverHeaders'
 
 export const handleCreate = async (
   token: string,

--- a/src/app/(home)/actions.ts
+++ b/src/app/(home)/actions.ts
@@ -8,8 +8,12 @@ import { headers } from 'next/headers'
 
 const getForwardedAssemblyHeaders = async (): Promise<Record<string, string>> => {
   const h = await headers()
+  const forwarded: Record<string, string> = {}
   const userAgent = h.get('user-agent')
-  return userAgent ? { 'x-assembly-user-agent': userAgent } : {}
+  if (userAgent) forwarded['x-assembly-user-agent'] = userAgent
+  const clientIp = h.get('x-real-ip') ?? h.get('x-forwarded-for')?.split(',')[0]?.trim()
+  if (clientIp) forwarded['x-assembly-client-ip'] = clientIp
+  return forwarded
 }
 
 export const handleCreate = async (

--- a/src/app/detail/[task_id]/[user_type]/actions.ts
+++ b/src/app/detail/[task_id]/[user_type]/actions.ts
@@ -9,8 +9,12 @@ import { headers } from 'next/headers'
 
 const getForwardedAssemblyHeaders = async (): Promise<Record<string, string>> => {
   const h = await headers()
+  const forwarded: Record<string, string> = {}
   const userAgent = h.get('user-agent')
-  return userAgent ? { 'x-assembly-user-agent': userAgent } : {}
+  if (userAgent) forwarded['x-assembly-user-agent'] = userAgent
+  const clientIp = h.get('x-real-ip') ?? h.get('x-forwarded-for')?.split(',')[0]?.trim()
+  if (clientIp) forwarded['x-assembly-client-ip'] = clientIp
+  return forwarded
 }
 
 export const updateTaskDetail = async ({

--- a/src/app/detail/[task_id]/[user_type]/actions.ts
+++ b/src/app/detail/[task_id]/[user_type]/actions.ts
@@ -5,17 +5,7 @@ import { ScrapMediaRequest } from '@/types/common'
 import { CreateAttachmentRequest } from '@/types/dto/attachments.dto'
 import { CreateComment, UpdateComment } from '@/types/dto/comment.dto'
 import { UpdateTaskRequest, Associations } from '@/types/dto/tasks.dto'
-import { headers } from 'next/headers'
-
-const getForwardedAssemblyHeaders = async (): Promise<Record<string, string>> => {
-  const h = await headers()
-  const forwarded: Record<string, string> = {}
-  const userAgent = h.get('user-agent')
-  if (userAgent) forwarded['x-assembly-user-agent'] = userAgent
-  const clientIp = h.get('x-real-ip') ?? h.get('x-forwarded-for')?.split(',')[0]?.trim()
-  if (clientIp) forwarded['x-assembly-client-ip'] = clientIp
-  return forwarded
-}
+import { getForwardedAssemblyHeaders } from '@/utils/serverHeaders'
 
 export const updateTaskDetail = async ({
   token,

--- a/src/app/detail/[task_id]/[user_type]/actions.ts
+++ b/src/app/detail/[task_id]/[user_type]/actions.ts
@@ -5,6 +5,13 @@ import { ScrapMediaRequest } from '@/types/common'
 import { CreateAttachmentRequest } from '@/types/dto/attachments.dto'
 import { CreateComment, UpdateComment } from '@/types/dto/comment.dto'
 import { UpdateTaskRequest, Associations } from '@/types/dto/tasks.dto'
+import { headers } from 'next/headers'
+
+const getForwardedAssemblyHeaders = async (): Promise<Record<string, string>> => {
+  const h = await headers()
+  const userAgent = h.get('user-agent')
+  return userAgent ? { 'x-assembly-user-agent': userAgent } : {}
+}
 
 export const updateTaskDetail = async ({
   token,
@@ -17,6 +24,7 @@ export const updateTaskDetail = async ({
 }) => {
   await fetch(`${apiUrl}/api/tasks/${taskId}?token=${token}`, {
     method: 'PATCH',
+    headers: await getForwardedAssemblyHeaders(),
     body: JSON.stringify({
       workflowStateId: payload.workflowStateId,
       internalUserId: payload.internalUserId,
@@ -36,6 +44,7 @@ export const updateTaskDetail = async ({
 export const updateWorkflowStateIdOfTask = async (token: string, taskId: string, targetWorkflowStateId: string) => {
   await fetch(`${apiUrl}/api/tasks/${taskId}?token=${token}`, {
     method: 'PATCH',
+    headers: await getForwardedAssemblyHeaders(),
     body: JSON.stringify({
       workflowStateId: targetWorkflowStateId,
     }),
@@ -53,6 +62,7 @@ export const updateAssignee = async (
 ) => {
   await fetch(`${apiUrl}/api/tasks/${task_id}?token=${token}`, {
     method: 'PATCH',
+    headers: await getForwardedAssemblyHeaders(),
     body: JSON.stringify({
       internalUserId,
       clientId,
@@ -66,12 +76,14 @@ export const updateAssignee = async (
 export const clientUpdateTask = async (token: string, taskId: string, targetWorkflowStateId: string) => {
   await fetch(`${apiUrl}/api/tasks/${taskId}/client?token=${token}&workflowStateId=${targetWorkflowStateId}`, {
     method: 'PATCH',
+    headers: await getForwardedAssemblyHeaders(),
   })
 }
 
 export const deleteTask = async (token: string, task_id: string) => {
   await fetch(`${apiUrl}/api/tasks/${task_id}?token=${token}`, {
     method: 'DELETE',
+    headers: await getForwardedAssemblyHeaders(),
   })
 }
 

--- a/src/utils/serverHeaders.ts
+++ b/src/utils/serverHeaders.ts
@@ -1,0 +1,11 @@
+import { headers } from 'next/headers'
+
+export const getForwardedAssemblyHeaders = async (): Promise<Record<string, string>> => {
+  const h = await headers()
+  const forwarded: Record<string, string> = {}
+  const userAgent = h.get('user-agent')
+  if (userAgent) forwarded['x-assembly-user-agent'] = userAgent
+  const clientIp = h.get('x-real-ip') ?? h.get('x-forwarded-for')?.split(',')[0]?.trim()
+  if (clientIp) forwarded['x-assembly-client-ip'] = clientIp
+  return forwarded
+}


### PR DESCRIPTION
## Changes

- [x] Forwarded x-assembly-user-agent through server actions. 


## Testing Criteria

<img width="794" height="107" alt="image" src="https://github.com/user-attachments/assets/7915f240-252d-4f13-803f-ef0f9fde550d" />

