### PR TITLE
OUT-3762: subtask viewers inherited from parent task regardless of caller identity

### DIFF
--- a/src/app/api/tasks/tasksShared.service.ts
+++ b/src/app/api/tasks/tasksShared.service.ts
@@ -610,7 +610,7 @@ export abstract class TasksSharedService extends BaseService {
 
   protected async createSubtasksFromTemplate(data: TaskTemplate, parentTask: Task, manualTimestamp: Date) {
     const { workspaceId, title, body, workflowStateId } = data
-    const { id: parentId, internalUserId, clientId, companyId, associations } = parentTask
+    const { id: parentId, internalUserId, clientId, companyId, associations, isShared } = parentTask
 
     try {
       const createTaskPayload = CreateTaskRequestSchema.parse({
@@ -624,6 +624,7 @@ export abstract class TasksSharedService extends BaseService {
         clientId,
         companyId,
         associations,
+        isShared,
       })
 
       await this.createTask(createTaskPayload, { disableSubtaskTemplates: true, manualTimestamp: manualTimestamp })


### PR DESCRIPTION
## Summary
- When creating subtasks from a template (e.g. via native automation), the parent task's isShared flag was not being propagated to the subtask
- This meant subtasks created by automations (which authenticate as internal users) would not inherit the Share with Client setting from the parent task
- Fix: pass isShared from parentTask through to the CreateTaskRequestSchema.parse() call in createSubtasksFromTemplate

## Test plan
- [ ] Create a parent task shared with a client (isShared: true, with associations, clientId/companyId)
- [ ] Trigger an automation that creates subtasks from a template on that parent task
- [ ] Verify the subtasks inherit isShared: true and are visible to the client
- [ ] Verify subtasks on non-shared parent tasks remain unshared

## Testing criteria

https://www.loom.com/share/bee18a8fecba45439962fd65dce6484a