### PR TITLE
OUT-3735 | Reminder copy helper: getReminderEmailDetails

### DIFF
--- a/src/app/api/notification/__snapshots__/notification.helpers.test.ts.snap
+++ b/src/app/api/notification/__snapshots__/notification.helpers.test.ts.snap
@@ -1,0 +1,139 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getReminderEmailDetails matches snapshot for company recipient 1`] = `
+{
+  "DUE_DATE_BEFORE_3D": {
+    "body": "This is a friendly reminder that you have a task ‘Submit timesheet’ due in 3 days.
+
+Please make sure to complete this task by the due date.",
+    "ctaParams": {
+      "taskId": "task_1",
+    },
+    "header": "A task was assigned to your company",
+    "subject": "Acme portal: [Due Soon] Task due in 3 days",
+    "title": "View task",
+  },
+  "DUE_DATE_OVERDUE_3D": {
+    "body": "This is a friendly reminder that the task ‘Submit timesheet’ is now overdue. It was due 3 days ago and is still pending completion.",
+    "ctaParams": {
+      "taskId": "task_1",
+    },
+    "header": "A task was assigned to your company",
+    "subject": "Acme portal: [Overdue] Task was due 3 days ago",
+    "title": "View task",
+  },
+  "DUE_DATE_OVERDUE_7D": {
+    "body": "This is a friendly reminder that the task ‘Submit timesheet’ is now one week overdue.
+
+Please complete this task as soon as possible.",
+    "ctaParams": {
+      "taskId": "task_1",
+    },
+    "header": "A task was assigned to your company",
+    "subject": "Acme portal: [Overdue] Task overdue by one week",
+    "title": "View task",
+  },
+  "DUE_DATE_TODAY": {
+    "body": "This is a friendly reminder that you have a task ‘Submit timesheet’ due today.
+
+Please complete this task as soon as possible.",
+    "ctaParams": {
+      "taskId": "task_1",
+    },
+    "header": "A task was assigned to your company",
+    "subject": "Acme portal: [Due Soon] Task due today",
+    "title": "View task",
+  },
+  "NO_DUE_DATE_3D": {
+    "body": "This is a friendly reminder that you have a task ‘Submit timesheet’ assigned to you that's still pending completion.
+
+If you've already completed this task, please mark it as done in the portal.",
+    "ctaParams": {
+      "taskId": "task_1",
+    },
+    "header": "A task was assigned to your company",
+    "subject": "Acme portal: [Reminder] You have a task to complete",
+    "title": "View task",
+  },
+  "NO_DUE_DATE_7D": {
+    "body": "This is a friendly reminder that you have a task ‘Submit timesheet’ that was assigned to you a week ago and is still pending.
+
+If you've already completed this task, please mark it as done in the portal.",
+    "ctaParams": {
+      "taskId": "task_1",
+    },
+    "header": "A task was assigned to your company",
+    "subject": "Acme portal: [Reminder] Task still pending",
+    "title": "View task",
+  },
+}
+`;
+
+exports[`getReminderEmailDetails matches snapshot for individual recipient 1`] = `
+{
+  "DUE_DATE_BEFORE_3D": {
+    "body": "This is a friendly reminder that you have a task ‘Submit timesheet’ due in 3 days.
+
+Please make sure to complete this task by the due date.",
+    "ctaParams": {
+      "taskId": "task_1",
+    },
+    "header": "A task was assigned to you",
+    "subject": "Acme portal: [Due Soon] Task due in 3 days",
+    "title": "View task",
+  },
+  "DUE_DATE_OVERDUE_3D": {
+    "body": "This is a friendly reminder that the task ‘Submit timesheet’ is now overdue. It was due 3 days ago and is still pending completion.",
+    "ctaParams": {
+      "taskId": "task_1",
+    },
+    "header": "A task was assigned to you",
+    "subject": "Acme portal: [Overdue] Task was due 3 days ago",
+    "title": "View task",
+  },
+  "DUE_DATE_OVERDUE_7D": {
+    "body": "This is a friendly reminder that the task ‘Submit timesheet’ is now one week overdue.
+
+Please complete this task as soon as possible.",
+    "ctaParams": {
+      "taskId": "task_1",
+    },
+    "header": "A task was assigned to you",
+    "subject": "Acme portal: [Overdue] Task overdue by one week",
+    "title": "View task",
+  },
+  "DUE_DATE_TODAY": {
+    "body": "This is a friendly reminder that you have a task ‘Submit timesheet’ due today.
+
+Please complete this task as soon as possible.",
+    "ctaParams": {
+      "taskId": "task_1",
+    },
+    "header": "A task was assigned to you",
+    "subject": "Acme portal: [Due Soon] Task due today",
+    "title": "View task",
+  },
+  "NO_DUE_DATE_3D": {
+    "body": "This is a friendly reminder that you have a task ‘Submit timesheet’ assigned to you that's still pending completion.
+
+If you've already completed this task, please mark it as done in the portal.",
+    "ctaParams": {
+      "taskId": "task_1",
+    },
+    "header": "A task was assigned to you",
+    "subject": "Acme portal: [Reminder] You have a task to complete",
+    "title": "View task",
+  },
+  "NO_DUE_DATE_7D": {
+    "body": "This is a friendly reminder that you have a task ‘Submit timesheet’ that was assigned to you a week ago and is still pending.
+
+If you've already completed this task, please mark it as done in the portal.",
+    "ctaParams": {
+      "taskId": "task_1",
+    },
+    "header": "A task was assigned to you",
+    "subject": "Acme portal: [Reminder] Task still pending",
+    "title": "View task",
+  },
+}
+`;

--- a/src/app/api/notification/notification.helpers.test.ts
+++ b/src/app/api/notification/notification.helpers.test.ts
@@ -1,0 +1,54 @@
+import { WorkspaceResponse } from '@/types/common'
+import { getReminderEmailDetails } from './notification.helpers'
+import { TaskReminderType } from '@prisma/client'
+
+const workspace: WorkspaceResponse = {
+  id: 'ws_1',
+  brandName: 'Acme',
+  labels: {
+    individualTerm: 'client',
+    individualTermPlural: 'clients',
+    groupTerm: 'company',
+    groupTermPlural: 'companies',
+  },
+}
+
+const task = { id: 'task_1', title: 'Submit timesheet' }
+
+describe('getReminderEmailDetails', () => {
+  it('returns a value for every TaskReminderType', () => {
+    const result = getReminderEmailDetails(workspace, task, false)
+    const expectedKeys = Object.values(TaskReminderType).sort()
+    expect(Object.keys(result).sort()).toEqual(expectedKeys)
+  })
+
+  it('matches snapshot for individual recipient', () => {
+    expect(getReminderEmailDetails(workspace, task, false)).toMatchSnapshot()
+  })
+
+  it('matches snapshot for company recipient', () => {
+    expect(getReminderEmailDetails(workspace, task, true)).toMatchSnapshot()
+  })
+
+  it('uses custom group term from workspace labels for company recipient', () => {
+    const customWorkspace: WorkspaceResponse = {
+      ...workspace,
+      labels: { ...workspace.labels, groupTerm: 'team' },
+    }
+    const result = getReminderEmailDetails(customWorkspace, task, true)
+    expect(result[TaskReminderType.NO_DUE_DATE_3D].header).toBe('A task was assigned to your team')
+  })
+
+  it('falls back gracefully when brandName is missing', () => {
+    const noBrand: WorkspaceResponse = { ...workspace, brandName: undefined }
+    const result = getReminderEmailDetails(noBrand, task, false)
+    expect(result[TaskReminderType.NO_DUE_DATE_3D].subject).toBe('portal: [Reminder] You have a task to complete')
+  })
+
+  it('emits ctaParams with the task id for every variant', () => {
+    const result = getReminderEmailDetails(workspace, task, false)
+    for (const variant of Object.values(TaskReminderType)) {
+      expect(result[variant].ctaParams).toEqual({ taskId: 'task_1' })
+    }
+  })
+})

--- a/src/app/api/notification/notification.helpers.ts
+++ b/src/app/api/notification/notification.helpers.ts
@@ -1,7 +1,7 @@
 import { WorkspaceResponse } from '@/types/common'
 import { getWorkspaceLabels } from '@/utils/getWorkspaceLabels'
 import { NotificationTaskActions } from '@api/core/types/tasks'
-import { Task } from '@prisma/client'
+import { Task, TaskReminderType } from '@prisma/client'
 
 /**
  * Helper function that sets the in-product notification title and body for a given notification trigger
@@ -197,6 +197,82 @@ export const getEmailDetails = (
       header: `A task was shared with you by ${actionUser}`,
       title: 'View task',
       body: `${actionUser} shared the task '${task?.title}'. View the task below to see updates and leave comments.`,
+      ctaParams,
+    },
+  }
+}
+
+/**
+ * Helper function that returns reminder email content for each TaskReminderType variant.
+ * Lifecycle is independent from `getEmailDetails` (which is keyed by NotificationTaskActions).
+ * @param {WorkspaceResponse} workspace - Workspace whose brandName fronts the subject and
+ *   whose labels resolve the company term.
+ * @param {Pick<Task, 'id' | 'title'>} task - Task being reminded about. Used for ctaParams and body interpolation.
+ * @param {boolean} isCompanyRecipient - True if recipient is a company (header reads "your {groupTerm}"),
+ *   false for an individual recipient (header reads "you").
+ * @returns Reminder email content keyed by TaskReminderType.
+ */
+export const getReminderEmailDetails = (
+  workspace: WorkspaceResponse,
+  task: Pick<Task, 'id' | 'title'>,
+  isCompanyRecipient: boolean,
+): Record<
+  TaskReminderType,
+  {
+    title: string
+    subject: string
+    header: string
+    body: string
+    ctaParams: { taskId: string }
+  }
+> => {
+  const portalPrefix = `${workspace.brandName ?? ''} portal:`.trimStart()
+  const labels = getWorkspaceLabels(workspace)
+  const header = isCompanyRecipient ? `A task was assigned to your ${labels.groupTerm}` : 'A task was assigned to you'
+  const ctaParams = { taskId: task.id }
+  const title = 'View task'
+
+  return {
+    [TaskReminderType.NO_DUE_DATE_3D]: {
+      subject: `${portalPrefix} [Reminder] You have a task to complete`,
+      header,
+      title,
+      body: `This is a friendly reminder that you have a task ‘${task.title}’ assigned to you that's still pending completion.\n\nIf you've already completed this task, please mark it as done in the portal.`,
+      ctaParams,
+    },
+    [TaskReminderType.NO_DUE_DATE_7D]: {
+      subject: `${portalPrefix} [Reminder] Task still pending`,
+      header,
+      title,
+      body: `This is a friendly reminder that you have a task ‘${task.title}’ that was assigned to you a week ago and is still pending.\n\nIf you've already completed this task, please mark it as done in the portal.`,
+      ctaParams,
+    },
+    [TaskReminderType.DUE_DATE_BEFORE_3D]: {
+      subject: `${portalPrefix} [Due Soon] Task due in 3 days`,
+      header,
+      title,
+      body: `This is a friendly reminder that you have a task ‘${task.title}’ due in 3 days.\n\nPlease make sure to complete this task by the due date.`,
+      ctaParams,
+    },
+    [TaskReminderType.DUE_DATE_TODAY]: {
+      subject: `${portalPrefix} [Due Soon] Task due today`,
+      header,
+      title,
+      body: `This is a friendly reminder that you have a task ‘${task.title}’ due today.\n\nPlease complete this task as soon as possible.`,
+      ctaParams,
+    },
+    [TaskReminderType.DUE_DATE_OVERDUE_3D]: {
+      subject: `${portalPrefix} [Overdue] Task was due 3 days ago`,
+      header,
+      title,
+      body: `This is a friendly reminder that the task ‘${task.title}’ is now overdue. It was due 3 days ago and is still pending completion.`,
+      ctaParams,
+    },
+    [TaskReminderType.DUE_DATE_OVERDUE_7D]: {
+      subject: `${portalPrefix} [Overdue] Task overdue by one week`,
+      header,
+      title,
+      body: `This is a friendly reminder that the task ‘${task.title}’ is now one week overdue.\n\nPlease complete this task as soon as possible.`,
       ctaParams,
     },
   }


