### PR TITLE
feat: workspace fetch optimization + parent tasks fetching

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,11 @@
 [tools]
-node = "20.19.4"
+bun = "1.2"
+node = "24"
+
+[tasks."dev"]
+description = "Run dev build with portless"
+run = "portless tasks bun -b next dev"
+
+[tasks."db:migrate"]
+description = "Migrate db"
+run = "bunx prisma migrate dev"

--- a/package.json
+++ b/package.json
@@ -140,6 +140,7 @@
     "seed:activity-logs": "tsx ./src/cmd/fill-activity-logs",
     "start": "next start",
     "test": "jest",
+    "tsc": "tsc --noEmit",
     "trigger": "npx trigger.dev@latest",
     "trigger:deploy-staging": "yarn trigger deploy -e staging",
     "vercel-build": "prisma generate && next build",

--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -11,7 +11,7 @@ import { SilentError } from '@/components/templates/SilentError'
 import { apiUrl } from '@/config'
 import { ClientSideStateUpdate } from '@/hoc/ClientSideStateUpdate'
 import { RealTime } from '@/hoc/RealTime'
-import { UrlActionParamsType, Token, TokenSchema, WorkspaceResponse } from '@/types/common'
+import { UrlActionParamsType, Token, TokenSchema } from '@/types/common'
 import { CreateAttachmentRequest } from '@/types/dto/attachments.dto'
 import { TaskResponse } from '@/types/dto/tasks.dto'
 import { CreateViewSettingsDTO } from '@/types/dto/viewSettings.dto'
@@ -61,11 +61,6 @@ export async function getTokenPayload(token: string): Promise<Token> {
   return payload as Token
 }
 
