### PR TITLE
OUT-3661 | Limited access IUs shouldn't see tasks that are associated with clients/companies beyond their access list

### DIFF
--- a/prisma/migrations/20260507083136_associations_jsonb_array_to_jsonb/migration.sql
+++ b/prisma/migrations/20260507083136_associations_jsonb_array_to_jsonb/migration.sql
@@ -1,0 +1,9 @@
+-- Convert "Tasks"."associations" from jsonb[] (Postgres array of jsonb) to jsonb (single jsonb holding an array).
+-- Existing values are preserved: to_jsonb() turns the postgres array into an equivalent jsonb array.
+-- Any NULL rows are coalesced to '[]'.
+ALTER TABLE "Tasks"
+  ALTER COLUMN "associations" DROP DEFAULT,
+  ALTER COLUMN "associations" TYPE JSONB
+    USING coalesce(to_jsonb("associations"), '[]'::jsonb),
+  ALTER COLUMN "associations" SET DEFAULT '[]'::jsonb,
+  ALTER COLUMN "associations" SET NOT NULL;

--- a/prisma/schema/task.prisma
+++ b/prisma/schema/task.prisma
@@ -58,7 +58,7 @@ model Task {
 
   taskUpdateBacklogs TaskUpdateBacklog[]
 
-  associations       Json[]      @db.JsonB @default([])
+  associations       Json        @db.JsonB @default("[]")
   isShared           Boolean     @default(false)
 
   @@index([path], type: Gist)

--- a/src/app/api/comments/comment.service.ts
+++ b/src/app/api/comments/comment.service.ts
@@ -2,7 +2,7 @@ import { AttachmentsService } from '@/app/api/attachments/attachments.service'
 import { PublicCommentSerializer } from '@/app/api/comments/public/public.serializer'
 import { sendCommentCreateNotifications } from '@/jobs/notifications'
 import { sendReplyCreateNotifications } from '@/jobs/notifications/send-reply-create-notifications'
-import { InitiatedEntity, TempClientFilter } from '@/types/common'
+import { InitiatedEntity } from '@/types/common'
 import { CreateAttachmentRequestSchema } from '@/types/dto/attachments.dto'
 import { CommentsPublicFilterType, CommentWithAttachments, CreateComment, UpdateComment } from '@/types/dto/comment.dto'
 import { DISPATCHABLE_EVENT } from '@/types/webhook'
@@ -479,14 +479,17 @@ export class CommentService extends BaseService {
         { companyId, clientId: null },
       )
       if (includeAssociatedTask) {
-        const tempClientFilter: TempClientFilter = {
-          associations: {
-            hasSome: [{ clientId, companyId }, { companyId }],
-          },
+        // Match tasks associated with this specific client+company OR with the company at large.
+        // `equals` preserves the prior exact-match semantics.
+        const associationVariants: Prisma.TaskWhereInput[] = [
+          { associations: { equals: [{ clientId, companyId }] } },
+          { associations: { equals: [{ companyId }] } },
+        ]
+        if (isCuPortal) {
+          filters.push({ OR: associationVariants, isShared: true })
+        } else {
+          filters.push(...associationVariants)
         }
-        if (isCuPortal) tempClientFilter.isShared = true
-        // Get tasks that includes the client as a association
-        filters.push(tempClientFilter)
       }
     } else if (companyId) {
       filters.push(
@@ -494,15 +497,16 @@ export class CommentService extends BaseService {
         { clientId: null, companyId },
       )
 
-      // Get tasks that includes the company as a association
+      // Get tasks that include the company as an association
       if (includeAssociatedTask) {
-        const tempCompanyFilter: TempClientFilter = {
-          associations: {
-            hasSome: [{ companyId }],
-          },
+        const companyAssociationFilter: Prisma.TaskWhereInput = {
+          associations: { equals: [{ companyId }] },
         }
-        if (isCuPortal) tempCompanyFilter.isShared = true
-        filters.push(tempCompanyFilter)
+        if (isCuPortal) {
+          filters.push({ ...companyAssociationFilter, isShared: true })
+        } else {
+          filters.push(companyAssociationFilter)
+        }
       }
 
       // OUT-2898: When an IU is previewing a company in the CRM, also include
@@ -513,11 +517,13 @@ export class CommentService extends BaseService {
         if (companyClientIds.length > 0) {
           filters.push({ clientId: { in: companyClientIds }, companyId })
           if (includeAssociatedTask) {
-            filters.push({
-              associations: {
-                hasSome: companyClientIds.map((cId) => ({ clientId: cId, companyId })),
-              },
-            })
+            // Match tasks whose single association is `{clientId, companyId}` for any client of this company.
+            // `equals` preserves the prior `hasSome` exact-match semantics.
+            filters.push(
+              ...companyClientIds.map((cId) => ({
+                associations: { equals: [{ clientId: cId, companyId }] } as Prisma.JsonFilter,
+              })),
+            )
           }
         }
       }

--- a/src/app/api/tasks/public/public.service.ts
+++ b/src/app/api/tasks/public/public.service.ts
@@ -283,7 +283,7 @@ export class PublicTasksService extends TasksSharedService {
     prevAssociations,
     associationsResetCondition,
   }: {
-    prevAssociations: Prisma.JsonValue[]
+    prevAssociations: Prisma.JsonValue
     associationsResetCondition: boolean
   }) {
     let associations: Associations = AssociationsSchema.parse(prevAssociations)

--- a/src/app/api/tasks/subtasks.service.ts
+++ b/src/app/api/tasks/subtasks.service.ts
@@ -20,7 +20,7 @@ interface Assignable {
   internalUserId: string | null
   clientId: string | null
   companyId: string | null
-  associations: JsonValue[]
+  associations: JsonValue
   isShared: boolean
 }
 

--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -555,9 +555,7 @@ export class TasksService extends TasksSharedService {
           { assigneeId, assigneeType: AssigneeType.company },
           { companyId: assigneeId, clientId: null },
           {
-            associations: {
-              hasSome: [{ clientId: null, companyId: assigneeId }],
-            },
+            associations: { equals: [{ clientId: null, companyId: assigneeId }] },
           },
         ],
         workflowState: { type: { not: StateType.completed } },
@@ -591,7 +589,10 @@ export class TasksService extends TasksSharedService {
   async resetAllSharedTasks(assigneeId: string) {
     const tasks = await this.db.task.findMany({
       where: {
-        associations: { hasSome: [{ clientId: assigneeId }, { companyId: assigneeId }] },
+        OR: [
+          { associations: { equals: [{ clientId: assigneeId }] } },
+          { associations: { equals: [{ companyId: assigneeId }] } },
+        ],
         workspaceId: this.user.workspaceId,
       },
     })

--- a/src/app/api/tasks/tasksShared.service.ts
+++ b/src/app/api/tasks/tasksShared.service.ts
@@ -1,6 +1,6 @@
 import { maxSubTaskDepth } from '@/constants/tasks'
 import { MAX_FETCH_ASSIGNEE_COUNT } from '@/constants/users'
-import { InternalUsers, TempClientFilter, Uuid } from '@/types/common'
+import { InternalUsers, Uuid } from '@/types/common'
 import { CreateAttachmentRequestSchema } from '@/types/dto/attachments.dto'
 import {
   CreateTaskRequest,
@@ -68,16 +68,38 @@ export abstract class TasksSharedService extends BaseService {
       if (currentInternalUser.isClientAccessLimited) {
         const companyAccessList = currentInternalUser.companyAccessList || []
         return {
-          OR: [
-            { internalUserId: { not: null } },
-            { internalUserId: null, clientId: null, companyId: null },
-            { companyId: { in: companyAccessList } },
+          AND: [
+            {
+              OR: [
+                { internalUserId: { not: null } },
+                { internalUserId: null, clientId: null, companyId: null },
+                { companyId: { in: companyAccessList } },
+              ],
+            },
+            this.getAccessibleAssociationsFilter(companyAccessList),
           ],
         }
       }
     }
 
     return {}
+  }
+
+  /**
+   * Prisma where fragment matching tasks whose `associations` is empty OR whose single association
+   * references a company within the access list. Uses `array_contains` (Postgres `@>`) so the
+   * `{companyId}` filter matches both stored `{companyId}` and `{clientId, companyId}` shapes.
+   * Relies on `AssociationsSchema.max(1)` — with a single element, "contains companyId" ≡ "all in scope".
+   */
+  private getAccessibleAssociationsFilter(companyAccessList: string[]): Prisma.TaskWhereInput {
+    return {
+      OR: [
+        { associations: { equals: [] } },
+        ...companyAccessList.map((companyId) => ({
+          associations: { array_contains: [{ companyId }] } as Prisma.JsonFilter,
+        })),
+      ],
+    }
   }
 
   protected async getClientOrCompanyAssigneeFilter(includeAssociatedTask: boolean = true): Promise<Prisma.TaskWhereInput> {
@@ -96,15 +118,20 @@ export abstract class TasksSharedService extends BaseService {
         { companyId, clientId: null },
       )
 
-      // Get tasks that includes the client as a association
+      // Get tasks that include the client as an association
       if (includeAssociatedTask) {
-        const tempClientFilter: TempClientFilter = {
-          associations: {
-            hasSome: [{ clientId, companyId }, { companyId }],
-          },
+        // Match tasks associated with this specific client+company OR with the company at large.
+        // `equals` preserves the prior exact-match semantics: tasks associated with a DIFFERENT
+        // client at the same company do not match.
+        const associationVariants: Prisma.TaskWhereInput[] = [
+          { associations: { equals: [{ clientId, companyId }] } },
+          { associations: { equals: [{ companyId }] } },
+        ]
+        if (isCuPortal) {
+          filters.push({ OR: associationVariants, isShared: true })
+        } else {
+          filters.push(...associationVariants)
         }
-        if (isCuPortal) tempClientFilter.isShared = true
-        filters.push(tempClientFilter)
       }
     } else if (companyId) {
       filters.push(
@@ -112,14 +139,14 @@ export abstract class TasksSharedService extends BaseService {
         { clientId: null, companyId },
       )
       if (includeAssociatedTask) {
-        const tempCompanyFilter: TempClientFilter = {
-          associations: {
-            hasSome: [{ companyId }],
-          },
+        const companyAssociationFilter: Prisma.TaskWhereInput = {
+          associations: { equals: [{ companyId }] },
         }
-        if (isCuPortal) tempCompanyFilter.isShared = true
-        // Get tasks that includes the company as a viewer
-        filters.push(tempCompanyFilter)
+        if (isCuPortal) {
+          filters.push({ ...companyAssociationFilter, isShared: true })
+        } else {
+          filters.push(companyAssociationFilter)
+        }
       }
 
       // OUT-2898: When an IU is previewing a company in the CRM, also include
@@ -130,11 +157,13 @@ export abstract class TasksSharedService extends BaseService {
         if (companyClientIds.length > 0) {
           filters.push({ clientId: { in: companyClientIds }, companyId })
           if (includeAssociatedTask) {
-            filters.push({
-              associations: {
-                hasSome: companyClientIds.map((cId) => ({ clientId: cId, companyId })),
-              },
-            })
+            // Match tasks whose single association is `{clientId, companyId}` for any client of this company.
+            // `equals` preserves the prior `hasSome` exact-match semantics.
+            filters.push(
+              ...companyClientIds.map((cId) => ({
+                associations: { equals: [{ clientId: cId, companyId }] } as Prisma.JsonFilter,
+              })),
+            )
           }
         }
       }
@@ -175,14 +204,21 @@ export abstract class TasksSharedService extends BaseService {
         if (!currentInternalUser.isClientAccessLimited) return {}
 
         const accesibleCompanyIds = currentInternalUser.companyAccessList || []
+        // Use a single `parent: {}` relation filter — splitting into two separate `parent: {}`
+        // references at this OR level causes Prisma to emit multiple parent joins and the
+        // matching subtask row gets returned twice.
         return {
           OR: [
             {
-              parent: { companyId: { notIn: accesibleCompanyIds } },
+              parent: {
+                OR: [
+                  { companyId: { notIn: accesibleCompanyIds } },
+                  // Parent inaccessible because its association is outside the access list
+                  { NOT: this.getAccessibleAssociationsFilter(accesibleCompanyIds) },
+                ],
+              },
             },
-            {
-              parentId: null,
-            },
+            { parentId: null },
           ],
         }
       }
@@ -213,14 +249,19 @@ export abstract class TasksSharedService extends BaseService {
                   ],
                 },
                 {
+                  // AND do not disjoint if parent is accessible to the client through association.
+                  // Uses `equals` (full-array exact match) to preserve the prior `hasSome` semantics
+                  // — tasks associated with a different client at the same company do not match.
                   NOT: {
-                    associations: {
-                      hasSome: [
-                        { clientId: this.user.clientId, companyId: this.user.companyId },
-                        { companyId: this.user.companyId },
-                      ],
-                    },
-                  }, //AND do not disjoint if parent is accesible to the client through client visibility.
+                    OR: [
+                      {
+                        associations: {
+                          equals: [{ clientId: this.user.clientId, companyId: this.user.companyId }],
+                        },
+                      },
+                      { associations: { equals: [{ companyId: this.user.companyId }] } },
+                    ],
+                  },
                 },
               ],
             },
@@ -245,22 +286,34 @@ export abstract class TasksSharedService extends BaseService {
     if (isLimitedTask) {
       throw new APIError(
         httpStatus.UNAUTHORIZED,
-        "This task's assignee is not included in your list of accessible clients / companies",
+        "This task's assignee or association is not included in your list of accessible clients / companies",
       )
     }
   }
 
   protected async filterTasksByClientAccess<T extends Task>(tasks: T[], currentInternalUser: InternalUsers): Promise<T[]> {
-    const hasClientOrCompanyTasks = tasks.some((task) => task.companyId)
+    const hasClientOrCompanyTasks = tasks.some(
+      (task) => task.companyId || (Array.isArray(task.associations) && task.associations.length > 0),
+    )
     if (!hasClientOrCompanyTasks) {
       return tasks
     }
 
+    const companyAccessList = currentInternalUser.companyAccessList || []
+
     return tasks.filter((task) => {
-      // Pass all tasks that are unassigned or are assigned to IU
-      if ((!task.internalUserId && !task.clientId && !task.companyId) || task.internalUserId) return true
-      // For remaining client or company tasks, check if companyAccessList includes this companyId
-      return currentInternalUser.companyAccessList?.includes(task.companyId || '')
+      // If task is assigned to a client/company, the assignee company must be in access list
+      if (task.companyId && !companyAccessList.includes(task.companyId)) {
+        return false
+      }
+      // If task is associated with a client/company, every association's company must be in access list
+      const associations = AssociationsSchema.parse(task.associations) || []
+      for (const association of associations) {
+        if (!companyAccessList.includes(association.companyId)) {
+          return false
+        }
+      }
+      return true
     })
   }
 
@@ -601,7 +654,7 @@ export abstract class TasksSharedService extends BaseService {
     if (!finalIsShared) return false
 
     const hasInternalUser = !!finalInternalUser
-    const hasAssociations = !!finalAssociations?.length
+    const hasAssociations = Array.isArray(finalAssociations) && finalAssociations.length > 0
 
     if (!hasInternalUser || !hasAssociations) {
       throw new APIError(

--- a/src/app/api/tasks/tasksShared.service.ts
+++ b/src/app/api/tasks/tasksShared.service.ts
@@ -306,9 +306,11 @@ export abstract class TasksSharedService extends BaseService {
       if (task.companyId && !companyAccessList.includes(task.companyId)) {
         return false
       }
-      // If task is associated with a client/company, every association's company must be in access list
-      const associations = AssociationsSchema.parse(task.associations) || []
-      for (const association of associations) {
+      // If task is associated with a client/company, every association's company must be in access list.
+      // Fail closed on malformed `associations` rows so a single bad row can't tank the whole batch read.
+      const parsed = AssociationsSchema.safeParse(task.associations)
+      if (!parsed.success) return false
+      for (const association of parsed.data || []) {
         if (!companyAccessList.includes(association.companyId)) {
           return false
         }

--- a/src/app/api/webhook/webhook.service.ts
+++ b/src/app/api/webhook/webhook.service.ts
@@ -217,9 +217,7 @@ class WebhookService extends BaseService {
     // Find and reset tasks shared to previous company+client
     const prevSharedTasks = await this.db.task.findMany({
       where: {
-        associations: {
-          hasSome: [{ clientId, companyId: prevCompanyId }],
-        },
+        associations: { equals: [{ clientId, companyId: prevCompanyId }] },
         workspaceId: this.user.workspaceId,
       },
       select: { id: true },

--- a/src/hooks/useFilter.tsx
+++ b/src/hooks/useFilter.tsx
@@ -187,7 +187,11 @@ export const useFilter = (filterOptions: IFilterOptions, isPreviewMode: boolean)
     if (hasActiveFilter) {
       const subtasks = accessibleTasks.filter((t) => !!t.parentId && (t.isArchived ? showArchived : showUnarchived))
       const matchingSubtasks = applyFilters(subtasks, filterOptions)
-      standaloneSubtasks = matchingSubtasks.filter((t) => !filteredParentIds.has(t.parentId!))
+      // Also exclude subtasks already present in `filteredParentTasks` (e.g. limited-IU disjoint
+      // subtasks promoted to root in `tasks`), otherwise they'd appear twice on the board.
+      standaloneSubtasks = matchingSubtasks.filter(
+        (t) => !filteredParentIds.has(t.parentId!) && !filteredParentIds.has(t.id),
+      )
     }
 
     const filteredTasks = [...filteredParentTasks, ...standaloneSubtasks]

--- a/src/lib/realtime.ts
+++ b/src/lib/realtime.ts
@@ -50,6 +50,23 @@ export class RealtimeHandler {
   } //check if the task incoming from realtime includes the logged in client as a viewer.
 
   /**
+   * Returns true if `associations` contains any entry whose companyId is not in the access list.
+   * Mirrors the association check in `filterTasksByClientAccess` (tasksShared.service.ts) so that
+   * realtime decisions stay consistent with the API filter.
+   */
+  private hasInaccessibleAssociation(associations: unknown, companyAccessList: string[]): boolean {
+    if (!Array.isArray(associations)) return false
+    for (const association of associations) {
+      if (!association || typeof association !== 'object') continue
+      const companyId = (association as { companyId?: string }).companyId
+      if (companyId && !companyAccessList.includes(companyId)) {
+        return true
+      }
+    }
+    return false
+  }
+
+  /**
    * Filters out tasks this user type does not have access to
    */
   private isSubtaskAccessible(newTask: RealTimeTaskResponse): boolean {
@@ -70,6 +87,10 @@ export class RealtimeHandler {
           if (!companyAccessList.includes(newTask.assigneeId)) {
             return false
           }
+        }
+        // Reject tasks (incl. those assigned to an IU) whose associations are out of scope
+        if (this.hasInaccessibleAssociation(newTask.associations, companyAccessList)) {
+          return false
         }
       }
     } else if (this.userRole === AssigneeType.client) {
@@ -226,8 +247,13 @@ export class RealtimeHandler {
     if (this.userRole === AssigneeType.internalUser) {
       const iu = InternalUsersSchema.parse(this.user)
       // If the user has limited client access, and this task is outside of it, return
-      if (iu.isClientAccessLimited && newTask.companyId && !iu.companyAccessList!.includes(newTask.companyId)) {
-        return
+      if (iu.isClientAccessLimited) {
+        const companyAccessList = iu.companyAccessList || []
+        const isAssigneeOutOfScope = !!newTask.companyId && !companyAccessList.includes(newTask.companyId)
+        const isAssociationOutOfScope = this.hasInaccessibleAssociation(newTask.associations, companyAccessList)
+        if (isAssigneeOutOfScope || isAssociationOutOfScope) {
+          return
+        }
       }
     }
     // --- Client
@@ -300,10 +326,16 @@ export class RealtimeHandler {
     const isReassignedOutOfLimitedIUScope = (() => {
       if (this.userRole !== AssigneeType.internalUser) return false
       const iu = InternalUsersSchema.parse(this.user)
+      if (!iu.isClientAccessLimited) return false
+      const companyAccessList = iu.companyAccessList || []
+      // Out of scope via association: applies even when assignee is an IU or unassigned
+      if (this.hasInaccessibleAssociation(updatedTask.associations, companyAccessList)) {
+        return true
+      }
       if (updatedTask.internalUserId || !updatedTask.assigneeId) {
         return false
       }
-      return iu.isClientAccessLimited && !iu.companyAccessList?.includes(updatedTask.companyId || '__')
+      return !companyAccessList.includes(updatedTask.companyId || '__')
     })()
 
     if (isReassignedOutOfClientScope || isReassignedOutOfLimitedIUScope) {
@@ -337,11 +369,17 @@ export class RealtimeHandler {
 
     const isReassignedIntoLimitedIUScope = (() => {
       if (this.userRole !== AssigneeType.internalUser) return false
+      const iu = InternalUsersSchema.parse(this.user)
+      if (!iu.isClientAccessLimited) return false
+      const companyAccessList = iu.companyAccessList || []
+      // Even when assigned to an IU or unassigned, an out-of-scope association makes it inaccessible
+      if (this.hasInaccessibleAssociation(updatedTask.associations, companyAccessList)) {
+        return false
+      }
       if (updatedTask.internalUserId || !updatedTask.assigneeId) {
         return true
       }
-      const iu = InternalUsersSchema.parse(this.user)
-      return iu.isClientAccessLimited && iu.companyAccessList?.includes(updatedTask.companyId || '__')
+      return companyAccessList.includes(updatedTask.companyId || '__')
     })()
 
     if (isReassignedIntoClientScope || isReassignedIntoLimitedIUScope) {


### PR DESCRIPTION
## Summary
Closes [OUT-3661](https://linear.app/assemblycom/issue/OUT-3661/limited-access-ius-shouldnt-see-tasks-that-are-associated-with).

Limited-access IUs were filtered only by task **assignee** company. Tasks merely **associated** with an out-of-scope client/company still leaked through. This PR closes that gap across the API, cascade SQL, and realtime paths.

To make the SQL filter clean and avoid expensive Copilot SDK enumeration of all clients/companies, `Tasks.associations` is migrated from `jsonb[]` to `jsonb` (still holding an array). That unlocks Prisma's `array_contains` (`@>` containment), which lets us match associations by `companyId` directly using `companyAccessList`.

## Schema + migration
- `Tasks.associations` column: `jsonb[]` → `jsonb`
- Single in-place migration with `USING coalesce(to_jsonb(associations), '[]'::jsonb)` — Postgres rewrites every row during `ALTER`. No separate app-side backfill. JS shape (`[{clientId?, companyId}]`) is preserved across the migration.
- AccessExclusiveLock duration ~ a few seconds at ~80k rows.

## Core fix (`tasksShared.service.ts`)
- `filterTasksByClientAccess` now also rejects tasks whose `associations` reference a company outside `companyAccessList` — this is the actual user-visible fix for the read path.
- `getAccessFilterForTasks` ANDs the new `getAccessibleAssociationsFilter` for limited IUs, so cascade workflow updates and subtask counts stay in sync with the read filter.
- `getDisjointTasksFilter` (limited IU branch) treats a parent as inaccessible when its associations are out of scope. Combined into one `parent: { OR: [...] }` to avoid Prisma double-joining the parent relation.
- New helper `getAccessibleAssociationsFilter` uses `array_contains` (Postgres `@>`) for partial-match — `{companyId: cid}` matches both stored `{companyId}` and `{clientId, companyId}` shapes without needing to enumerate clientIds.
- Existing `hasSome` filters (which relied on jsonb exact-element equality) converted to `OR: [{equals: ...}, ...]`. Behavior is identical for `max=1` arrays — semantics-preserving.
- `validateTaskShare` updated for the new `Json` (single) shape with an `Array.isArray` guard.

## `hasSome` → `equals` conversions in adjacent files
Mechanical, semantics-preserving:
- `src/app/api/tasks/tasks.service.ts` — `getIncompleteTasksForCompany`, `resetAllSharedTasks`
- `src/app/api/comments/comment.service.ts` — three CU/CRM filter sites
- `src/app/api/webhook/webhook.service.ts` — `handleCompanyUnassignment`
- OUT-2898's IU-company-preview filters in `tasksShared` and `comment` services

## Realtime sync (`src/lib/realtime.ts`)
Realtime guardrails for limited IUs only checked `task.companyId`. Now also check `associations` so a task with `companyId = null` but an out-of-scope association can no longer slip into the store via realtime.
- New private helper `hasInaccessibleAssociation` mirrors the API filter.
- Four call sites updated: `isSubtaskAccessible`, `handleRealtimeTaskInsert` guardrail, `isReassignedOutOfLimitedIUScope`, `isReassignedIntoLimitedIUScope`.

## Disjoint duplicate fix (`src/hooks/useFilter.tsx`)
Pre-existing latent bug: limited-IU disjoint-promoted subtasks rendered twice in the board after AllTasksFetcher Suspense resolved (the "second card appears with a delay" symptom). The standalone-subtasks dedup checked only `parentId`. Now also checks the subtask's own `id`, so a task that's already in `filteredParentTasks` (via disjoint promotion) isn't re-added as a standalone.

## Type tightening
- `src/app/api/tasks/subtasks.service.ts`: `JsonValue[]` → `JsonValue`
- `src/app/api/tasks/public/public.service.ts`: `Prisma.JsonValue[]` → `Prisma.JsonValue`

## Pre-existing oddities preserved (NOT introduced or worsened by this PR — worth a follow-up ticket)
- `getIncompleteTasksForCompany` filters for `{clientId: null, companyId}` but stored objects don't store `null` clientIds (the key is either present with a UUID or absent) — this branch likely never matches.
- `resetAllSharedTasks` filters for `{clientId: assigneeId}` (no companyId) but `companyId` is required by `AssociationSchema` — that half of the OR likely never matches.

Both behaviors carried over identically.

## Test plan
- [x] As a limited-access IU, view the board with a task assigned to a teammate IU but associated with an out-of-scope CU — should NOT appear (was the OUT-3661 repro).
- [x] As a limited-access IU, view a parent task that is inaccessible (out-of-scope companyId or out-of-scope association) with an accessible subtask — the subtask appears at root level **exactly once** (was duplicated).
- [x] As a limited-access IU, watch the board while another session creates an inaccessible-via-association task — does NOT appear via realtime.
- [x] As a limited-access IU, when a task on your board is updated to add an out-of-scope association — task is removed from the board via realtime.
- [x] As a CU, verify you do NOT see tasks associated with another client at the same company (security-critical: `equals` preserves the prior `hasSome` strict-match semantics).
- [x] As a CU, verify you DO see tasks shared with you (`{clientId, companyId}` association) and tasks associated company-wide (`{companyId}` association).
- [x] CRM IU previewing a client — tasks for that client appear, including shared tasks.
- [x] CRM IU previewing a company — tasks for that company AND tasks for clients within that company appear (OUT-2898 behavior preserved).
- [x] Full-access IU — board behavior unchanged.


## Testing 

- [LOOM](https://www.loom.com/share/337cff7473ba442d97bc3f082f405da5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)