### PR DESCRIPTION
## Summary
- Adds `getReminderEmailDetails(workspace, task, isCompanyRecipient)` in `notification.helpers.ts` — returns subject/header/title/body/ctaParams for each of the six `TaskReminderType` variants.
- Header branches on recipient kind: "to you" for individuals, "to your {groupTerm}" for companies (resolved via `getWorkspaceLabels`).
- Subjects include `{brandName} portal:` prefix interpolated from `workspace.brandName`.
- Lives alongside `getEmailDetails` rather than merging — `NotificationTaskActions` and reminder types have separate lifecycles.

**Note:** stacked on top of #1229 (OUT-3734). Base should switch to `main` once that lands.

**Minor copy deviation:** PRD shows `DUE_DATE_OVERDUE_7D` subject without the `{Company} portal:` prefix (the other 5 have it). I included the prefix for consistency — looks like a PRD typo. Easy to drop if intentional.

## Test plan
- [x] Helper returns a value for every `TaskReminderType` variant
- [x] Snapshot test covers all 6 variants for individual recipient
- [x] Snapshot test covers all 6 variants for company recipient
- [x] Custom `groupTerm` from workspace labels flows into header
- [x] Missing `brandName` degrades gracefully (`portal:` prefix without leading whitespace)
- [x] `ctaParams: { taskId }` emitted on every variant
- [x] `tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)