### PR TITLE
OUT-3727 | Deleted task doesn´t disappear in real-time

### DIFF
--- a/src/app/_fetchers/TaskDataFetcher.tsx
+++ b/src/app/_fetchers/TaskDataFetcher.tsx
@@ -3,7 +3,7 @@ import store from '@/redux/store'
 import { DisplayOptions } from '@/types/dto/viewSettings.dto'
 import { PropsWithToken } from '@/types/interfaces'
 import { fetcher } from '@/utils/fetcher'
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { useSelector } from 'react-redux'
 import useSWR from 'swr'
 
@@ -43,11 +43,25 @@ export const TaskDataFetcher = ({ token }: PropsWithToken) => {
     store.dispatch(setIsTasksLoading(isLoading))
   }, [isLoading])
 
+  // Skip dispatching the initial `data`. On mount, `data` is either fallbackData (a snapshot of
+  // redux that SSR/CSU has already populated) or SWR's cached response from a prior session —
+  // which may be stale relative to redux if a realtime event ran while this component wasn't
+  // mounted (e.g. a task deleted from the details page before redirecting back to the board,
+  // OUT-3727). Redux is already authoritative in both cases.
+  //
+  // We compare against the initial `data` *reference* (captured via `useRef`) rather than a
+  // boolean "is first run" flag, because in dev React Strict Mode runs effects twice on mount
+  // with the same `data` — a boolean flag flips on the first run and lets the second run
+  // dispatch, which re-introduces the stale cache. A reference check correctly treats both
+  // strict-mode runs as "still the initial value, skip", and only dispatches when `data` is
+  // actually replaced (filter toggle, key change, revalidation).
+  const initialData = useRef(data).current
   useEffect(() => {
+    if (data === initialData) return
     if (data?.tasks) {
       store.dispatch(setTasks(data.tasks))
     }
-  }, [data])
+  }, [data, initialData])
 
   return null
 }

--- a/src/lib/realtime.ts
+++ b/src/lib/realtime.ts
@@ -303,15 +303,13 @@ export class RealtimeHandler {
 
     // CASE I: Task is deleted
     if (updatedTask.deletedAt) {
-      setTimeout(() => {
-        store.dispatch(setTasks(filterOutUpdatedTask(tasks)))
-        store.dispatch(setAccessibleTasks(filterOutUpdatedTask(accessibleTasks)))
-      }, 0) //simple patch for race condition when update event fires before create event
-
+      store.dispatch(setTasks(filterOutUpdatedTask(tasks)))
+      store.dispatch(setAccessibleTasks(filterOutUpdatedTask(accessibleTasks)))
       //if a user is in the details page when the task is deleted then we want the user to get redirected to '/' route
       if (updatedTask.id === activeTask?.id) {
         return this.redirectToBoard(updatedTask)
       }
+      return
     }
 
     // CASE II: REASSIGNMENT OUT OF SCOPE


### PR DESCRIPTION
## Summary

Fixes [OUT-3727](https://linear.app/assemblycom/issue/OUT-3727/deleted-task-doesnt-disappear-in-real-time): after deleting a task from its details page, the user is correctly redirected to the board but the deleted task is still rendered there. Repros on both list and board views.

## Root cause

Two interlocking issues:

**1. `realtime.ts` deferred the redux cleanup with `setTimeout(0)`.** The wrap was added long ago to guard a "UPDATE arrives before INSERT" race during task creation, but that race can't reach a soft-delete (the task must already exist client-side for the user to be deleting it). The deferral did, however, push the redux update past the synchronous `router.push('/')` call — opening a window where the freshly-mounted board could read stale redux.

**2. `TaskDataFetcher`'s useEffect re-hydrated redux from SWR's stale global cache on remount.** SWR's cache survives navigation; with `revalidateOnMount: false` it returns the cached pre-delete response on remount; the useEffect dispatched that cached response back into redux, undoing the realtime cleanup.

Both pieces had to misbehave for the bug to appear. The realtime side fired correctly; SWR's cache was just always one beat behind.

## Changes

**`src/lib/realtime.ts` (CASE I — delete)**
- Removed the `setTimeout(0)` wrap. Sync dispatch lands before `router.push` triggers the board render, so the new TaskBoard reads a clean redux state.
- Added an explicit `return` after the redirect block. Previously, when the deleted task wasn't the user's `activeTask`, control fell through to CASE II/III/IV and CASE IV's `tasks.map(...)` would re-add the task with `deletedAt` set. The old code relied on the `setTimeout(0)` to undo that. With the explicit return, the fall-through doesn't happen and no cleanup is needed.

**`src/app/_fetchers/TaskDataFetcher.tsx`**
- Skip dispatching the initial `data`. On mount, `data` is either fallbackData (a snapshot of redux that SSR/CSU has already populated) or SWR's cached response from a prior session — in both cases redux is authoritative and we shouldn't clobber it.
- Implemented as a `useRef`-captured reference check (`if (data === initialData) return`) rather than a boolean "first run" flag. A boolean flips on the first invocation and lets the second invocation through, which is exactly what React Strict Mode's double-invoke triggers (confirmed in the diagnostic logs we ran during investigation). A reference check correctly treats both Strict-Mode invocations as "still the initial value, skip."
- Subsequent `data` changes (filter toggles, background revalidation) still dispatch normally — they produce a new `data` reference.

## What this incidentally fixes

CASE II / III / IV (realtime reassigns and edits) had the same staleness pattern — they update redux but don't sync SWR's cache, so the next remount of `TaskDataFetcher` would dispatch the cached pre-update version back over redux. The `useRef` skip protects against all of those too, not just deletes. No bug was reported for them; they were probably manifesting as occasional "old title for a moment" flickers no one flagged.

## Test plan

- [x] Delete a task from the details page → confirm it disappears immediately from the board on redirect (the original ticket repro)
- [x] Delete a task from the details page → confirm it stays gone after a few seconds (no late re-add from SWR revalidation)
- [x] Toggle `Show archived` / `Show completed` filters off and back on — board updates correctly each time (the regression that broke an earlier attempt at this fix)
- [x] Edit a task title via the details page → navigate back to the board → confirm the new title is shown (covers the incidental CASE IV fix)
- [x] Confirm subtask realtime events still work — that handler's separate `setTimeout(0)` is untouched and still protects the genuine create-before-update race during template-based bulk subtask creation
- [x] Confirm client portal flow — same `TaskBoard` → `TaskDataFetcher` path, no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)