### PR TITLE
OUT-3736 | Eligibility SQL: single-day reminder query

### DIFF
--- a/src/jobs/notifications/eligibility.test.ts
+++ b/src/jobs/notifications/eligibility.test.ts
@@ -1,0 +1,54 @@
+import { AssigneeType, TaskReminderType } from '@prisma/client'
+
+const mockQueryRaw = jest.fn()
+
+jest.mock('@/lib/db', () => ({
+  __esModule: true,
+  default: {
+    getInstance: () => ({ $queryRaw: mockQueryRaw }),
+  },
+}))
+
+import DBClient from '@/lib/db'
+import { getEligibleReminders } from './eligibility'
+
+describe('getEligibleReminders', () => {
+  beforeEach(() => {
+    mockQueryRaw.mockReset()
+  })
+
+  it('returns rows verbatim from the underlying $queryRaw call', async () => {
+    const rows = [
+      {
+        taskId: 't1',
+        workspaceId: 'ws1',
+        assigneeId: 'c1',
+        assigneeType: AssigneeType.client,
+        companyId: 'co1',
+        reminderType: TaskReminderType.NO_DUE_DATE_3D,
+      },
+    ]
+    mockQueryRaw.mockResolvedValueOnce(rows)
+
+    const result = await getEligibleReminders(DBClient.getInstance())
+
+    expect(result).toEqual(rows)
+  })
+
+  it('returns an empty array when no tasks are eligible', async () => {
+    mockQueryRaw.mockResolvedValueOnce([])
+    const result = await getEligibleReminders(DBClient.getInstance())
+    expect(result).toEqual([])
+  })
+
+  it('issues exactly one $queryRaw call', async () => {
+    mockQueryRaw.mockResolvedValueOnce([])
+    await getEligibleReminders(DBClient.getInstance())
+    expect(mockQueryRaw).toHaveBeenCalledTimes(1)
+  })
+
+  it('propagates errors from $queryRaw', async () => {
+    mockQueryRaw.mockRejectedValueOnce(new Error('connection refused'))
+    await expect(getEligibleReminders(DBClient.getInstance())).rejects.toThrow('connection refused')
+  })
+})

