### PR TITLE
OUT-3713 | Tasks app outage from subtasks update payload

### DIFF
--- a/src/app/detail/ui/TaskCardList.tsx
+++ b/src/app/detail/ui/TaskCardList.tsx
@@ -197,14 +197,21 @@ export const TaskCardList = ({
     if (variant === 'task') {
       store.dispatch(updateWorkflowStateIdByTaskId({ taskId: task.id, targetWorkflowStateId: value.id }))
     }
-    if (mode === UserRole.Client && !previewMode) {
-      clientUpdateTask(z.string().parse(token), task.id, value.id, skipSubtaskCascade)
+    const runUpdate = async () => {
+      if (mode === UserRole.Client && !previewMode) {
+        await clientUpdateTask(z.string().parse(token), task.id, value.id, skipSubtaskCascade)
+      } else {
+        await updateTask({
+          token: z.string().parse(token),
+          taskId: task.id,
+          payload: { workflowStateId: value.id, skipSubtaskCascade },
+        })
+      }
+    }
+    if (handleUpdate) {
+      handleUpdate(task.id, { workflowStateId: value.id, workflowState: value }, runUpdate)
     } else {
-      updateTask({
-        token: z.string().parse(token),
-        taskId: task.id,
-        payload: { workflowStateId: value.id, skipSubtaskCascade },
-      })
+      void runUpdate()
     }
   }
 

--- a/src/app/detail/ui/TaskCardList.tsx
+++ b/src/app/detail/ui/TaskCardList.tsx
@@ -18,6 +18,7 @@ import { useHandleSelectorComponent } from '@/hooks/useHandleSelectorComponent'
 import { useOpenSubtaskCount } from '@/hooks/useSubtaskCount'
 import { selectAuthDetails } from '@/redux/features/authDetailsSlice'
 import {
+  bulkUpdateWorkflowStateIdByTaskIds,
   selectTaskBoard,
   setAssigneeCache,
   setConfirmAssigneeModalId,
@@ -196,6 +197,8 @@ export const TaskCardList = ({
     updateStatusValue(value)
     if (variant === 'task') {
       store.dispatch(updateWorkflowStateIdByTaskId({ taskId: task.id, targetWorkflowStateId: value.id }))
+    } else if (variant === 'subtask-board') {
+      store.dispatch(bulkUpdateWorkflowStateIdByTaskIds({ taskIds: [task.id], targetWorkflowStateId: value.id }))
     }
     const runUpdate = async () => {
       if (mode === UserRole.Client && !previewMode) {

--- a/src/redux/features/taskBoardSlice.tsx
+++ b/src/redux/features/taskBoardSlice.tsx
@@ -231,7 +231,12 @@ const taskBoardSlice = createSlice({
     },
 
     setAccessibleTasks: (state, action: { payload: TaskResponse[] }) => {
-      state.accessibleTasks = action.payload
+      const workflowStateById = new Map(state.workflowStates.map((s) => [s.id, s]))
+      state.accessibleTasks = action.payload.map((task) => {
+        if (task.workflowState || !task.workflowStateId) return task
+        const hydrated = workflowStateById.get(task.workflowStateId)
+        return hydrated ? { ...task, workflowState: hydrated } : task
+      })
     },
 
     setConfirmAssigneeModalId: (state, action: { payload: string | undefined }) => {

--- a/src/redux/features/taskBoardSlice.tsx
+++ b/src/redux/features/taskBoardSlice.tsx
@@ -231,6 +231,8 @@ const taskBoardSlice = createSlice({
     },
 
     setAccessibleTasks: (state, action: { payload: TaskResponse[] }) => {
+      //also append workflowState object while setting setAccessibleTasks. setAccessibleTasks is triggered from realtime updates which do not contain the workflowState in their payload.
+      // Since subtasks sorting relies on workflowState, we need this object appended on each real time updated task.
       const workflowStateById = new Map(state.workflowStates.map((s) => [s.id, s]))
       state.accessibleTasks = action.payload.map((task) => {
         if (task.workflowState || !task.workflowStateId) return task

--- a/src/utils/sortByDescending.ts
+++ b/src/utils/sortByDescending.ts
@@ -10,7 +10,7 @@ interface WithDueDate extends BaseSortable {
 }
 
 interface WithSubtaskSort extends WithDueDate {
-  workflowState: { type: StateType }
+  workflowState?: { type: StateType }
 }
 
 const getTimestamp = (date: string | Date) => new Date(date).getTime()
@@ -22,6 +22,8 @@ const subtaskStatePriority: Record<StateType, number> = {
   [StateType.backlog]: 3,
   [StateType.cancelled]: 4,
 }
+
+const UNKNOWN_STATE_PRIORITY = Number.MAX_SAFE_INTEGER
 
 export const sortByDescendingOrder = <T extends BaseSortable, K extends keyof T = never>(
   items: T[],
@@ -49,8 +51,10 @@ export const sortTaskByDescendingOrder = <T extends WithDueDate>(tasks: T[]) => 
 export const sortTemplatesByDescendingOrder = <T extends BaseSortable>(templates: T[]) => sortByDescendingOrder(templates)
 
 export const sortSubtasksByPriority = <T extends WithSubtaskSort>(subtasks: T[]): T[] => {
+  const priorityOf = (state?: { type: StateType }) =>
+    state ? (subtaskStatePriority[state.type] ?? UNKNOWN_STATE_PRIORITY) : UNKNOWN_STATE_PRIORITY
   return [...subtasks].sort((a, b) => {
-    const priorityDiff = subtaskStatePriority[a.workflowState.type] - subtaskStatePriority[b.workflowState.type]
+    const priorityDiff = priorityOf(a.workflowState) - priorityOf(b.workflowState)
     if (priorityDiff !== 0) return priorityDiff
 
     if (a.dueDate && !b.dueDate) return -1


### PR DESCRIPTION
## Changes

- [x] When subtasks are updated in board page or details page, subsequent realtime changes if captured through `postgres_changes` from our realtime handler. The payload from realtime does not contain `workflowstate` object because it is a raw table payload without any join operation. But the subtask sorting handler strictly required the `workflowstate` object. Made this optional which acts as a defense mechanism not to crash the app. 
- [x] While setting tasks on `accessibleTask` store from realtime payload, created a map of `workflowstate` object to pass to the sorting handler. This acts as a solution to fix our problem. 
- [x] added a quick improvement on optimistic updates. 

 
## Testing Criteria

- [LOOM](https://www.loom.com/share/fee19ac46a15456195cf556d30aefddc?focus_title=1&muted=1&from_recorder=1)

Also fixed the sorting optimistic update on board view. 
