### PR TITLE
OUT-3497 | Custom status labels: allow workspaces to rename Todo, In Progress, and Done

### DIFF
--- a/src/app/api/workflow-states/[id]/route.ts
+++ b/src/app/api/workflow-states/[id]/route.ts
@@ -1,0 +1,4 @@
+import { withErrorHandler } from '@api/core/utils/withErrorHandler'
+import { updateWorkflowState } from '@api/workflow-states/[id]/workflowStates.controller'
+
+export const PATCH = withErrorHandler(updateWorkflowState)

--- a/src/app/api/workflow-states/[id]/workflowStates.controller.ts
+++ b/src/app/api/workflow-states/[id]/workflowStates.controller.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from 'next/server'
+import WorkflowStatesService from '@api/workflow-states/workflowStates.service'
+import { UpdateWorkflowStateRequestSchema } from '@/types/dto/workflowStates.dto'
+import authenticate from '@api/core/utils/authenticate'
+import { IdParams } from '@api/core/types/api'
+
+export const updateWorkflowState = async (req: NextRequest, { params }: IdParams) => {
+  const { id } = await params
+  const user = await authenticate(req)
+
+  const data = UpdateWorkflowStateRequestSchema.parse(await req.json())
+  const workflowStatesService = new WorkflowStatesService(user)
+  const updatedWorkflowState = await workflowStatesService.updateWorkflowState(id, data)
+
+  return NextResponse.json({ updatedWorkflowState })
+}

--- a/src/app/api/workflow-states/workflowStates.service.ts
+++ b/src/app/api/workflow-states/workflowStates.service.ts
@@ -1,11 +1,12 @@
 import { BaseService } from '@api/core/services/base.service'
-import { CreateWorkflowStateRequest } from '@/types/dto/workflowStates.dto'
+import { CreateWorkflowStateRequest, UpdateWorkflowStateRequest } from '@/types/dto/workflowStates.dto'
 import { Resource } from '@api/core/types/api'
 import { generateRandomString, toCamelCase } from '@/utils/string'
 import { PoliciesService } from '@api/core/services/policies.service'
 import { UserAction } from '@api/core/types/user'
 import { WorkflowState } from '@prisma/client'
 import { getWorkflowStatesByWorkspace } from '@/utils/workflowStates'
+import { DEFAULT_WORKFLOW_STATE_NAMES } from '@/constants/workflowStates'
 
 class WorkflowStatesService extends BaseService {
   async getAllWorkflowStates() {
@@ -45,15 +46,35 @@ class WorkflowStatesService extends BaseService {
     })
   }
 