--- a/src/jobs/notifications/eligibility.ts
+++ b/src/jobs/notifications/eligibility.ts
@@ -1,0 +1,75 @@
+import DBClient from '@/lib/db'
+import { AssigneeType, TaskReminderType } from '@prisma/client'
+
+export type EligibilityRow = {
+  taskId: string
+  workspaceId: string
+  assigneeId: string
+  assigneeType: AssigneeType
+  /**
+   * Company context for the recipient.
+   * - assigneeType='client'      → task.companyId (a client may belong to multiple companies on Copilot;
+   *                                this disambiguates which "hat" they're wearing for this task)
+   * - assigneeType='company'     → assigneeId (the company IS the assignee; caller fans out to members)
+   * - assigneeType='internalUser'→ null (IUs have no company concept and never receive email notifications)
+   *
+   * Required for ClientNotifications inserts (unique key includes companyId) and for
+   * Copilot's recipientCompanyId on email-bearing notifications. See
+   * src/app/api/notification/notification.service.ts:558.
+   */
+  companyId: string | null
+  reminderType: TaskReminderType
+}
+
+/**
+ * Returns one row per (task, assignee, reminderType) eligible for a reminder today.
+ *
+ * Company-assigned tasks emit a single row with assigneeType='company' and assigneeId
+ * set to the company id. Caller fans those out to individual members via Copilot —
+ * the SQL deliberately stops at the company boundary so DB has no Copilot dependency.
+ *
+ * Already-sent reminders are NOT filtered here. The TaskReminderSents unique constraint
+ * is the dedupe primitive at insert time, so a retried cron run is idempotent without
+ * an extra NOT EXISTS check (the windows are exact-day so day-N reminders don't repeat
+ * in normal operation).
+ */
+export const getEligibleReminders = async (db: ReturnType<typeof DBClient.getInstance>): Promise<EligibilityRow[]> => {
+  return db.$queryRaw<EligibilityRow[]>`
+    SELECT
+      t.id::text AS "taskId",
+      t."workspaceId",
+      t."assigneeId"::text AS "assigneeId",
+      t."assigneeType" AS "assigneeType",
+      (CASE
+        WHEN t."assigneeType" = 'company' THEN t."assigneeId"::text
+        WHEN t."assigneeType" = 'client'  THEN t."companyId"::text
+        ELSE NULL
+      END) AS "companyId",
+      (CASE
+        WHEN t."dueDate" IS NULL AND t."assignedAt"::date = CURRENT_DATE - 3 THEN 'NO_DUE_DATE_3D'
+        WHEN t."dueDate" IS NULL AND t."assignedAt"::date = CURRENT_DATE - 7 THEN 'NO_DUE_DATE_7D'
+        WHEN t."dueDate"::date = CURRENT_DATE + 3                            THEN 'DUE_DATE_BEFORE_3D'
+        WHEN t."dueDate"::date = CURRENT_DATE                                THEN 'DUE_DATE_TODAY'
+        WHEN t."dueDate"::date = CURRENT_DATE - 3                            THEN 'DUE_DATE_OVERDUE_3D'
+        WHEN t."dueDate"::date = CURRENT_DATE - 7                            THEN 'DUE_DATE_OVERDUE_7D'
+      END)::"TaskReminderType" AS "reminderType"
+    FROM "Tasks" t
+    LEFT JOIN "Tasks" parent ON parent.id = t."parentId"
+    WHERE t."deletedAt" IS NULL
+      AND t."isArchived" = false
+      AND t."completedAt" IS NULL
+      AND t."assigneeId" IS NOT NULL
+      AND t."assigneeType" IS NOT NULL
+      -- Subtask carve-out: same-assignee subtasks fold into the parent reminder.
+      -- A NULL parent.assigneeId counts as "different" so a standalone subtask under
+      -- an unassigned parent still gets a reminder.
+      AND (t."parentId" IS NULL OR parent."assigneeId" IS DISTINCT FROM t."assigneeId")
+      -- Guard against malformed VARCHAR(10) dueDate values: only cast when the string
+      -- looks like ISO YYYY-MM-DD. Without this, a single bad row poisons the whole query.
+      AND (t."dueDate" IS NULL OR t."dueDate" ~ '^[0-9]{4}-[0-9]{2}-[0-9]{2}$')
+      AND (
+        (t."dueDate" IS NULL AND t."assignedAt"::date IN (CURRENT_DATE - 3, CURRENT_DATE - 7))
+        OR t."dueDate"::date IN (CURRENT_DATE - 7, CURRENT_DATE - 3, CURRENT_DATE, CURRENT_DATE + 3)
+      )
+  `
+}

--- a/src/jobs/notifications/eligibility.ts
+++ b/src/jobs/notifications/eligibility.ts
@@ -54,7 +54,16 @@ export const getEligibleReminders = async (db: ReturnType<typeof DBClient.getIns
         WHEN t."dueDate"::date = CURRENT_DATE - 7                            THEN 'DUE_DATE_OVERDUE_7D'
       END)::"TaskReminderType" AS "reminderType"
     FROM "Tasks" t
-    LEFT JOIN "Tasks" parent ON parent.id = t."parentId"
+    -- Only join "alive" parents. The carve-out below folds same-assignee subtasks
+    -- into the parent's reminder, which is only meaningful when the parent itself
+    -- is eligible for one. For soft-deleted / archived / completed parents the join
+    -- returns NULL, which IS DISTINCT FROM any real assigneeId, so the subtask
+    -- correctly emits its own reminder.
+    LEFT JOIN "Tasks" parent
+      ON parent.id = t."parentId"
+      AND parent."deletedAt" IS NULL
+      AND parent."isArchived" = false
+      AND parent."completedAt" IS NULL
     WHERE t."deletedAt" IS NULL
       AND t."isArchived" = false
       AND t."completedAt" IS NULL
