### PR TITLE
OUT-3660 | User icon should switch instantly when task is reassigned

### DIFF
--- a/src/app/detail/ui/TaskCardList.tsx
+++ b/src/app/detail/ui/TaskCardList.tsx
@@ -186,7 +186,9 @@ export const TaskCardList = ({
       return NoAssignee
     }
     const assigneeId = getAssigneeId(userIds)
-    const match = assignee.find((assignee) => assignee.id === assigneeId)
+    const match = assignee.find((a) =>
+      userIds.clientId ? a.id === assigneeId && a.companyId === userIds.companyId : a.id === assigneeId,
+    )
     return match ?? NoAssignee
   }
 

--- a/src/app/detail/ui/TaskCardList.tsx
+++ b/src/app/detail/ui/TaskCardList.tsx
@@ -133,11 +133,13 @@ export const TaskCardList = ({
     const hasNoAssignee = !internalUserId && !isAssigneeClient
     const associations = isAssigneeClient ? [] : undefined
     const isShared = hasNoAssignee || isAssigneeClient ? false : undefined
+    const nextAssignee = getAssigneeValue(userIds)
     store.dispatch(setConfirmAssigneeModalId(undefined))
     store.dispatch(setConfirmAssociationModalId(undefined))
+    setAssigneeValue(nextAssignee)
     if (handleUpdate) {
       token &&
-        handleUpdate(task.id, { internalUserId, clientId, companyId }, () =>
+        handleUpdate(task.id, { assigneeId: getAssigneeId(userIds), internalUserId, clientId, companyId }, () =>
           updateAssignee(token, task.id, internalUserId, clientId, companyId, associations, isShared),
         )
     } else {
@@ -169,7 +171,7 @@ export const TaskCardList = ({
       const isShared = hasNoAssignee || isAssigneeClient ? false : undefined
       if (handleUpdate) {
         token &&
-          handleUpdate(task.id, { assigneeId: nextAssignee?.id }, () =>
+          handleUpdate(task.id, { assigneeId: nextAssignee?.id, internalUserId, clientId, companyId }, () =>
             updateAssignee(token, task.id, internalUserId, clientId, companyId, associations, isShared),
           )
       } else {


### PR DESCRIPTION
## Summary
Closes [OUT-3660](https://linear.app/assemblycom/issue/OUT-3660/user-icon-should-switch-instantly-when-task-is-reassigned).

The assignee avatar in the subtasks list (and other `TaskCardList` variants) briefly flashed the "no assignee" icon before showing the new assignee. It happened on any reassignment that:
- went through a confirmation modal (e.g. removing a shared association, reassigning to a client when restricted), **or**
- crossed assignee types in the direct path (e.g. CU → IU) — no modal needed.

IU → IU never flickered.

### Root cause
`TaskCardList.handleAssigneeChange` and `handleConfirmAssigneeChange` each sent an incomplete optimistic SWR patch:
- Direct path patched only `{ assigneeId }`, leaving `internalUserId/clientId/companyId` stale.
- Modal path patched only `{ internalUserId, clientId, companyId }`, leaving `assigneeId` stale, and never called `setAssigneeValue`.

After the optimistic mutate, the `useEffect` re-ran `getSelectorAssigneeFromTask`. That lookup branches on `task.clientId` and matches by `task.assigneeId` + `task.companyId`. With one half of the pair stale, the lookup returned `undefined` → `setAssigneeValue(NoAssignee)` → flicker until server revalidation landed.

### Fix
Both reassignment paths now:
1. Patch a consistent payload: `{ assigneeId, internalUserId, clientId, companyId }`.
2. Call `setAssigneeValue(nextAssignee)` synchronously so the avatar swaps on the same render.

The fix is localized to `TaskCardList.tsx`, which is used for subtasks on the details page, subtasks on the board page, and top-level tasks in board list view. The parent task selector in `Sidebar.tsx` and the kanban `TaskCard.tsx` were already correct (different update channels).

## Test plan
- [x] On the task details page, in the subtasks list:
  - [x] Reassign CU → IU (no modal): avatar swaps instantly to new IU, no flash to "no assignee".
  - [x] Reassign IU → CU when task has internal-only fields (assignee confirm modal): avatar swaps instantly on confirm.
  - [x] Remove a shared association via the association confirm modal: avatar updates instantly on confirm.
  - [x] Reassign IU → IU (baseline): still flicker-free.
  - [x] Remove assignee from any starting state: avatar shows "no assignee" instantly.
- [x] Repeat the same matrix on the board page subtasks list and the board list view (top-level tasks).
- [x] Refresh after each action: the avatar persists to the same assignee server-side.

## Testing 

- [LOOM](https://www.loom.com/share/5ad79333c47749a8843aaac3d80d0d38)