+  async updateWorkflowState(id: string, data: UpdateWorkflowStateRequest) {
+    const policyGate = new PoliciesService(this.user)
+    policyGate.authorize(UserAction.Update, Resource.Tasks)
+
+    return await this.db.workflowState.update({
+      where: { id, workspaceId: this.user.workspaceId },
+      data,
+    })
+  }
+
   /**
    * Sets default workflow states for a fresh workspace
    */
   private async setDefaultWorkflowStates() {
     return await this.db.workflowState.createMany({
       data: [
-        { type: 'unstarted', name: 'To Do', key: 'todo', workspaceId: this.user.workspaceId },
-        { type: 'started', name: 'In Progress', key: 'inProgress', workspaceId: this.user.workspaceId },
-        { type: 'completed', name: 'Done', key: 'completed', workspaceId: this.user.workspaceId },
+        { type: 'unstarted', name: DEFAULT_WORKFLOW_STATE_NAMES.unstarted, key: 'todo', workspaceId: this.user.workspaceId },
+        {
+          type: 'started',
+          name: DEFAULT_WORKFLOW_STATE_NAMES.started,
+          key: 'inProgress',
+          workspaceId: this.user.workspaceId,
+        },
+        {
+          type: 'completed',
+          name: DEFAULT_WORKFLOW_STATE_NAMES.completed,
+          key: 'completed',
+          workspaceId: this.user.workspaceId,
+        },
       ],
       skipDuplicates: true, //doesnt create if there is an existing workflowState.
     })

--- a/src/app/configure-tasks-app/actions.ts
+++ b/src/app/configure-tasks-app/actions.ts
@@ -2,6 +2,7 @@
 import { apiUrl } from '@/config'
 import { CreateTemplateRequest, UpdateTemplateRequest } from '@/types/dto/templates.dto'
 import { UpdateWorkspaceSettingsDTO } from '@/types/dto/workspaceSettings.dto'
+import { UpdateWorkflowStateRequest } from '@/types/dto/workflowStates.dto'
 
 export const createNewTemplate = async (token: string, payload: CreateTemplateRequest) => {
   const resp = await fetch(`${apiUrl}/api/tasks/templates?token=${token}`, {
@@ -43,4 +44,16 @@ export async function updateWorkspaceSettings(token: string, payload: UpdateWork
     throw new Error(`Failed to update workspace settings: ${resp.status}`)
   }
   return await resp.json()
+}
+
+export async function updateWorkflowState(token: string, id: string, payload: UpdateWorkflowStateRequest) {
+  const resp = await fetch(`${apiUrl}/api/workflow-states/${id}?token=${token}`, {
+    method: 'PATCH',
+    body: JSON.stringify(payload),
+  })
+  if (!resp.ok) {
+    throw new Error(`Failed to update workflow state: ${resp.status}`)
+  }
+  const { updatedWorkflowState } = await resp.json()
+  return updatedWorkflowState
 }

--- a/src/app/configure-tasks-app/page.tsx
+++ b/src/app/configure-tasks-app/page.tsx
@@ -98,6 +98,7 @@ export default async function ConfigureTasksAppPage(props: ConfigureTasksAppPage
             token={token}
             portalUrl={workspace.portalUrl}
           />
+          <StatusCustomizationSection initialWorkflowStates={workflowStates} token={token} />
           <TemplateBoard
             handleCreateTemplate={async (payload: CreateTemplateRequest) => {
               'use server'
@@ -112,7 +113,6 @@ export default async function ConfigureTasksAppPage(props: ConfigureTasksAppPage
               await editTemplate(token, templateId, payload)
             }}
           />
-          <StatusCustomizationSection initialWorkflowStates={workflowStates} token={token} />
         </Stack>
       </RealTimeTemplates>
     </ClientSideStateUpdate>

--- a/src/app/configure-tasks-app/page.tsx
+++ b/src/app/configure-tasks-app/page.tsx
@@ -15,6 +15,7 @@ import { RealTimeTemplates } from '@/hoc/RealtimeTemplates'
 import { Token, TokenSchema, WorkspaceResponse } from '@/types/common'
 import { ConfigureTasksAppBridge } from '@/app/configure-tasks-app/ui/ConfigureTasksAppBridge'
 import { AutoArchiveSection } from '@/app/configure-tasks-app/ui/AutoArchiveSection'
+import { StatusCustomizationSection } from '@/app/configure-tasks-app/ui/StatusCustomizationSection'
 import { Stack } from '@mui/material'
 
 async function getAllWorkflowStates(token: string): Promise<WorkflowStateResponse[]> {
@@ -111,6 +112,7 @@ export default async function ConfigureTasksAppPage(props: ConfigureTasksAppPage
               await editTemplate(token, templateId, payload)
             }}
           />
+          <StatusCustomizationSection initialWorkflowStates={workflowStates} token={token} />
         </Stack>
       </RealTimeTemplates>
     </ClientSideStateUpdate>

--- a/src/app/configure-tasks-app/ui/AutoArchiveSection.tsx
+++ b/src/app/configure-tasks-app/ui/AutoArchiveSection.tsx
@@ -77,8 +77,8 @@ export const AutoArchiveSection = ({ initialAutoArchiveAfterDays, token, portalU
 
       <Box
         sx={{
-          border: (theme) => `1px solid ${theme.color.borders.borderDisabled}`,
-          borderRadius: '8px',
+          border: (theme) => `1px solid ${theme.color.borders.border}`,
+          borderRadius: '4px',
           background: (theme) => theme.color.base.white,
         }}
       >
@@ -90,7 +90,7 @@ export const AutoArchiveSection = ({ initialAutoArchiveAfterDays, token, portalU
         {isEnabled && (
           <Box
             sx={{
-              borderTop: (theme) => `1px solid ${theme.color.borders.borderDisabled}`,
+              borderTop: (theme) => `1px solid ${theme.color.borders.border}`,
               px: '16px',
               py: '14px',
             }}

--- a/src/app/configure-tasks-app/ui/StatusCustomizationSection.tsx
+++ b/src/app/configure-tasks-app/ui/StatusCustomizationSection.tsx
@@ -120,7 +120,7 @@ export const StatusCustomizationSection = ({ initialWorkflowStates, token }: Sta
                 px: '12px',
                 py: '12px',
                 minHeight: '52px',
-                borderTop: (theme) => (index === 0 ? 'none' : `1px solid ${theme.color.borders.border}`),
+                boxShadow: (theme) => (index === 0 ? 'none' : `inset 0 1px 0 0 ${theme.color.borders.border}`),
                 '&:hover': isEditing
                   ? undefined
                   : {

--- a/src/app/configure-tasks-app/ui/StatusCustomizationSection.tsx
+++ b/src/app/configure-tasks-app/ui/StatusCustomizationSection.tsx
@@ -1,0 +1,219 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { Box, InputBase, Stack, Typography } from '@mui/material'
+import { Icon } from 'copilot-design-system'
+import { StateType } from '@prisma/client'
+import { WorkflowStateResponse } from '@/types/dto/workflowStates.dto'
+import { PrimaryBtn } from '@/components/buttons/PrimaryBtn'
+import { SecondaryBtn } from '@/components/buttons/SecondaryBtn'
+import { updateWorkflowState } from '@/app/configure-tasks-app/actions'
+import store from '@/redux/store'
+import { setWorkflowStates } from '@/redux/features/taskBoardSlice'
+
+const STATUS_ICON_BY_TYPE: Record<StateType, 'ToDo' | 'InProgress' | 'SuccessSolid'> = {
+  unstarted: 'ToDo',
+  backlog: 'ToDo',
+  started: 'InProgress',
+  completed: 'SuccessSolid',
+  cancelled: 'ToDo',
+}
+
+const STATUS_ICON_COLOR_BY_TYPE: Record<StateType, string> = {
+  unstarted: '#90959D',
+  backlog: '#90959D',
+  started: '#E5A11A',
+  completed: '#115B3B',
+  cancelled: '#90959D',
+}
+
+interface StatusCustomizationSectionProps {
+  initialWorkflowStates: WorkflowStateResponse[]
+  token: string
+}
+
+export const StatusCustomizationSection = ({ initialWorkflowStates, token }: StatusCustomizationSectionProps) => {
+  const [states, setStates] = useState<WorkflowStateResponse[]>(initialWorkflowStates)
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [draftName, setDraftName] = useState('')
+  const [savingId, setSavingId] = useState<string | null>(null)
+  const inputRef = useRef<HTMLInputElement | null>(null)
+
+  useEffect(() => {
+    if (editingId && inputRef.current) {
+      const input = inputRef.current
+      input.focus()
+      const end = input.value.length
+      input.setSelectionRange(end, end)
+    }
+  }, [editingId])
+
+  const beginEdit = (state: WorkflowStateResponse) => {
+    setEditingId(state.id)
+    setDraftName(state.name)
+  }
+
+  const cancelEdit = () => {
+    setEditingId(null)
+    setDraftName('')
+  }
+
+  const saveEdit = async () => {
+    if (!editingId) return
+    const trimmed = draftName.trim()
+    const current = states.find((s) => s.id === editingId)
+    if (!current || !trimmed || trimmed === current.name) {
+      cancelEdit()
+      return
+    }
+
+    setSavingId(editingId)
+    try {
+      const updated = await updateWorkflowState(token, editingId, { name: trimmed })
+      const nextStates = states.map((s) => (s.id === editingId ? { ...s, name: updated?.name ?? trimmed } : s))
+      setStates(nextStates)
+      store.dispatch(setWorkflowStates(nextStates))
+      cancelEdit()
+    } catch (err) {
+      console.error('Failed to rename workflow state', err)
+    } finally {
+      setSavingId(null)
+    }
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      saveEdit()
+    } else if (e.key === 'Escape') {
+      e.preventDefault()
+      cancelEdit()
+    }
+  }
+
+  return (
+    <Box sx={{ width: '100%', maxWidth: '640px', margin: '0 auto', px: { xs: 2, sm: 0 } }}>
+      <Typography variant="lg" sx={{ display: 'block', mb: '12px' }}>
+        Status Customization
+      </Typography>
+
+      <Box
+        sx={{
+          border: (theme) => `1px solid ${theme.color.borders.border}`,
+          borderRadius: '4px',
+          background: (theme) => theme.color.base.white,
+          overflow: 'hidden',
+        }}
+      >
+        {states.map((state, index) => {
+          const isEditing = editingId === state.id
+          const isSaving = savingId === state.id
+          const trimmedDraft = draftName.trim()
+          const canSave = !!trimmedDraft && trimmedDraft !== state.name && !isSaving
+
+          return (
+            <Stack
+              key={state.id}
+              direction="row"
+              alignItems="center"
+              sx={{
+                px: '12px',
+                py: '12px',
+                minHeight: '52px',
+                borderTop: (theme) => (index === 0 ? 'none' : `1px solid ${theme.color.borders.border}`),
+                '&:hover': isEditing
+                  ? undefined
+                  : {
+                      backgroundColor: (theme) => theme.color.gray[100],
+                    },
+                '&:hover .StatusCustomizationSection-edit': { opacity: isEditing ? 0 : 1 },
+              }}
+            >
+              <Box
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  flexShrink: 0,
+                  mr: '12px',
+                  color: STATUS_ICON_COLOR_BY_TYPE[state.type],
+                }}
+              >
+                <Icon icon={STATUS_ICON_BY_TYPE[state.type]} width={20} height={20} />
+              </Box>
+
+              {isEditing ? (
+                <Stack direction="row" alignItems="center" columnGap="8px" sx={{ flex: 1, minWidth: 0 }}>
+                  <InputBase
+                    inputRef={inputRef}
+                    value={draftName}
+                    onChange={(e) => setDraftName(e.target.value)}
+                    onKeyDown={handleKeyDown}
+                    disabled={isSaving}
+                    inputProps={{ maxLength: 255, 'aria-label': `Rename ${state.name}` }}
+                    sx={(theme) => ({
+                      flex: 1,
+                      height: '28px',
+                      px: '12px',
+                      py: 0,
+                      borderRadius: '4px',
+                      border: `1px solid ${theme.color.gray[700]}`,
+                      boxSizing: 'border-box',
+                      fontFamily: theme.typography.bodyMd.fontFamily,
+                      fontSize: theme.typography.bodyMd.fontSize,
+                      fontWeight: theme.typography.bodyMd.fontWeight,
+                      lineHeight: theme.typography.bodyMd.lineHeight,
+                      background: theme.color.base.white,
+                      '& input': { padding: 0, height: '100%', boxSizing: 'border-box' },
+                    })}
+                  />
+                  <SecondaryBtn
+                    handleClick={cancelEdit}
+                    padding="3px 8px"
+                    height="25px"
+                    buttonContent={
+                      <Typography variant="sm" sx={{ color: (theme) => theme.color.gray[700] }}>
+                        Cancel
+                      </Typography>
+                    }
+                  />
+                  <PrimaryBtn buttonText="Save" handleClick={saveEdit} disabled={!canSave} padding="3px 8px" height="25px" />
+                </Stack>
+              ) : (
+                <>
+                  <Typography variant="bodyMd" sx={{ flex: 1, minWidth: 0 }}>
+                    {state.name}
+                  </Typography>
+                  <Box
+                    component="button"
+                    type="button"
+                    aria-label={`Rename ${state.name}`}
+                    onClick={() => beginEdit(state)}
+                    className="StatusCustomizationSection-edit"
+                    sx={(theme) => ({
+                      opacity: 0,
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      width: '24px',
+                      height: '24px',
+                      border: 'none',
+                      background: 'transparent',
+                      borderRadius: '4px',
+                      cursor: 'pointer',
+                      color: theme.color.gray[500],
+                      '@media (hover: none)': { opacity: 1 },
+                      '&:hover': { background: theme.color.gray[100], color: theme.color.gray[700] },
+                      '&:focus-visible': { opacity: 1, outline: `1px solid ${theme.color.gray[400]}` },
+                    })}
+                  >
+                    <Icon icon="Edit" width={14} height={14} />
+                  </Box>
+                </>
+              )}
+            </Stack>
+          )
+        })}
+      </Box>
+    </Box>
+  )
+}

--- a/src/components/buttons/PrimaryBtn.tsx
+++ b/src/components/buttons/PrimaryBtn.tsx
@@ -9,6 +9,7 @@ export const PrimaryBtn = ({
   buttonBackground,
   disabled,
   padding,
+  height,
   variant = 'default',
 }: {
   startIcon?: ReactNode
@@ -17,6 +18,7 @@ export const PrimaryBtn = ({
   buttonBackground?: string
   disabled?: boolean
   padding?: string
+  height?: string
   variant?: 'default' | 'danger'
 }) => {
   return (
@@ -35,6 +37,7 @@ export const PrimaryBtn = ({
         borderRadius: '4px',
         cursor: 'pointer',
         padding: padding ?? 'none',
+        height: height ?? 'auto',
       })}
       onClick={() => handleClick()}
       disableRipple

--- a/src/constants/workflowStates.ts
+++ b/src/constants/workflowStates.ts
@@ -1,0 +1,9 @@
+import { StateType } from '@prisma/client'
+
+export const DEFAULT_WORKFLOW_STATE_NAMES: Record<StateType, string> = {
+  unstarted: 'To Do',
+  started: 'In Progress',
+  completed: 'Done',
+  backlog: 'Backlog',
+  cancelled: 'Cancelled',
+}

--- a/src/types/dto/workflowStates.dto.ts
+++ b/src/types/dto/workflowStates.dto.ts
@@ -11,6 +11,11 @@ export const CreateWorkflowStateRequestSchema = z.object({
 })
 export type CreateWorkflowStateRequest = z.infer<typeof CreateWorkflowStateRequestSchema>
 
+export const UpdateWorkflowStateRequestSchema = z.object({
+  name: z.string().trim().min(1).max(255),
+})
+export type UpdateWorkflowStateRequest = z.infer<typeof UpdateWorkflowStateRequestSchema>
+
 export const WorkflowStateResponseSchema = z.object({
   id: z.string(),
   workspaceId: z.string(),


### PR DESCRIPTION
## Summary

- Workspace admins can rename the three default workflow state labels (To Do / In Progress / Done) from a new **Status Customization** section on the Configure Tasks App page, inline per row with Cancel/Save.
- Renames persist directly to `WorkflowState.name`, so every surface that already reads it (board view, list view, detail selector, activity log, template board) picks up the custom label with zero new render-time override logic.
- The public API is unaffected — `PublicTaskSerializer` maps `workflowState.type` through a hardcoded `statusMap`, so the public `status` field continues to return the default values (`todo` / `inProgress` / `completed`).

## Implementation notes

- New `PATCH /api/workflow-states/[id]` endpoint, scoped by `workspaceId`, gated by `UserAction.Update, Resource.Tasks`. Cross-workspace IDs return 404 by design.
- `UpdateWorkflowStateRequestSchema` validates name (`trim`, non-empty, max 255).
- Default seed names are extracted into `src/constants/workflowStates.ts` so they have a single source of truth (used by `setDefaultWorkflowStates` and future reset-to-default flows).
- Frontend section matches Figma `6088:7818` — `52px` row, `28px` text-field, `25px` Cancel/Save buttons. Edit pencil reveals on hover; on touch devices (`@media (hover: none)`) it stays visible.
- After a successful rename, the updated workflow states are dispatched to Redux (`setWorkflowStates`) so the TemplateBoard on the same page re-renders without a refetch.
- Added an optional `height` prop to `PrimaryBtn` (mirroring `SecondaryBtn`) for consistent sizing.
- Updated Auto-archive + Status Customization to use `theme.color.borders.border` instead of the lighter `borderDisabled` so card borders match the Templates section visually.

## Test plan

- [x] Fresh workspace seeds with the default "To Do" / "In Progress" / "Done" names.
- [x] Renaming a state on `/configure-tasks-app` persists across reload.
- [x] Renamed labels appear on the main task board column headers, list view, task detail workflow selector, and activity log.
- [x] TemplateBoard on the configure page reflects renames immediately (Redux dispatch path).
- [x] Public API (`GET /api/v1/tasks/:id` with an API key) still returns the canonical `status` value, not the renamed label.
- [x] CU attempting `PATCH /api/workflow-states/:id` is denied via `PoliciesService`.
- [x] Cross-workspace ID PATCH returns 404.
- [x] Empty / whitespace-only / unchanged name values disable the Save button or reject the request.
- [x] Mobile: the edit pencil is always visible, hover background isn't required.
- [x] Row height stays constant (52px) across display ↔ edit transitions for all three rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)