### PR TITLE
perf(tasks): index tuning + SQL client-access filter (OUT-2675)

### DIFF
--- a/prisma/migrations/20260501120000_add_lookup_indexes/README.md
+++ b/prisma/migrations/20260501120000_add_lookup_indexes/README.md
@@ -4,17 +4,17 @@ Adds 9 indexes (8 btree + 1 GIN) to support common lookups on `Tasks`, `Comments
 
 ## What's in this migration
 
-| Index | Table | Type | Purpose |
-|---|---|---|---|
-| `IX_Tasks_workspaceId` | Tasks | btree | Generic tenant filter |
-| `IX_Tasks_assigneeId` | Tasks | btree | Webhook bulk operations |
-| `IX_Tasks_workspaceId_isArchived_dueDate_createdAt` | Tasks | btree (composite) | Tasks list endpoint — exactly matches the WHERE + ORDER BY shape |
-| `IX_Tasks_associations_gin` | Tasks | **GIN** (`jsonb_path_ops`) | JSONB containment queries (e.g. `associations: { hasSome: [...] }`) |
-| `IX_ClientNotifications_taskId` | ClientNotifications | btree | Lookups by task |
-| `IX_ClientNotifications_clientId` | ClientNotifications | btree | webhook bulk lookup by client |
-| `IX_ClientNotifications_companyId` | ClientNotifications | btree | (low confidence — see "Post-rollout monitoring") |
-| `IX_Comments_parentId` | Comments | btree | Reply lookups |
-| `IX_Comments_workspaceId` | Comments | btree | (low confidence — see "Post-rollout monitoring") |
+| Index                                               | Table               | Type                       | Purpose                                                             |
+| --------------------------------------------------- | ------------------- | -------------------------- | ------------------------------------------------------------------- |
+| `IX_Tasks_workspaceId`                              | Tasks               | btree                      | Generic tenant filter                                               |
+| `IX_Tasks_assigneeId`                               | Tasks               | btree                      | Webhook bulk operations                                             |
+| `IX_Tasks_workspaceId_isArchived_dueDate_createdAt` | Tasks               | btree (composite)          | Tasks list endpoint — exactly matches the WHERE + ORDER BY shape    |
+| `IX_Tasks_associations_gin`                         | Tasks               | **GIN** (`jsonb_path_ops`) | JSONB containment queries (e.g. `associations: { hasSome: [...] }`) |
+| `IX_ClientNotifications_taskId`                     | ClientNotifications | btree                      | Lookups by task                                                     |
+| `IX_ClientNotifications_clientId`                   | ClientNotifications | btree                      | webhook bulk lookup by client                                       |
+| `IX_ClientNotifications_companyId`                  | ClientNotifications | btree                      | (low confidence — see "Post-rollout monitoring")                    |
+| `IX_Comments_parentId`                              | Comments            | btree                      | Reply lookups                                                       |
+| `IX_Comments_workspaceId`                           | Comments            | btree                      | (low confidence — see "Post-rollout monitoring")                    |
 
 Note on the GIN index: Prisma cannot model `GIN` on `Json[]` in its schema. The `task.prisma` annotation intentionally omits it. `prisma migrate diff` will flag it as drift — that is intentional and expected.
 
@@ -61,6 +61,7 @@ CREATE INDEX CONCURRENTLY "IX_Comments_workspaceId" ON "Comments"("workspaceId")
 ```
 
 Notes:
+
 - Run each statement separately. `CONCURRENTLY` is incompatible with explicit transaction blocks; wrapping multiple `CONCURRENTLY` statements in `BEGIN/COMMIT` will fail.
 - If a `CONCURRENTLY` build is interrupted, Postgres leaves an `INVALID` index behind. Drop it (`DROP INDEX CONCURRENTLY "<name>"`) before retrying.
 - Build progress is visible in `pg_stat_progress_create_index` while it runs.
@@ -176,6 +177,7 @@ ORDER BY idx_scan ASC;
 Indexes with `idx_scan = 0` after sustained traffic are dead weight — drop them.
 
 Suspected low-value entries to watch:
