### PR TITLE
fix(POR-19989): re-sign attachment node URLs in task comments, bodies, templates

### DIFF
--- a/src/utils/signedUrlReplacer.test.ts
+++ b/src/utils/signedUrlReplacer.test.ts
@@ -1,0 +1,80 @@
+jest.mock('@/utils/signUrl', () => ({
+  getSignedUrl: jest.fn(),
+}))
+
+import { replaceImageSrc, getFilePathFromUrl } from '@/utils/signedUrlReplacer'
+
+describe('replaceImageSrc', () => {
+  const mockGetSignedUrl = jest.fn((filePath: string) =>
+    Promise.resolve(`https://supabase.co/storage/v1/object/sign/media/${filePath}?token=fresh`),
+  )
+
+  beforeEach(() => {
+    mockGetSignedUrl.mockClear()
+  })
+
+  it('re-signs img tag src', async () => {
+    const html = '<p>Hello</p><img src="https://supabase.co/storage/v1/object/sign/media/ws/img.png?token=old">'
+    const result = await replaceImageSrc(html, mockGetSignedUrl)
+    expect(result).toContain('token=fresh')
+    expect(result).not.toContain('token=old')
+    expect(mockGetSignedUrl).toHaveBeenCalledWith('ws/img.png')
+  })
+
+  it('re-signs attachment tag src', async () => {
+    const html =
+      '<div data-type="attachment" src="https://supabase.co/storage/v1/object/sign/media/ws/doc.pdf?token=old"></div>'
+    const result = await replaceImageSrc(html, mockGetSignedUrl)
+    expect(result).toContain('token=fresh')
+    expect(result).not.toContain('token=old')
+    expect(mockGetSignedUrl).toHaveBeenCalledWith('ws/doc.pdf')
+  })
+
+  it('re-signs both img and attachment tags in the same HTML', async () => {
+    const html = [
+      '<img src="https://supabase.co/storage/v1/object/sign/media/ws/img.png?token=old">',
+      '<div data-type="attachment" src="https://supabase.co/storage/v1/object/sign/media/ws/doc.pdf?token=old"></div>',
+    ].join('')
+    const result = await replaceImageSrc(html, mockGetSignedUrl)
+    expect(result).not.toContain('token=old')
+    expect(mockGetSignedUrl).toHaveBeenCalledTimes(2)
+    expect(mockGetSignedUrl).toHaveBeenCalledWith('ws/img.png')
+    expect(mockGetSignedUrl).toHaveBeenCalledWith('ws/doc.pdf')
+  })
+
+  it('deduplicates the same URL across img and attachment tags', async () => {
+    const url = 'https://supabase.co/storage/v1/object/sign/media/ws/file.png?token=old'
+    const html = `<img src="${url}"><div data-type="attachment" src="${url}"></div>`
+    await replaceImageSrc(html, mockGetSignedUrl)
+    expect(mockGetSignedUrl).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns html unchanged when there are no img or attachment tags', async () => {
+    const html = '<p>No media here</p>'
+    const result = await replaceImageSrc(html, mockGetSignedUrl)
+    expect(result).toBe(html)
+    expect(mockGetSignedUrl).not.toHaveBeenCalled()
+  })
+
+  it('skips URLs that do not contain /media/ path', async () => {
+    const html = '<img src="https://example.com/other/path.png">'
+    const result = await replaceImageSrc(html, mockGetSignedUrl)
+    expect(result).toBe(html)
+    expect(mockGetSignedUrl).not.toHaveBeenCalled()
+  })
+})
+
+describe('getFilePathFromUrl', () => {
+  it('extracts file path after /media/', () => {
+    const url = 'https://supabase.co/storage/v1/object/sign/media/ws/img.png?token=abc'
+    expect(getFilePathFromUrl(url)).toBe('ws/img.png')
+  })
+
+  it('returns null for invalid URLs', () => {
+    expect(getFilePathFromUrl('not-a-url')).toBeNull()
+  })
+
+  it('returns undefined for URLs without /media/ segment', () => {
+    expect(getFilePathFromUrl('https://example.com/other/path')).toBeUndefined()
+  })
+})

--- a/src/utils/signedUrlReplacer.ts
+++ b/src/utils/signedUrlReplacer.ts
@@ -1,22 +1,28 @@
 import { getSignedUrl } from '@/utils/signUrl'
 import { Comment } from '@prisma/client'
 
+const imgTagRegex = /<img\s+[^>]*src="([^"]+)"[^>]*>/g
+const attachmentTagRegex = /<\s*[a-zA-Z]+\s+[^>]*data-type="attachment"[^>]*src="([^"]+)"[^>]*>/g
+
 export async function replaceImageSrc(htmlString: string, getSignedUrl: (filePath: string) => Promise<string | undefined>) {
-  const imgTagRegex = /<img\s+[^>]*src="([^"]+)"[^>]*>/g //expression used to match all img tags in provided HTML string.
   const replacements: { originalSrc: string; newUrl: string }[] = []
+  const seen = new Set<string>()
   let match
 
-  // First pass: collect all replacements
-  while ((match = imgTagRegex.exec(htmlString)) !== null) {
-    const originalSrc = match[1] //matches the content of the first capture of regex, ie string inside the src attribute of the img tag.
-    const filePath = getFilePathFromUrl(originalSrc)
-    if (filePath) {
-      const newUrl = await getSignedUrl(filePath)
-      newUrl && replacements.push({ originalSrc, newUrl })
+  for (const regex of [imgTagRegex, attachmentTagRegex]) {
+    regex.lastIndex = 0
+    while ((match = regex.exec(htmlString)) !== null) {
+      const originalSrc = match[1]
+      if (seen.has(originalSrc)) continue
+      seen.add(originalSrc)
+      const filePath = getFilePathFromUrl(originalSrc)
+      if (filePath) {
+        const newUrl = await getSignedUrl(filePath)
+        newUrl && replacements.push({ originalSrc, newUrl })
+      }
     }
   }
 
-  // Second pass: apply all replacements
   for (const { originalSrc, newUrl } of replacements) {
     htmlString = htmlString.replace(originalSrc, newUrl)
   }


### PR DESCRIPTION
## Summary

- Non-image attachments (PDFs, docs) in task comments/bodies/templates had signed Supabase URLs expire after 1 hour because replaceImageSrc only matched img tags
- Added attachmentTagRegex to also re-sign div[data-type=attachment] nodes on every read, with URL deduplication
- Root cause: Tapwrite emits non-image files as attachment nodes, not img tags

## Test plan

- [x] Unit tests pass (9/9)
- [ ] Manual: create a task comment with a PDF, wait >1 hour, verify download still works
- [ ] Manual: verify existing image attachments still re-sign correctly