### PR TITLE
OUT-3734 | Schema: add TaskReminderSent table + TaskReminderType enum

### DIFF
--- a/prisma/migrations/20260515091539_add_task_reminder_sents_table/migration.sql
+++ b/prisma/migrations/20260515091539_add_task_reminder_sents_table/migration.sql
@@ -1,0 +1,20 @@
+-- CreateEnum
+CREATE TYPE "TaskReminderType" AS ENUM ('NO_DUE_DATE_3D', 'NO_DUE_DATE_7D', 'DUE_DATE_BEFORE_3D', 'DUE_DATE_TODAY', 'DUE_DATE_OVERDUE_3D', 'DUE_DATE_OVERDUE_7D');
+
+-- CreateTable
+CREATE TABLE "TaskReminderSents" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "taskId" UUID NOT NULL,
+    "workspaceId" VARCHAR(32) NOT NULL,
+    "recipientId" UUID NOT NULL,
+    "reminderType" "TaskReminderType" NOT NULL,
+    "sentAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "TaskReminderSents_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "TaskReminderSents_taskId_recipientId_reminderType_key" ON "TaskReminderSents"("taskId", "recipientId", "reminderType");
+
+-- AddForeignKey
+ALTER TABLE "TaskReminderSents" ADD CONSTRAINT "TaskReminderSents_taskId_fkey" FOREIGN KEY ("taskId") REFERENCES "Tasks"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema/task.prisma
+++ b/prisma/schema/task.prisma
@@ -57,6 +57,7 @@ model Task {
   deletedBy           String?       @db.Uuid
 
   taskUpdateBacklogs TaskUpdateBacklog[]
+  taskReminderSents  TaskReminderSent[]
 
   associations       Json        @db.JsonB @default("[]")
   isShared           Boolean     @default(false)

--- a/prisma/schema/taskReminderSent.prisma
+++ b/prisma/schema/taskReminderSent.prisma
@@ -1,0 +1,21 @@
+enum TaskReminderType {
+  NO_DUE_DATE_3D
+  NO_DUE_DATE_7D
+  DUE_DATE_BEFORE_3D
+  DUE_DATE_TODAY
+  DUE_DATE_OVERDUE_3D
+  DUE_DATE_OVERDUE_7D
+}
+
+model TaskReminderSent {
+  id           String           @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  task         Task             @relation(fields: [taskId], references: [id], onDelete: Cascade)
+  taskId       String           @db.Uuid
+  workspaceId  String           @db.VarChar(32)
+  recipientId  String           @db.Uuid
+  reminderType TaskReminderType
+  sentAt       DateTime         @default(now())
+
+  @@unique([taskId, recipientId, reminderType])
+  @@map("TaskReminderSents")
+}


### PR DESCRIPTION
## Summary
- Adds `TaskReminderType` enum and `TaskReminderSents` table — the idempotency ledger for reminder emails (Milestone 1).
- Unique constraint on `(taskId, recipientId, reminderType)` is the dedupe primitive so retries and manual re-triggers cannot double-send.
- FK to `Tasks(id)` with `ON DELETE CASCADE`; `workspaceId` carried for tenancy parity with the rest of the schema.

## Test plan
- [x] `prisma validate` passes
- [x] `prisma migrate dev` applies cleanly on local Postgres
- [x] `prisma generate` produces the expected types
- [x] Duplicate insert on `(taskId, recipientId, reminderType)` raises a unique-constraint violation
- [x] Hard-deleting the parent `Task` cascades and removes ledger rows
- [x] Migration applies cleanly in staging on deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)