+
 - `IX_ClientNotifications_companyId` — current code paths always pair `companyId` with `clientId`, so the `clientId` index covers them.
 - `IX_Comments_workspaceId` — no production query I found filters by `workspaceId` alone on Comments; tenant filter is always combined with `taskId` or `parentId`.
 - `IX_Tasks_workspaceId` — superseded by the new composite `IX_Tasks_workspaceId_isArchived_dueDate_createdAt` for the list path. Other call sites still benefit from the standalone, but if it shows zero scans, it can go.

--- a/prisma/migrations/20260501120000_add_lookup_indexes/README.md
+++ b/prisma/migrations/20260501120000_add_lookup_indexes/README.md
@@ -1,6 +1,26 @@
 # Migration: add_lookup_indexes
 
-Adds 8 btree indexes to support common lookups on `Tasks`, `Comments`, and `ClientNotifications`.
+Adds 9 indexes (8 btree + 1 GIN) to support common lookups on `Tasks`, `Comments`, and `ClientNotifications`. Pairs with a `tasks.service.ts` refactor that pushes the client-access filter into SQL.
+
+## What's in this migration
+
+| Index | Table | Type | Purpose |
+|---|---|---|---|
+| `IX_Tasks_workspaceId` | Tasks | btree | Generic tenant filter |
+| `IX_Tasks_assigneeId` | Tasks | btree | Webhook bulk operations |
+| `IX_Tasks_workspaceId_isArchived_dueDate_createdAt` | Tasks | btree (composite) | Tasks list endpoint — exactly matches the WHERE + ORDER BY shape |
+| `IX_Tasks_associations_gin` | Tasks | **GIN** (`jsonb_path_ops`) | JSONB containment queries (e.g. `associations: { hasSome: [...] }`) |
+| `IX_ClientNotifications_taskId` | ClientNotifications | btree | Lookups by task |
+| `IX_ClientNotifications_clientId` | ClientNotifications | btree | webhook bulk lookup by client |
+| `IX_ClientNotifications_companyId` | ClientNotifications | btree | (low confidence — see "Post-rollout monitoring") |
+| `IX_Comments_parentId` | Comments | btree | Reply lookups |
+| `IX_Comments_workspaceId` | Comments | btree | (low confidence — see "Post-rollout monitoring") |
+
+Note on the GIN index: Prisma cannot model `GIN` on `Json[]` in its schema. The `task.prisma` annotation intentionally omits it. `prisma migrate diff` will flag it as drift — that is intentional and expected.
+
+## Paired code change
+
+`src/app/api/tasks/tasks.service.ts#listTasks` no longer post-filters via `filterTasksByClientAccess` in JS. It now composes `getAccessFilterForTasks()` into the Prisma `where` via `AND`, so the client-access constraint is enforced in SQL. Same return shape, same task IDs — just less data fetched and filtered server-side.
 
 ## Why this migration needs special handling
 