-export async function getWorkspace(token: string): Promise<WorkspaceResponse> {
-  const copilot = new CopilotAPI(token)
-  return await copilot.getWorkspace()
-}
-
 export async function getViewSettings(token: string): Promise<CreateViewSettingsDTO> {
   const res = await fetch(`${apiUrl}/api/view-settings?token=${token}`, {
     next: { tags: ['getViewSettings'] },
@@ -96,10 +91,9 @@ export default async function Main(props: {
   redirectIfTaskCta(searchParams, userRole)
 
   const viewSettings = await getViewSettings(token)
-  const [workflowStates, tasks, workspace] = await Promise.all([
+  const [workflowStates, tasks] = await Promise.all([
     getAllWorkflowStates(token),
     getAllTasks(token, { showArchived: viewSettings.showArchived, showUnarchived: viewSettings.showUnarchived }),
-    getWorkspace(token),
   ])
 
   if (tokenPayload.companyId) {
@@ -118,7 +112,6 @@ export default async function Main(props: {
         viewSettings={viewSettings}
         tokenPayload={tokenPayload}
         clearExpandedComments={true}
-        workspace={workspace}
         action={searchParams?.action}
         pf={searchParams?.pf}
       >
@@ -135,7 +128,7 @@ export default async function Main(props: {
 
         <RealTime tokenPayload={tokenPayload}>
           <RealTimeTemplates tokenPayload={tokenPayload} token={token}>
-            <TaskBoard mode={UserRole.IU} workspace={workspace} token={token} />
+            <TaskBoard mode={UserRole.IU} token={token} />
             <ModalNewTaskForm
               handleCreateMultipleAttachments={async (attachments: CreateAttachmentRequest[]) => {
                 'use server'

--- a/src/app/_fetchers/WorkspaceFetcher.tsx
+++ b/src/app/_fetchers/WorkspaceFetcher.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import { selectAuthDetails, setWorkspace } from '@/redux/features/authDetailsSlice'
+import store from '@/redux/store'
+import { WorkspaceResponse } from '@/types/common'
+import { fetcher } from '@/utils/fetcher'
+import { useSearchParams } from 'next/navigation'
+import { useEffect } from 'react'
+import { useSelector } from 'react-redux'
+import useSWR from 'swr'
+
+export const WorkspaceFetcher = () => {
+  const searchParams = useSearchParams()
+  const token = searchParams.get('token')
+  const { workspace } = useSelector(selectAuthDetails)
+
+  const shouldFetch = !!token && !workspace
+  const { data } = useSWR<WorkspaceResponse>(shouldFetch ? `/api/workspace?token=${token}` : null, fetcher, {
+    refreshInterval: 0,
+    revalidateOnFocus: false,
+    dedupingInterval: 60_000,
+  })
+
+  useEffect(() => {
+    if (data) {
+      store.dispatch(setWorkspace(data))
+    }
+  }, [data])
+
+  return null
+}

--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -704,7 +704,6 @@ export class TasksService extends TasksSharedService {
   }
 
   async getTraversalPath(id: string): Promise<AncestorTaskResponse[]> {
-    const pathQueryStartedAt = performance.now()
     const taskWithPath = (
       await this.db.$queryRaw<{ path: string }[]>`
       SELECT "path" from "Tasks"
@@ -712,7 +711,7 @@ export class TasksService extends TasksSharedService {
       LIMIT 1
     `
     )?.[0]
-    console.info(`[perf] getTraversalPath path-query id=${id} took ${(performance.now() - pathQueryStartedAt).toFixed(2)}ms`)
+
     if (!taskWithPath) {
       throw new APIError(httpStatus.NOT_FOUND, 'The requested task was not found')
     }
@@ -720,7 +719,7 @@ export class TasksService extends TasksSharedService {
     const parentIds = getIdsFromLtreePath(taskWithPath.path)
     const parentTasksStartedAt = performance.now()
 
-    const parentTasks = (await this.db.task.findMany({
+    const fetchedParents = (await this.db.task.findMany({
       where: {
         id: {
           in: parentIds,
@@ -739,15 +738,14 @@ export class TasksService extends TasksSharedService {
       },
     })) as AncestorTaskResponse[]
 
-    const parentTaskIds = new Set(parentTasks.map((task) => task.id))
-
-    if (new Set(parentIds).difference(parentTaskIds) && parentIds.length !== parentTaskIds.size) {
-      throw new APIError(httpStatus.EXPECTATION_FAILED, 'Unable to get all of the parent ids.')
-    }
-
-    console.info(
-      `[perf] getTraversalPath parent-tasks id=${id} count=${parentTasks.length} took ${(performance.now() - parentTasksStartedAt).toFixed(2)}ms`,
-    )
+    const parentTasksById = new Map(fetchedParents.map((task) => [task.id, task]))
+    const parentTasks = parentIds.map((parentId) => {
+      const task = parentTasksById.get(parentId)
+      if (!task) {
+        throw new APIError(httpStatus.EXPECTATION_FAILED, `Missing parent task ${parentId} in traversal path of ${id}`)
+      }
+      return task
+    })
 
     const subtaskService = new SubtaskService(this.user)
     return await subtaskService.getAccessiblePathTasks(parentTasks)

--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -704,6 +704,7 @@ export class TasksService extends TasksSharedService {
   }
 
   async getTraversalPath(id: string): Promise<AncestorTaskResponse[]> {
+    const pathQueryStartedAt = performance.now()
     const taskWithPath = (
       await this.db.$queryRaw<{ path: string }[]>`
       SELECT "path" from "Tasks"
@@ -711,27 +712,41 @@ export class TasksService extends TasksSharedService {
       LIMIT 1
     `
     )?.[0]
+    console.info(`[perf] getTraversalPath path-query id=${id} took ${(performance.now() - pathQueryStartedAt).toFixed(2)}ms`)
     if (!taskWithPath) {
       throw new APIError(httpStatus.NOT_FOUND, 'The requested task was not found')
     }
 
-    const parents = getIdsFromLtreePath(taskWithPath.path)
-    const parentTasks = await Promise.all(
-      parents.map((id) =>
-        this.db.task.findFirstOrThrow({
-          where: { id, workspaceId: this.user.workspaceId },
-          select: {
-            id: true,
-            title: true,
-            label: true,
-            clientId: true,
-            companyId: true,
-            internalUserId: true,
-            associations: true,
-            isShared: true,
-          },
-        }),
-      ) as Promise<AncestorTaskResponse>[],
+    const parentIds = getIdsFromLtreePath(taskWithPath.path)
+    const parentTasksStartedAt = performance.now()
+
+    const parentTasks = (await this.db.task.findMany({
+      where: {
+        id: {
+          in: parentIds,
+        },
+        workspaceId: this.user.workspaceId,
+      },
+      select: {
+        id: true,
+        title: true,
+        label: true,
+        clientId: true,
+        companyId: true,
+        internalUserId: true,
+        associations: true,
+        isShared: true,
+      },
+    })) as AncestorTaskResponse[]
+
+    const parentTaskIds = new Set(parentTasks.map((task) => task.id))
+
+    if (new Set(parentIds).difference(parentTaskIds) && parentIds.length !== parentTaskIds.size) {
+      throw new APIError(httpStatus.EXPECTATION_FAILED, 'Unable to get all of the parent ids.')
+    }
+
+    console.info(
+      `[perf] getTraversalPath parent-tasks id=${id} count=${parentTasks.length} took ${(performance.now() - parentTasksStartedAt).toFixed(2)}ms`,
     )
 
     const subtaskService = new SubtaskService(this.user)

--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -717,7 +717,6 @@ export class TasksService extends TasksSharedService {
     }
 
     const parentIds = getIdsFromLtreePath(taskWithPath.path)
-    const parentTasksStartedAt = performance.now()
 
     const fetchedParents = (await this.db.task.findMany({
       where: {

--- a/src/app/api/workspace/route.ts
+++ b/src/app/api/workspace/route.ts
@@ -1,0 +1,12 @@
+import { getMemoizedWorkspace } from '@/utils/copilotMemo'
+import authenticate from '@api/core/utils/authenticate'
+import { withErrorHandler } from '@api/core/utils/withErrorHandler'
+import { NextRequest, NextResponse } from 'next/server'
+
+const getWorkspace = async (req: NextRequest) => {
+  const user = await authenticate(req)
+  const workspace = await getMemoizedWorkspace(user.token)
+  return NextResponse.json(workspace)
+}
+
+export const GET = withErrorHandler(getWorkspace)

--- a/src/app/client/page.tsx
+++ b/src/app/client/page.tsx
@@ -14,7 +14,7 @@ import { SilentError } from '@/components/templates/SilentError'
 import { apiUrl } from '@/config'
 import { ClientSideStateUpdate } from '@/hoc/ClientSideStateUpdate'
 import { RealTime } from '@/hoc/RealTime'
-import { Token, TokenSchema, UrlActionParamsType, WorkspaceResponse } from '@/types/common'
+import { Token, TokenSchema, UrlActionParamsType } from '@/types/common'
 import { CreateAttachmentRequest } from '@/types/dto/attachments.dto'
 import { TaskResponse } from '@/types/dto/tasks.dto'
 import { WorkflowStateResponse } from '@/types/dto/workflowStates.dto'
@@ -50,11 +50,6 @@ async function getTokenPayload(token: string): Promise<Token> {
   return payload as Token
 }
 
-async function getWorkspace(token: string): Promise<WorkspaceResponse> {
-  const copilot = new CopilotAPI(token)
-  return await copilot.getWorkspace()
-}
-
 export default async function ClientPage(props: { searchParams: Promise<{ token: string } & UrlActionParamsType> }) {
   const searchParams = await props.searchParams
   const token = searchParams.token
@@ -62,12 +57,11 @@ export default async function ClientPage(props: { searchParams: Promise<{ token:
     return <SilentError message="Please provide a Valid Token" />
   }
   redirectIfTaskCta(searchParams, UserType.CLIENT_USER)
-  const [workflowStates, tasks, viewSettings, tokenPayload, workspace] = await Promise.all([
+  const [workflowStates, tasks, viewSettings, tokenPayload] = await Promise.all([
     getAllWorkflowStates(token),
     getAllTasks(token),
     getViewSettings(token),
     getTokenPayload(token),
-    getWorkspace(token),
   ])
 
   const previewMode = getPreviewMode(tokenPayload)
@@ -87,7 +81,6 @@ export default async function ClientPage(props: { searchParams: Promise<{ token:
         tokenPayload={tokenPayload}
         viewSettings={viewSettings}
         clearExpandedComments={true}
-        workspace={workspace}
         action={searchParams?.action}
         pf={searchParams?.pf}
       >
@@ -105,7 +98,7 @@ export default async function ClientPage(props: { searchParams: Promise<{ token:
           <AllTasksFetcher token={token} />
         </Suspense>
 
-        <TaskBoardAppBridge token={token} role={UserRole.Client} portalUrl={workspace.portalUrl} />
+        <TaskBoardAppBridge token={token} role={UserRole.Client} />
         <RealTime tokenPayload={tokenPayload}>
           <TaskBoard mode={UserRole.Client} token={token} />
           <ModalNewTaskForm

--- a/src/app/detail/[task_id]/[user_type]/DetailStateUpdate.tsx
+++ b/src/app/detail/[task_id]/[user_type]/DetailStateUpdate.tsx
@@ -1,6 +1,6 @@
 import { ClientSideStateUpdate } from '@/hoc/ClientSideStateUpdate'
 import { getAllTasks, getAllWorkflowStates } from '@/app/(home)/page'
-import { Token, WorkspaceResponse } from '@/types/common'
+import { Token } from '@/types/common'
 import { TaskResponse } from '@/types/dto/tasks.dto'
 import { CreateViewSettingsDTO } from '@/types/dto/viewSettings.dto'
 
@@ -10,7 +10,6 @@ interface DetailStateUpdateProps {
   tokenPayload: Token | null
   task: TaskResponse
   children: React.ReactNode
-  workspace?: WorkspaceResponse
   viewSettings: CreateViewSettingsDTO
 }
 
@@ -19,19 +18,12 @@ export const DetailStateUpdate = async ({
   token,
   tokenPayload,
   task,
-  workspace,
   viewSettings,
   children,
 }: DetailStateUpdateProps) => {
   if (!isRedirect) {
     return (
-      <ClientSideStateUpdate
-        token={token}
-        tokenPayload={tokenPayload}
-        task={task}
-        workspace={workspace}
-        viewSettings={viewSettings}
-      >
+      <ClientSideStateUpdate token={token} tokenPayload={tokenPayload} task={task} viewSettings={viewSettings}>
         {children}
       </ClientSideStateUpdate>
     )
@@ -48,7 +40,6 @@ export const DetailStateUpdate = async ({
       viewSettings={viewSettings}
       tokenPayload={tokenPayload}
       task={task}
-      workspace={workspace}
     >
       {children}
     </ClientSideStateUpdate>

--- a/src/app/detail/[task_id]/[user_type]/page.tsx
+++ b/src/app/detail/[task_id]/[user_type]/page.tsx
@@ -35,7 +35,6 @@ import { AppMargin, SizeofAppMargin } from '@/hoc/AppMargin'
 import { AttachmentProvider } from '@/hoc/PostAttachmentProvider'
 import { RealTime } from '@/hoc/RealTime'
 import { RealTimeTemplates } from '@/hoc/RealtimeTemplates'
-import { WorkspaceResponse } from '@/types/common'
 import { AncestorTaskResponse, SubTaskStatusResponse, TaskResponse } from '@/types/dto/tasks.dto'
 import { UserType } from '@/types/interfaces'
 import { getAssigneeCacheLookupKey, UserIdsWithAssociationSharedType } from '@/utils/assignee'
@@ -60,11 +59,6 @@ async function getOneTask(token: string, taskId: string): Promise<TaskResponse |
     }
     throw error
   }
-}
-
-async function getWorkspace(token: string): Promise<WorkspaceResponse> {
-  const copilot = new CopilotAPI(token)
-  return await copilot.getWorkspace()
 }
 
 async function getSubTasksStatus(token: string, taskId: string): Promise<SubTaskStatusResponse> {
@@ -94,10 +88,9 @@ export default async function TaskDetailPage(props: {
 
   const copilotClient = new CopilotAPI(token)
 
-  const [task, tokenPayload, workspace, subTaskStatus, taskPath, viewSettings] = await Promise.all([
+  const [task, tokenPayload, subTaskStatus, taskPath, viewSettings] = await Promise.all([
     getOneTask(token, task_id),
     copilotClient.getTokenPayload(),
-    getWorkspace(token),
     getSubTasksStatus(token, task_id),
     getTaskPath(token, task_id),
     getViewSettings(token),
@@ -135,7 +128,6 @@ export default async function TaskDetailPage(props: {
       token={token}
       tokenPayload={tokenPayload}
       task={task}
-      workspace={workspace}
       viewSettings={viewSettings}
     >
       {token && <OneTaskDataFetcher token={token} task_id={task_id} initialTask={task} />}
@@ -163,12 +155,7 @@ export default async function TaskDetailPage(props: {
                 </StyledBox>
               ) : (
                 <>
-                  <HeaderBreadcrumbs
-                    token={token}
-                    items={breadcrumbItems}
-                    userType={params.user_type}
-                    portalUrl={workspace.portalUrl}
-                  />
+                  <HeaderBreadcrumbs token={token} items={breadcrumbItems} userType={params.user_type} />
                   <ArchiveWrapper taskId={task_id} userType={user_type} />
                 </>
               )}
@@ -252,7 +239,6 @@ export default async function TaskDetailPage(props: {
                 task_id={task_id}
                 selectedAssigneeId={task?.assigneeId}
                 userType={user_type}
-                portalUrl={workspace.portalUrl}
                 selectedWorkflowState={task?.workflowState}
                 fromNotificationCenter={fromNotificationCenter}
                 updateWorkflowState={async (workflowState, skipSubtaskCascade) => {

--- a/src/app/detail/ui/ClientDetailAppBridge.tsx
+++ b/src/app/detail/ui/ClientDetailAppBridge.tsx
@@ -4,15 +4,18 @@ import { Icons } from '@/hooks/app-bridge/types'
 import { useAwake } from '@/hooks/app-bridge/useAwake'
 import { usePrimaryCta } from '@/hooks/app-bridge/usePrimaryCta'
 import { useSecondaryCta } from '@/hooks/app-bridge/useSecondaryCta'
-import { useCallback, useEffect, useState } from 'react'
+import { selectAuthDetails } from '@/redux/features/authDetailsSlice'
+import { useCallback } from 'react'
+import { useSelector } from 'react-redux'
 
 interface DetailAppBridgeProps {
   handleTaskComplete: () => void
   isTaskCompleted: boolean
-  portalUrl?: string
 }
 
-export const ClientDetailAppBridge = ({ handleTaskComplete, isTaskCompleted, portalUrl }: DetailAppBridgeProps) => {
+export const ClientDetailAppBridge = ({ handleTaskComplete, isTaskCompleted }: DetailAppBridgeProps) => {
+  const { workspace } = useSelector(selectAuthDetails)
+  const portalUrl = workspace?.portalUrl
   const awake = useAwake()
 
   const handleMarkAsDone = useCallback(() => {

--- a/src/app/detail/ui/DetailAppBridge.tsx
+++ b/src/app/detail/ui/DetailAppBridge.tsx
@@ -4,16 +4,19 @@ import { Clickable, Icons } from '@/hooks/app-bridge/types'
 import { useActionsMenu } from '@/hooks/app-bridge/useActionsMenu'
 import { usePrimaryCta } from '@/hooks/app-bridge/usePrimaryCta'
 import { useSecondaryCta } from '@/hooks/app-bridge/useSecondaryCta'
+import { selectAuthDetails } from '@/redux/features/authDetailsSlice'
 import { setShowConfirmDeleteModal } from '@/redux/features/taskDetailsSlice'
 import store from '@/redux/store'
+import { useSelector } from 'react-redux'
 
 interface DetailAppBridgeProps {
   isArchived: boolean
   handleToggleArchive: () => void
-  portalUrl?: string
 }
 
-export const DetailAppBridge = ({ isArchived, handleToggleArchive, portalUrl }: DetailAppBridgeProps) => {
+export const DetailAppBridge = ({ isArchived, handleToggleArchive }: DetailAppBridgeProps) => {
+  const { workspace } = useSelector(selectAuthDetails)
+  const portalUrl = workspace?.portalUrl
   const handleDelete = () => store.dispatch(setShowConfirmDeleteModal())
 
   usePrimaryCta(null, { portalUrl })

--- a/src/app/detail/ui/Sidebar.tsx
+++ b/src/app/detail/ui/Sidebar.tsx
@@ -74,7 +74,6 @@ export const Sidebar = ({
   disabled,
   workflowDisabled = false,
   userType,
-  portalUrl,
   fromNotificationCenter: fromNotificationCenterProp,
 }: {
   task_id: string
@@ -86,7 +85,6 @@ export const Sidebar = ({
   disabled: boolean
   workflowDisabled?: boolean
   userType: UserType
-  portalUrl?: string
   fromNotificationCenter?: boolean
 }) => {
   const { activeTask, workflowStates, accessibleTasks, assignee, previewMode } = useSelector(selectTaskBoard)
@@ -779,7 +777,6 @@ export const Sidebar = ({
             if (!completedWorkflowState) return
             handleWorkflowStateChange(completedWorkflowState)
           }}
-          portalUrl={portalUrl}
         />
       )}
     </Box>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,12 +1,14 @@
 // export const fetchCache = 'force-no-store'
 // export const revalidate = 0
 
+import { WorkspaceFetcher } from '@/app/_fetchers/WorkspaceFetcher'
 import { ProgressLoad } from '@/components/TopLoader'
 import { InterrupCmdK } from '@/hoc/Interrupt_CmdK'
 import { swrConfig } from '@/lib/swr-config'
 import { ProviderWrapper } from '@/redux/ProviderWrapper'
 import type { Metadata } from 'next'
 import { Inter } from 'next/font/google'
+import { Suspense } from 'react'
 import { SWRConfig } from 'swr'
 import ThemeRegistry from './ThemeRegistry'
 
@@ -29,7 +31,12 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <InterrupCmdK>
           <ProviderWrapper>
             <ThemeRegistry options={{ key: 'mui' }}>
-              <SWRConfig value={swrConfig}>{children} </SWRConfig>
+              <SWRConfig value={swrConfig}>
+                <Suspense fallback={null}>
+                  <WorkspaceFetcher />
+                </Suspense>
+                {children}
+              </SWRConfig>
             </ThemeRegistry>
           </ProviderWrapper>
         </InterrupCmdK>

--- a/src/app/manage-templates/[template_id]/page.tsx
+++ b/src/app/manage-templates/[template_id]/page.tsx
@@ -1,4 +1,4 @@
-import { getAllWorkflowStates, getTokenPayload, getWorkspace } from '@/app/(home)/page'
+import { getAllWorkflowStates, getTokenPayload } from '@/app/(home)/page'
 import { ResponsiveStack } from '@/app/detail/ui/ResponsiveStack'
 import { apiUrl } from '@/config'
 import { ClientSideStateUpdate } from '@/hoc/ClientSideStateUpdate'
@@ -38,11 +38,10 @@ export default async function TaskDetailPage(props: {
   const { token } = searchParams
   const { template_id } = params
 
-  const [workflowStates, template, tokenPayload, workspace] = await Promise.all([
+  const [workflowStates, template, tokenPayload] = await Promise.all([
     getAllWorkflowStates(token),
     getTemplate(template_id, token),
     getTokenPayload(token),
-    getWorkspace(token),
   ])
 
   if (!template) {
@@ -82,7 +81,7 @@ export default async function TaskDetailPage(props: {
                   <HeaderBreadcrumbs token={token} items={breadcrumbItems} userType={UserType.INTERNAL_USER} />
                 )}
               </StyledBox>
-              <ManageTemplateDetailsAppBridge portalUrl={workspace.portalUrl} template={template} />
+              <ManageTemplateDetailsAppBridge template={template} />
               <TaskDetailsContainer
                 sx={{
                   padding: { xs: '20px 16px ', sm: '30px 20px' },

--- a/src/app/manage-templates/page.tsx
+++ b/src/app/manage-templates/page.tsx
@@ -12,7 +12,7 @@ import { MAX_FETCH_ASSIGNEE_COUNT } from '@/constants/users'
 import { CopilotAPI } from '@/utils/CopilotAPI'
 import { CreateTemplateRequest, UpdateTemplateRequest } from '@/types/dto/templates.dto'
 import { RealTimeTemplates } from '@/hoc/RealtimeTemplates'
-import { Token, TokenSchema, WorkspaceResponse } from '@/types/common'
+import { Token, TokenSchema } from '@/types/common'
 import { ManageTemplatesAppBridge } from '@/app/manage-templates/ui/ManageTemplatesAppBridge'
 import { UserRole } from '@/app/api/core/types/user'
 
@@ -52,11 +52,6 @@ async function getTokenPayload(token: string): Promise<Token> {
   return payload
 }
 
-async function getWorkspace(token: string): Promise<WorkspaceResponse> {
-  const copilot = new CopilotAPI(token)
-  return await copilot.getWorkspace()
-}
-
 interface ManageTemplatesPageProps {
   searchParams: Promise<{
     token: string
@@ -66,12 +61,11 @@ interface ManageTemplatesPageProps {
 export default async function ManageTemplatesPage(props: ManageTemplatesPageProps) {
   const searchParams = await props.searchParams
   const { token } = searchParams
-  const [workflowStates, assignee, templates, tokenPayload, workspace] = await Promise.all([
+  const [workflowStates, assignee, templates, tokenPayload] = await Promise.all([
     getAllWorkflowStates(token),
     addTypeToAssignee(await getAssigneeList(token)),
     getAllTemplates(token),
     getTokenPayload(token),
-    getWorkspace(token),
   ])
 
   return (
@@ -82,7 +76,7 @@ export default async function ManageTemplatesPage(props: ManageTemplatesPageProp
       templates={templates}
       tokenPayload={tokenPayload}
     >
-      <ManageTemplatesAppBridge token={token} role={UserRole.IU} portalUrl={workspace.portalUrl} />
+      <ManageTemplatesAppBridge token={token} role={UserRole.IU} />
       <RealTimeTemplates tokenPayload={tokenPayload} token={token}>
         <TemplateBoard
           handleCreateTemplate={async (payload: CreateTemplateRequest) => {

--- a/src/app/manage-templates/ui/ManageTemplatesAppBridge.tsx
+++ b/src/app/manage-templates/ui/ManageTemplatesAppBridge.tsx
@@ -4,19 +4,21 @@ import { Icons } from '@/hooks/app-bridge/types'
 import { useActionsMenu } from '@/hooks/app-bridge/useActionsMenu'
 import { useBreadcrumbs } from '@/hooks/app-bridge/useBreadcrumbs'
 import { usePrimaryCta } from '@/hooks/app-bridge/usePrimaryCta'
+import { selectAuthDetails } from '@/redux/features/authDetailsSlice'
 import { setShowTemplateModal } from '@/redux/features/templateSlice'
 import store from '@/redux/store'
 import { TargetMethod } from '@/types/interfaces'
 import { UserRole } from '@api/core/types/user'
-import { useRouter } from 'next/navigation'
+import { useSelector } from 'react-redux'
 
 interface TaskBoardAppBridgeProps {
   token: string
   role: UserRole
-  portalUrl?: string
 }
 
-export const ManageTemplatesAppBridge = ({ token, role, portalUrl }: TaskBoardAppBridgeProps) => {
+export const ManageTemplatesAppBridge = ({ token, role }: TaskBoardAppBridgeProps) => {
+  const { workspace } = useSelector(selectAuthDetails)
+  const portalUrl = workspace?.portalUrl
   const handleTemplateCreate = () => {
     store.dispatch(setShowTemplateModal({ targetMethod: TargetMethod.POST }))
   }

--- a/src/app/manage-templates/ui/ManageTemplatesDetailsAppBridge.tsx
+++ b/src/app/manage-templates/ui/ManageTemplatesDetailsAppBridge.tsx
@@ -3,20 +3,22 @@
 import { Clickable, Icons } from '@/hooks/app-bridge/types'
 import { useActionsMenu } from '@/hooks/app-bridge/useActionsMenu'
 import { useAwake } from '@/hooks/app-bridge/useAwake'
-import { useBreadcrumbs } from '@/hooks/app-bridge/useBreadcrumbs'
 import { usePrimaryCta } from '@/hooks/app-bridge/usePrimaryCta'
+import { selectAuthDetails } from '@/redux/features/authDetailsSlice'
 import { setShowConfirmDeleteModal } from '@/redux/features/taskDetailsSlice'
 import { setCreateTemplateFields, setTargetTemplateId } from '@/redux/features/templateSlice'
 import store from '@/redux/store'
 import { ITemplate } from '@/types/interfaces'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback } from 'react'
+import { useSelector } from 'react-redux'
 
 interface ManageTemplateDetailsAppBridgeProps {
-  portalUrl?: string
   template: ITemplate
 }
 
-export const ManageTemplateDetailsAppBridge = ({ portalUrl, template }: ManageTemplateDetailsAppBridgeProps) => {
+export const ManageTemplateDetailsAppBridge = ({ template }: ManageTemplateDetailsAppBridgeProps) => {
+  const { workspace } = useSelector(selectAuthDetails)
+  const portalUrl = workspace?.portalUrl
   const awake = useAwake()
 
   const handleDeleteTemplate = useCallback(() => {

--- a/src/app/ui/TaskBoard.tsx
+++ b/src/app/ui/TaskBoard.tsx
@@ -16,7 +16,6 @@ import { TaskDragPreview } from '@/hoc/dndKit/TaskDragPreview'
 import { useFilter } from '@/hooks/useFilter'
 import { selectTaskBoard, updateWorkflowStateIdByTaskId } from '@/redux/features/taskBoardSlice'
 import store from '@/redux/store'
-import { WorkspaceResponse } from '@/types/common'
 import { TaskResponse } from '@/types/dto/tasks.dto'
 import { WorkflowStateResponse } from '@/types/dto/workflowStates.dto'
 import { View } from '@/types/interfaces'
@@ -32,11 +31,10 @@ import { z } from 'zod'
 
 interface TaskBoardProps {
   mode: UserRole
-  workspace?: WorkspaceResponse
   token: string
 }
 
-export const TaskBoard = ({ mode, workspace, token }: TaskBoardProps) => {
+export const TaskBoard = ({ mode, token }: TaskBoardProps) => {
   const {
     workflowStates,
     tasks,
@@ -162,7 +160,7 @@ export const TaskBoard = ({ mode, workspace, token }: TaskBoardProps) => {
     <>
       <TaskDataFetcher token={token} />
 
-      {mode == UserRole.IU && <TaskBoardAppBridge token={token} role={UserRole.IU} portalUrl={workspace?.portalUrl} />}
+      {mode == UserRole.IU && <TaskBoardAppBridge token={token} role={UserRole.IU} />}
 
       {/* Filterbars */}
       <FilterBar mode={mode} />

--- a/src/app/ui/TaskBoardAppBridge.tsx
+++ b/src/app/ui/TaskBoardAppBridge.tsx
@@ -6,20 +6,23 @@ import { useAwake } from '@/hooks/app-bridge/useAwake'
 import { useBreadcrumbs } from '@/hooks/app-bridge/useBreadcrumbs'
 import { usePrimaryCta } from '@/hooks/app-bridge/usePrimaryCta'
 import { useSecondaryCta } from '@/hooks/app-bridge/useSecondaryCta'
+import { selectAuthDetails } from '@/redux/features/authDetailsSlice'
 import { setShowModal } from '@/redux/features/createTaskSlice'
 import store from '@/redux/store'
 import { UserRole } from '@api/core/types/user'
 import { useRouter } from 'next/navigation'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback } from 'react'
+import { useSelector } from 'react-redux'
 
 interface TaskBoardAppBridgeProps {
   token: string
   role: UserRole
-  portalUrl?: string
   isTaskBoardEmpty?: boolean
 }
 
-export const TaskBoardAppBridge = ({ token, role, portalUrl, isTaskBoardEmpty = false }: TaskBoardAppBridgeProps) => {
+export const TaskBoardAppBridge = ({ token, role, isTaskBoardEmpty = false }: TaskBoardAppBridgeProps) => {
+  const { workspace } = useSelector(selectAuthDetails)
+  const portalUrl = workspace?.portalUrl
   const router = useRouter()
   const awake = useAwake()
 

--- a/src/components/layouts/HeaderBreadcrumbs.tsx
+++ b/src/components/layouts/HeaderBreadcrumbs.tsx
@@ -4,6 +4,7 @@ import { StyledKeyboardIcon, StyledTypography } from '@/app/detail/ui/styledComp
 import { SecondaryBtn } from '@/components/buttons/SecondaryBtn'
 import { CustomLink } from '@/hoc/CustomLink'
 import { useBreadcrumbs } from '@/hooks/app-bridge/useBreadcrumbs'
+import { selectAuthDetails } from '@/redux/features/authDetailsSlice'
 import { selectTaskBoard } from '@/redux/features/taskBoardSlice'
 import { UserType } from '@/types/interfaces'
 import { Stack, Typography } from '@mui/material'
@@ -17,14 +18,14 @@ export const HeaderBreadcrumbs = ({
   token,
   items,
   userType,
-  portalUrl,
 }: {
   token: string | undefined
   items: { label: string; href?: string }[]
   userType: UserType
-  portalUrl?: string
 }) => {
   const { previewMode } = useSelector(selectTaskBoard)
+  const { workspace } = useSelector(selectAuthDetails)
+  const portalUrl = workspace?.portalUrl
   const router = useRouter()
 
   const getTasksLink = (userType: UserType): ValidTasksBoardLink => {

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -94,9 +94,6 @@ export const ClientResponseSchema = z.object({
   companyIds: z.array(z.string().uuid()).optional(),
   status: z.string(),
   avatarImageUrl: z.string().nullable(),
-  // customFields: z
-  //   .record(z.string(), z.union([z.string().nullable(), z.array(z.string()).nullable(), z.object({}).nullable()]))
-  //   .nullable(),
   fallbackColor: z.string().nullish(),
   createdAt: z.string().datetime(),
 })

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -94,9 +94,9 @@ export const ClientResponseSchema = z.object({
   companyIds: z.array(z.string().uuid()).optional(),
   status: z.string(),
   avatarImageUrl: z.string().nullable(),
-  customFields: z
-    .record(z.string(), z.union([z.string().nullable(), z.array(z.string()).nullable(), z.object({}).nullable()]))
-    .nullable(),
+  // customFields: z
+  //   .record(z.string(), z.union([z.string().nullable(), z.array(z.string()).nullable(), z.object({}).nullable()]))
+  //   .nullable(),
   fallbackColor: z.string().nullish(),
   createdAt: z.string().datetime(),
 })

--- a/src/utils/copilotMemo.ts
+++ b/src/utils/copilotMemo.ts
@@ -1,0 +1,8 @@
+import { CopilotAPI } from '@/utils/CopilotAPI'
+import { WorkspaceResponse } from '@/types/common'
+import { cache } from 'react'
+
+export const getMemoizedWorkspace = cache(async (token: string): Promise<WorkspaceResponse> => {
+  const copilot = new CopilotAPI(token)
+  return copilot.getWorkspace()
+})


### PR DESCRIPTION
## Summary

resolves OUT-3705 [OUT-3705: Optimize workspace to be fetched once per session](https://linear.app/assemblycom/issue/OUT-3705/optimize-workspace-to-be-fetched-once-per-session)

- [x] Fetch workspace on client side and once per session
- [x] Update rest of the codebase to use portalUrl from store rather than props.
- [x] For subtasks we get the details of both tasks with single query instead of multiple 
- [x] resolves OUT-3695 [OUT-3695: Remove customFields from clients response](https://linear.app/assemblycom/issue/OUT-3695/remove-customfields-from-clients-response)

## Test plan

- [x] App boots, workspace data appears in redux after first paint
- [x] Detail page: sidebar + header breadcrumbs render correctly with `portalUrl`-dependent CTAs
- [x] Home / client board: app bridges (CTAs, breadcrumbs) work
- [x] Manage templates list + detail: app bridges work
- [x] First-paint flash on `portalUrl`-dependent UI is not visually disruptive
- [x] Subtask detail page: ancestor breadcrumbs render in correct root → leaf order (parent tasks ordering fix)


https://github.com/user-attachments/assets/42d86a99-eb06-4711-a61d-655282705d09



🤖 Generated with [Claude Code](https://claude.com/claude-code)