@@ -62,7 +71,8 @@ export const getEligibleReminders = async (db: ReturnType<typeof DBClient.getIns
       AND t."assigneeType" IS NOT NULL
       -- Subtask carve-out: same-assignee subtasks fold into the parent reminder.
       -- A NULL parent.assigneeId counts as "different" so a standalone subtask under
-      -- an unassigned parent still gets a reminder.
+      -- an unassigned parent (or under a dead parent, per the join filter above)
+      -- still gets a reminder.
       AND (t."parentId" IS NULL OR parent."assigneeId" IS DISTINCT FROM t."assigneeId")
       -- Guard against malformed VARCHAR(10) dueDate values: only cast when the string
       -- looks like ISO YYYY-MM-DD. Without this, a single bad row poisons the whole query.


### PR DESCRIPTION
## Changes

- [x] New module `src/jobs/notifications/eligibility.ts` exposing `getEligibleReminders()` — a single raw-SQL query that returns one row per `(task, assignee, reminderType)` eligible for a task reminder today.
- [x] Covers the six exact-day windows from the PRD: `NO_DUE_DATE_3D`, `NO_DUE_DATE_7D`, `DUE_DATE_BEFORE_3D`, `DUE_DATE_TODAY`, `DUE_DATE_OVERDUE_3D`, `DUE_DATE_OVERDUE_7D`.
- [x] Exclusions per PRD: soft-deleted, archived, completed, and unassigned tasks are dropped; same-assignee subtasks fold into the parent (using `IS DISTINCT FROM` so a NULL parent assignee still counts as "different").
- [x] Malformed-date guard: regex check on `Task.dueDate` (`VARCHAR(10)`) before `::date` cast so one bad row can't poison the query.
- [x] `EligibilityRow` carries `companyId` derived per `assigneeType` (client → `task.companyId`; company → `task.assigneeId`; internalUser → `null`) so the future sender can stamp `ClientNotifications.companyId` and Copilot's `recipientCompanyId` without re-fetching the task.
- [x] Unit tests in `eligibility.test.ts` covering the function's behavior (mocked `$queryRaw`).

Linear: https://linear.app/assemblycom/issue/OUT-3736/eligibility-sql-single-day-reminder-query

## Testing Criteria

- [x] `yarn test src/jobs/notifications/eligibility.test.ts` — 4 passing, 100% coverage on the module.
- [ ] Smoke-tested the SQL against Supabase preview / production using a widened date window to confirm the filters (deleted / archived / completed / subtask carve-out / dueDate regex) behave as expected against real data. Reverted to exact-day match for production.
- [ ] Verified by inspection that the per-`assigneeType` `companyId` derivation matches what `notification.service.ts:558` and `ClientNotifications`'s unique key `(taskId, clientId, companyId, deletedAt)` expect.

Boundary fixtures (D-3 hit, D-2 / D-4 miss) are deferred to the consumer ticket where a Postgres-backed integration test is more useful — this module is a thin SQL wrapper and is currently not wired into any cron.

## Notes

- Already-sent reminders are **not** filtered here. The `TaskReminderSents` unique constraint is the dedupe primitive at insert time, so a retried cron run is naturally idempotent. The exact-day windows mean a given (task, window) pair only matches on one calendar day, so day-N reminders don't repeat in normal operation.
- Company fan-out (one task → many client recipients) is deferred to the caller via `copilot.getCompanyClients(...)`. Keeping the SQL Copilot-free mirrors the pattern in `src/jobs/auto-archive/auto-archive-completed-tasks.ts:31-82`.
- No Trigger.dev cron wiring in this PR — that lands with the sender ticket.

## Impact & Surface Area of Change

- **Net-new module**, not imported anywhere yet. Zero runtime behavior change in this PR.
- No schema changes, no migrations, no Prisma client regeneration needed.
- Safe to merge ahead of the sender + cron PRs without affecting any existing notification path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)