@@ -29,7 +49,10 @@ Connect to the production database (Supabase SQL editor, `psql`, whatever you no
 ```sql
 CREATE INDEX CONCURRENTLY "IX_Tasks_workspaceId" ON "Tasks"("workspaceId");
 CREATE INDEX CONCURRENTLY "IX_Tasks_assigneeId" ON "Tasks"("assigneeId");
-CREATE INDEX CONCURRENTLY "IX_Tasks_workspaceId_createdAt" ON "Tasks"("workspaceId", "createdAt" DESC);
+CREATE INDEX CONCURRENTLY "IX_Tasks_workspaceId_isArchived_dueDate_createdAt"
+  ON "Tasks"("workspaceId", "isArchived", "dueDate" ASC NULLS LAST, "createdAt" DESC);
+CREATE INDEX CONCURRENTLY "IX_Tasks_associations_gin"
+  ON "Tasks" USING GIN ("associations" jsonb_path_ops);
 CREATE INDEX CONCURRENTLY "IX_ClientNotifications_taskId" ON "ClientNotifications"("taskId");
 CREATE INDEX CONCURRENTLY "IX_ClientNotifications_clientId" ON "ClientNotifications"("clientId");
 CREATE INDEX CONCURRENTLY "IX_ClientNotifications_companyId" ON "ClientNotifications"("companyId");
@@ -41,6 +64,7 @@ Notes:
 - Run each statement separately. `CONCURRENTLY` is incompatible with explicit transaction blocks; wrapping multiple `CONCURRENTLY` statements in `BEGIN/COMMIT` will fail.
 - If a `CONCURRENTLY` build is interrupted, Postgres leaves an `INVALID` index behind. Drop it (`DROP INDEX CONCURRENTLY "<name>"`) before retrying.
 - Build progress is visible in `pg_stat_progress_create_index` while it runs.
+- The GIN build can be slower than a btree on the same row count — give it more time.
 
 ### 2. Mark the migration as applied in Prisma's history
 
@@ -62,15 +86,79 @@ WHERE indexname LIKE 'IX_Tasks_%'
    OR indexname LIKE 'IX_ClientNotifications_%';
 ```
 
-Then run `EXPLAIN ANALYZE` on a representative query and confirm the planner picked the new index:
+Then run `EXPLAIN ANALYZE` on representative queries:
 
 ```sql
+-- Should pick the new composite — no separate Sort node above the Index Scan
 EXPLAIN ANALYZE
 SELECT * FROM "Tasks"
-WHERE "workspaceId" = '<real-workspace-id>' AND "deletedAt" IS NULL;
+WHERE "workspaceId" = '<real-workspace-id>'
+  AND "isArchived" = false
+  AND "deletedAt" IS NULL
+ORDER BY "dueDate" ASC NULLS LAST, "createdAt" DESC;
+
+-- Should pick the GIN index, not Seq Scan
+EXPLAIN ANALYZE
+SELECT * FROM "Tasks"
+WHERE "associations" @> '[{"companyId": "<some-uuid>"}]'::jsonb[]
+  AND "deletedAt" IS NULL;
 ```
 
-Look for `Index Scan using "IX_Tasks_workspaceId"` (or the composite) instead of `Seq Scan`.
+## Manual test plan (verify locally before merging)
+
+This PR bundles index changes AND a service-layer refactor (`filterTasksByClientAccess` → SQL). All of the following should pass.
+
+### A. Migration mechanics
+
+- [ ] `bun prisma migrate dev` runs cleanly on a fresh local DB.
+- [ ] `bun prisma generate` produces no schema drift other than the documented GIN drift on `Tasks.associations`.
+- [ ] App boots (`bun dev`) with no Prisma errors at startup.
+
+### B. Tasks list — happy path (no FE behavior change)
+
+- [ ] As an internal user with `isClientAccessLimited = false`, open a board with ≥10 tasks across multiple workflow states. Same task IDs, same order as before this branch.
+- [ ] Sort order: tasks with `dueDate` come first (ascending), tasks with no due date appear last, ties broken by `createdAt DESC`.
+- [ ] Toggle "show archived" → archived tasks appear, ordered by the same rules.
+- [ ] Open a single task detail (`/detail/<id>`) → loads correctly.
+- [ ] Drag a task between columns → state moves persist after reload.
+- [ ] Keyword search across `task.body` (the FE filter via `useFilter.tsx:106`) still works — confirms `body` is still in the response.
+
+### C. Tasks list — client-access-limited IU (THIS IS THE CRITICAL CASE)
+
+This is what the SQL refactor changes. The result set MUST be identical to the JS-filter version.
+
+- [ ] Log in as an internal user where `isClientAccessLimited = true` and `companyAccessList = [companyA, companyB]`.
+- [ ] Open the board. Confirm:
+  - [ ] Tasks assigned to internalUsers (any IU, not just current) → visible.
+  - [ ] Unassigned tasks (no internalUserId, no clientId, no companyId) → visible.
+  - [ ] Tasks for clients/companies in companyA / companyB → visible.
+  - [ ] Tasks for companies NOT in the access list → NOT visible.
+- [ ] Disjoint subtask edge case: parent task is for a company OUTSIDE access list, subtask is for a company IN access list → the subtask must still surface as a root-level task in the board.
+- [ ] Try opening a task detail URL by id for a task outside the access list → blocked by the existing `checkClientAccessForTask` policy gate (this hasn't changed).
+- [ ] Empty access list (`companyAccessList = []`) for a restricted IU → board shows only IU-assigned tasks and unassigned tasks. No client/company tasks visible.
+
+### D. CU portal users (clients / companies)
+
+- [ ] Log in as a client → see only the tasks assigned to the client / their company / shared associations. Same set as before this PR.
+- [ ] Log in as a company portal user → same.
+- [ ] CU disjoint subtasks: parent task accessible to CU through associations but subtask not directly assigned → still surfaces as root-level. Same as before this PR.
+
+### E. Webhook flows (touch the GIN index path)
+
+- [ ] In Copilot, change a client's company association → tasks-app correctly moves the related tasks. Old client notifications are cleaned up.
+- [ ] Delete a client → tasks for that client are deleted, shared tasks are reset, related notifications cleared.
+- [ ] Create a task assigned to a company, then change the company → task moves correctly.
+
+### F. Cross-cutting regressions
+
+- [ ] Subtasks page renders correctly for both unrestricted and restricted IUs.
+- [ ] Templates and view-settings unaffected (none of the touched code paths).
+- [ ] Public API (`/api/tasks/public/*`) returns identical results — that path uses `getClientOrCompanyAssigneeFilter` directly and was not modified.
+
+### G. Performance sanity check (optional but recommended)
+
+- [ ] On a workspace with thousands of tasks where the user is an `isClientAccessLimited` IU, time the `/api/tasks` request before vs after this branch. Expect significant reduction (dropping the JS post-filter + smaller fetched row set + index-driven sort).
+- [ ] Run the `EXPLAIN ANALYZE` queries in section "Verify" above. Confirm `Index Scan` (no `Seq Scan`).
 
 ## Post-rollout monitoring
 
@@ -88,5 +176,6 @@ ORDER BY idx_scan ASC;
 Indexes with `idx_scan = 0` after sustained traffic are dead weight — drop them.
 
 Suspected low-value entries to watch:
-- `IX_ClientNotifications_companyId` — current code paths always pair it with `clientId`, so the `clientId` index covers them.
+- `IX_ClientNotifications_companyId` — current code paths always pair `companyId` with `clientId`, so the `clientId` index covers them.
 - `IX_Comments_workspaceId` — no production query I found filters by `workspaceId` alone on Comments; tenant filter is always combined with `taskId` or `parentId`.
+- `IX_Tasks_workspaceId` — superseded by the new composite `IX_Tasks_workspaceId_isArchived_dueDate_createdAt` for the list path. Other call sites still benefit from the standalone, but if it shows zero scans, it can go.

--- a/prisma/migrations/20260501120000_add_lookup_indexes/README.md
+++ b/prisma/migrations/20260501120000_add_lookup_indexes/README.md
@@ -1,0 +1,92 @@
+# Migration: add_lookup_indexes
+
+Adds 8 btree indexes to support common lookups on `Tasks`, `Comments`, and `ClientNotifications`.
+
+## Why this migration needs special handling
+
+`Tasks` and `Comments` are large in production. A plain `CREATE INDEX` takes a heavy lock that blocks writes for the duration of the build — potentially many minutes of downtime. The fix is `CREATE INDEX CONCURRENTLY`, but that statement cannot run inside a transaction, and Prisma wraps every migration in a transaction.
+
+So the rollout differs by environment.
+
+## Local / staging
+
+Just run the normal migration command. Plain `CREATE INDEX` is fast on small data and matches the existing migration style in this repo.
+
+```bash
+bun prisma migrate dev
+```
+
+## Production rollout
+
+**Do not run `prisma migrate deploy` for this migration.** It will block writes.
+
+Instead:
+
+### 1. Apply each index manually with `CONCURRENTLY`
+
+Connect to the production database (Supabase SQL editor, `psql`, whatever you normally use) and run **each statement in its own session, one at a time**:
+
+```sql
+CREATE INDEX CONCURRENTLY "IX_Tasks_workspaceId" ON "Tasks"("workspaceId");
+CREATE INDEX CONCURRENTLY "IX_Tasks_assigneeId" ON "Tasks"("assigneeId");
+CREATE INDEX CONCURRENTLY "IX_Tasks_workspaceId_createdAt" ON "Tasks"("workspaceId", "createdAt" DESC);
+CREATE INDEX CONCURRENTLY "IX_ClientNotifications_taskId" ON "ClientNotifications"("taskId");
+CREATE INDEX CONCURRENTLY "IX_ClientNotifications_clientId" ON "ClientNotifications"("clientId");
+CREATE INDEX CONCURRENTLY "IX_ClientNotifications_companyId" ON "ClientNotifications"("companyId");
+CREATE INDEX CONCURRENTLY "IX_Comments_parentId" ON "Comments"("parentId");
+CREATE INDEX CONCURRENTLY "IX_Comments_workspaceId" ON "Comments"("workspaceId");
+```
+
+Notes:
+- Run each statement separately. `CONCURRENTLY` is incompatible with explicit transaction blocks; wrapping multiple `CONCURRENTLY` statements in `BEGIN/COMMIT` will fail.
+- If a `CONCURRENTLY` build is interrupted, Postgres leaves an `INVALID` index behind. Drop it (`DROP INDEX CONCURRENTLY "<name>"`) before retrying.
+- Build progress is visible in `pg_stat_progress_create_index` while it runs.
+
+### 2. Mark the migration as applied in Prisma's history
+
+After every index is built, tell Prisma not to try running the migration:
+
+```bash
+bun prisma migrate resolve --applied 20260501120000_add_lookup_indexes
+```
+
+This inserts a row into `_prisma_migrations` so future `migrate deploy` runs skip this migration.
+
+### 3. Verify
+
+```sql
+SELECT indexname, indexdef
+FROM pg_indexes
+WHERE indexname LIKE 'IX_Tasks_%'
+   OR indexname LIKE 'IX_Comments_%'
+   OR indexname LIKE 'IX_ClientNotifications_%';
+```
+
+Then run `EXPLAIN ANALYZE` on a representative query and confirm the planner picked the new index:
+
+```sql
+EXPLAIN ANALYZE
+SELECT * FROM "Tasks"
+WHERE "workspaceId" = '<real-workspace-id>' AND "deletedAt" IS NULL;
+```
+
+Look for `Index Scan using "IX_Tasks_workspaceId"` (or the composite) instead of `Seq Scan`.
+
+## Post-rollout monitoring
+
+After ~1 week of traffic, check which indexes are actually being used:
+
+```sql
+SELECT relname, indexrelname, idx_scan
+FROM pg_stat_user_indexes
+WHERE indexrelname LIKE 'IX_Tasks_%'
+   OR indexrelname LIKE 'IX_Comments_%'
+   OR indexrelname LIKE 'IX_ClientNotifications_%'
+ORDER BY idx_scan ASC;
+```
+
+Indexes with `idx_scan = 0` after sustained traffic are dead weight — drop them.
+
+Suspected low-value entries to watch:
+- `IX_ClientNotifications_companyId` — current code paths always pair it with `clientId`, so the `clientId` index covers them.
+- `IX_Comments_workspaceId` — no production query I found filters by `workspaceId` alone on Comments; tenant filter is always combined with `taskId` or `parentId`.

--- a/prisma/migrations/20260501120000_add_lookup_indexes/migration.sql
+++ b/prisma/migrations/20260501120000_add_lookup_indexes/migration.sql
@@ -1,0 +1,41 @@
+-- ----------------------------------------------------------------------------
+-- ⚠️  PRODUCTION ROLLOUT WARNING
+-- ----------------------------------------------------------------------------
+-- This migration creates btree indexes on large tables (Tasks, Comments,
+-- ClientNotifications). Running plain `CREATE INDEX` takes an
+-- ACCESS EXCLUSIVE-equivalent lock and will BLOCK WRITES for the duration
+-- of the index build — minutes of downtime on multi-million-row tables.
+--
+-- ✅ For local / staging:   `bun prisma migrate dev` (this file is fine).
+-- ⚠️  For production:        DO NOT run via `prisma migrate deploy`.
+--                            Follow `./README.md` to apply each statement
+--                            with CREATE INDEX CONCURRENTLY, then mark this
+--                            migration as applied with
+--                            `prisma migrate resolve --applied 20260501120000_add_lookup_indexes`.
+-- ----------------------------------------------------------------------------
+
+-- CreateIndex
+CREATE INDEX "IX_Tasks_workspaceId" ON "Tasks"("workspaceId");
+
+-- CreateIndex
+CREATE INDEX "IX_Tasks_assigneeId" ON "Tasks"("assigneeId");
+
+-- CreateIndex
+-- Composite for the tenant-scoped Tasks list ordering
+-- (tasks.service.ts orderBy [dueDate, createdAt desc] inside a workspace).
+CREATE INDEX "IX_Tasks_workspaceId_createdAt" ON "Tasks"("workspaceId", "createdAt" DESC);
+
+-- CreateIndex
+CREATE INDEX "IX_ClientNotifications_taskId" ON "ClientNotifications"("taskId");
+
+-- CreateIndex
+CREATE INDEX "IX_ClientNotifications_clientId" ON "ClientNotifications"("clientId");
+
+-- CreateIndex
+CREATE INDEX "IX_ClientNotifications_companyId" ON "ClientNotifications"("companyId");
+
+-- CreateIndex
+CREATE INDEX "IX_Comments_parentId" ON "Comments"("parentId");
+
+-- CreateIndex
+CREATE INDEX "IX_Comments_workspaceId" ON "Comments"("workspaceId");

--- a/prisma/migrations/20260501120000_add_lookup_indexes/migration.sql
+++ b/prisma/migrations/20260501120000_add_lookup_indexes/migration.sql
@@ -21,9 +21,21 @@ CREATE INDEX "IX_Tasks_workspaceId" ON "Tasks"("workspaceId");
 CREATE INDEX "IX_Tasks_assigneeId" ON "Tasks"("assigneeId");
 
 -- CreateIndex
--- Composite for the tenant-scoped Tasks list ordering
--- (tasks.service.ts orderBy [dueDate, createdAt desc] inside a workspace).
-CREATE INDEX "IX_Tasks_workspaceId_createdAt" ON "Tasks"("workspaceId", "createdAt" DESC);
+-- Composite that matches the Tasks list endpoint's filter + ordering:
+--   WHERE workspaceId = $1 AND isArchived = $2 AND deletedAt IS NULL
+--   ORDER BY "dueDate" ASC NULLS LAST, "createdAt" DESC
+-- See tasks.service.ts#listTasks. Plain (non-partial) so it stays in sync
+-- with Prisma's @@index — Prisma can't model partial indexes.
+CREATE INDEX "IX_Tasks_workspaceId_isArchived_dueDate_createdAt"
+  ON "Tasks"("workspaceId", "isArchived", "dueDate" ASC NULLS LAST, "createdAt" DESC);
+
+-- CreateIndex
+-- GIN index for JSONB containment lookups on associations
+-- (e.g. webhook.service.ts uses { associations: { hasSome: [{ companyId: ... }] } }).
+-- Prisma cannot model GIN on Json[] in schema, so this lives only in SQL —
+-- the schema file intentionally omits this index.
+CREATE INDEX "IX_Tasks_associations_gin"
+  ON "Tasks" USING GIN ("associations" jsonb_path_ops);
 
 -- CreateIndex
 CREATE INDEX "IX_ClientNotifications_taskId" ON "ClientNotifications"("taskId");

--- a/prisma/schema/clientNotification.prisma
+++ b/prisma/schema/clientNotification.prisma
@@ -20,5 +20,8 @@ model ClientNotification {
   // Either way, soft deleting client notifications (not IU ones) is not very useful in the first place
   @@unique([taskId, clientId, companyId, deletedAt], name: "UQ_ClientNotifications_taskId_clientId_companyId_deletedAt")
   @@index([notificationId], name: "IX_ClientNotifications_notificationId")
+  @@index([taskId], name: "IX_ClientNotifications_taskId")
+  @@index([clientId], name: "IX_ClientNotifications_clientId")
+  @@index([companyId], name: "IX_ClientNotifications_companyId")
   @@map("ClientNotifications")
 }

--- a/prisma/schema/comment.prisma
+++ b/prisma/schema/comment.prisma
@@ -27,4 +27,6 @@ model Comment {
 
   @@map("Comments")
   @@index([taskId, workspaceId, createdAt(sort: Desc)], name: "IX_Comments_taskId_workspaceId_createdAt")
+  @@index([parentId], name: "IX_Comments_parentId")
+  @@index([workspaceId], name: "IX_Comments_workspaceId")
 }

--- a/prisma/schema/task.prisma
+++ b/prisma/schema/task.prisma
@@ -62,5 +62,8 @@ model Task {
   isShared           Boolean     @default(false)
 
   @@index([path], type: Gist)
+  @@index([workspaceId], name: "IX_Tasks_workspaceId")
+  @@index([assigneeId], name: "IX_Tasks_assigneeId")
+  @@index([workspaceId, createdAt(sort: Desc)], name: "IX_Tasks_workspaceId_createdAt")
   @@map("Tasks")
 }

--- a/prisma/schema/task.prisma
+++ b/prisma/schema/task.prisma
@@ -64,6 +64,10 @@ model Task {
   @@index([path], type: Gist)
   @@index([workspaceId], name: "IX_Tasks_workspaceId")
   @@index([assigneeId], name: "IX_Tasks_assigneeId")
-  @@index([workspaceId, createdAt(sort: Desc)], name: "IX_Tasks_workspaceId_createdAt")
+  @@index([workspaceId, isArchived, dueDate, createdAt(sort: Desc)], name: "IX_Tasks_workspaceId_isArchived_dueDate_createdAt")
+  // NOTE: A GIN index on `associations` (jsonb_path_ops) also exists in the database
+  // for JSONB containment queries. It is created via raw SQL in the migration
+  // (20260501120000_add_lookup_indexes) because Prisma cannot model GIN on Json[].
+  // Run `prisma migrate diff` and ignore the GIN entry — it is intentional drift.
   @@map("Tasks")
 }

--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -100,23 +100,21 @@ export class TasksService extends TasksSharedService {
     const orderBy: Prisma.TaskOrderByWithRelationInput[] = [{ createdAt: 'desc' }]
     orderBy.unshift({ dueDate: { sort: 'asc', nulls: 'last' } })
 
+    // Push the client-access filter into SQL instead of fetching all rows
+    // and post-filtering in JS (the previous filterTasksByClientAccess pass).
+    // Composed via AND to avoid clobbering the OR clauses already present in
+    // the assembled `where` (buildTaskPermissions / disjointTasksFilter both
+    // return top-level OR for some user roles).
+    const accessFilter = await this.getAccessFilterForTasks()
+
     const tasks = await this.db.task.findMany({
-      where,
+      where: { AND: [where, accessFilter] },
       orderBy,
       relationLoadStrategy: 'join',
       include: { workflowState: true },
     })
 
-    if (!this.user.internalUserId) {
-      return tasks
-    }
-
-    // Now we have the challenge of figuring out if a task is assigned to a client / company that falls in IU's access list
-    const currentInternalUser = await this.copilot.getInternalUser(this.user.internalUserId)
-    if (!currentInternalUser.isClientAccessLimited) return tasks
-
-    const filteredTasks = await this.filterTasksByClientAccess(tasks, currentInternalUser)
-    return filteredTasks
+    return tasks
   }
 
   async createTask(data: CreateTaskRequest, opts?: { disableSubtaskTemplates?: boolean; manualTimestamp?: Date }) {


### PR DESCRIPTION
Linear: OUT-2675

## Summary

Bundles three changes that all target the Tasks list endpoint hot path. None affect the FE response shape.

### 1. Lookup indexes on tenant-scoped columns
8 btree indexes covering hot tenant-scoped lookups that currently seq-scan large tables.
- **Tasks**: `workspaceId`, `assigneeId`, composite `(workspaceId, isArchived, dueDate ASC NULLS LAST, createdAt DESC)`
- **ClientNotifications**: `taskId`, `clientId`, `companyId`
- **Comments**: `parentId`, `workspaceId`

The composite Tasks index exactly matches the list endpoint's WHERE + ORDER BY shape so the planner can satisfy it with a single Index Scan (no separate Sort node above it).

### 2. GIN index on `Tasks.associations`
For the JSONB containment lookups in `webhook.service.ts` (e.g. `associations: { hasSome: [{ companyId }] }`). Currently those scan the full table. The GIN index lives in raw SQL only — Prisma can't model GIN on `Json[]`, and `task.prisma` documents the intentional drift.

### 3. SQL client-access filter (drops the JS post-filter)
`tasks.service.ts#listTasks` previously fetched all tenant tasks then filtered in JS via `filterTasksByClientAccess` for client-access-limited IUs. This switches to SQL via the existing `getAccessFilterForTasks()` helper (already used by 3 other call sites), composed with `AND` so it doesn't clobber the existing `OR` clauses in the assembled `where`. Same return shape, same task IDs.

## Skipped (intentional)

- ❌ **Pagination on the list** — confirmed with @anit it stays as-is.
- ❌ **SELECT narrowing on Tasks** — FE audit found `task.body` is consumed in three places (`useFilter.tsx:106` keyword search, `ClientTaskCard.tsx:106` description preview, `OneTaskDataFetcher.tsx:35-42` image-src diff). Dropping it would break FE.
- ❌ **Caching** — out of scope for now per @anit.
- ❌ **`WorkflowStates(workspaceId)` index** — already covered by the existing `(workspaceId, key)` composite (leading column).
- ❌ **`ViewSettings(companyId)` index** — all queries filter by the full user-id tuple; existing indexes cover them.

## ⚠️ Production rollout requires manual steps

Plain `CREATE INDEX` blocks writes during the build. **Do not run `prisma migrate deploy` for this migration in prod.**

Procedure in `prisma/migrations/20260501120000_add_lookup_indexes/README.md`. Short version:
1. Run each `CREATE INDEX CONCURRENTLY` statement manually (e.g. via Supabase SQL editor), one session at a time.
2. Mark the migration as applied: `bun prisma migrate resolve --applied 20260501120000_add_lookup_indexes`.
3. Verify with `EXPLAIN ANALYZE` per the README.

Local / staging via `bun prisma migrate dev` works as normal.

## Manual test plan

Full checklist with edge cases is in `prisma/migrations/20260501120000_add_lookup_indexes/README.md` under "Manual test plan". Sections:
- A. Migration mechanics
- B. Tasks list happy path (unrestricted IU)
- C. Tasks list — client-access-limited IU **(critical — this is what the SQL refactor changes)**
- D. CU portal users
- E. Webhook flows (touches the GIN index path)
- F. Cross-cutting regressions
- G. Performance sanity check (EXPLAIN ANALYZE)

The most important verification is section C — same set of tasks must be visible to a restricted IU before vs after this branch.

## Low-confidence indexes flagged for monitoring

After ~1 week of production traffic, check `pg_stat_user_indexes.idx_scan` and drop these if they're at 0:
- `IX_ClientNotifications_companyId`
- `IX_Comments_workspaceId`
- `IX_Tasks_workspaceId` (potentially superseded by the new composite for the list path)

The README has the verification SQL.