### PR TITLE
OUT-3763 | Attachments on Task Comments Are Not Loading

### DIFF
--- a/src/app/api/comments/comment.service.ts
+++ b/src/app/api/comments/comment.service.ts
@@ -56,10 +56,14 @@ export class CommentService extends BaseService {
     })
 
     let commentToReturn = comment // return the latest comment object with attachments (if any)
+    let oldFilePathsToRemove: string[] = []
     try {
       if (comment.content) {
-        const newContent = await this.updateCommentIdOfAttachmentsAfterCreation(comment.content, data.taskId, comment.id)
-        // mutate commentToReturn here with signed attachment urls
+        const { content: newContent, oldFilePaths } = await this.updateCommentIdOfAttachmentsAfterCreation(
+          comment.content,
+          data.taskId,
+          comment.id,
+        )
         commentToReturn = await this.db.comment.update({
           where: { id: comment.id },
           data: {
@@ -68,11 +72,28 @@ export class CommentService extends BaseService {
           },
           include: { attachments: true },
         })
+        oldFilePathsToRemove = oldFilePaths
         console.info('CommentService#createComment | Comment content attachments updated for comment ID:', comment.id)
       }
     } catch (e: unknown) {
       await this.db.comment.delete({ where: { id: comment.id } })
       console.error('CommentService#createComment | Rolling back comment creation', e)
+      // Without this the activity log + webhook below fire for a deleted comment.
+      throw e
+    }
+
+    // Remove originals only after the rewritten content is committed.
+    if (oldFilePathsToRemove.length) {
+      const supabaseActions = new SupabaseActions()
+      await Promise.all(
+        oldFilePathsToRemove.map(async (path) => {
+          try {
+            await supabaseActions.removeAttachment(path)
+          } catch (err) {
+            console.warn('OUT-3763: failed to remove old attachment after copy', path, err)
+          }
+        }),
+      )
     }
 
     if (!comment.parentId) {
@@ -323,83 +344,87 @@ export class CommentService extends BaseService {
     })
   }
 
-  private async updateCommentIdOfAttachmentsAfterCreation(htmlString: string, task_id: string, commentId: string) {
-    const imgTagRegex = /<img\s+[^>]*src="([^"]+)"[^>]*>/g //expression used to match all img srcs in provided HTML string.
-    const attachmentTagRegex = /<\s*[a-zA-Z]+\s+[^>]*data-type="attachment"[^>]*src="([^"]+)"[^>]*>/g //expression used to match all attachment srcs in provided HTML string.
+  // OUT-3763: copy (not move) and sign before any DB write so a failure here
+  // never leaves the comment content pointing at a path the file isn't at.
+  private async updateCommentIdOfAttachmentsAfterCreation(
+    htmlString: string,
+    task_id: string,
+    commentId: string,
+  ): Promise<{ content: string; oldFilePaths: string[] }> {
+    const imgTagRegex = /<img\s+[^>]*src="([^"]+)"[^>]*>/g
+    const attachmentTagRegex = /<\s*[a-zA-Z]+\s+[^>]*data-type="attachment"[^>]*src="([^"]+)"[^>]*>/g
     let match
-    const replacements: { originalSrc: string; newUrl: string }[] = []
-
-    const newFilePaths: { originalSrc: string; newFilePath: string }[] = []
-    const copyAttachmentPromises: Promise<void>[] = []
-    const createAttachmentPayloads = []
     const matches: { originalSrc: string; filePath: string; fileName: string }[] = []
+    const seenSrcs = new Set<string>()
 
-    while ((match = imgTagRegex.exec(htmlString)) !== null) {
-      const originalSrc = match[1]
-      const filePath = getFilePathFromUrl(originalSrc)
-      const fileName = filePath?.split('/').pop()
-      if (filePath && fileName) {
-        matches.push({ originalSrc, filePath, fileName })
+    for (const regex of [imgTagRegex, attachmentTagRegex]) {
+      regex.lastIndex = 0
+      while ((match = regex.exec(htmlString)) !== null) {
+        const originalSrc = match[1]
+        if (seenSrcs.has(originalSrc)) continue
+        const filePath = getFilePathFromUrl(originalSrc)
+        const fileName = filePath?.split('/').pop()
+        if (filePath && fileName) {
+          seenSrcs.add(originalSrc)
+          matches.push({ originalSrc, filePath, fileName })
+        }
       }
     }
 
-    while ((match = attachmentTagRegex.exec(htmlString)) !== null) {
-      const originalSrc = match[1]
-      const filePath = getFilePathFromUrl(originalSrc)
-      const fileName = filePath?.split('/').pop()
-      if (filePath && fileName) {
-        matches.push({ originalSrc, filePath, fileName })
-      }
-    }
+    const supabaseActions = new SupabaseActions()
+    const createAttachmentPayloads: ReturnType<typeof CreateAttachmentRequestSchema.parse>[] = []
+    const replacements: { originalSrc: string; newUrl: string }[] = []
+    const oldFilePaths: string[] = []
+    const newFilePathsList: string[] = []
 
     for (const { originalSrc, filePath, fileName } of matches) {
       const newFilePath = `${this.user.workspaceId}/${task_id}/comments/${commentId}/${fileName}`
-      const supabaseActions = new SupabaseActions()
-
       const fileMetaData = await supabaseActions.getMetaData(filePath)
       createAttachmentPayloads.push(
         CreateAttachmentRequestSchema.parse({
-          commentId: commentId,
+          commentId,
           filePath: newFilePath,
           fileSize: fileMetaData?.size,
           fileType: fileMetaData?.contentType,
           fileName: fileMetaData?.metadata?.originalFileName || getFileNameFromPath(newFilePath),
         }),
       )
-      copyAttachmentPromises.push(supabaseActions.moveAttachment(filePath, newFilePath))
-      newFilePaths.push({ originalSrc, newFilePath })
+      await supabaseActions.copyAttachment(filePath, newFilePath)
+
+      let newUrl = await getSignedUrl(newFilePath)
+      if (!newUrl) {
+        // Supabase's signer can briefly lag a fresh write.
+        await new Promise((resolve) => setTimeout(resolve, 200))
+        newUrl = await getSignedUrl(newFilePath)
+      }
+      if (!newUrl) {
+        throw new APIError(
+          httpStatus.INTERNAL_SERVER_ERROR,
+          `Failed to sign URL for newly copied attachment at ${newFilePath}`,
+        )
+      }
+      replacements.push({ originalSrc, newUrl })
+      oldFilePaths.push(filePath)
+      newFilePathsList.push(newFilePath)
     }
 
-    await Promise.all(copyAttachmentPromises)
-    const attachmentService = new AttachmentsService(this.user)
+    for (const { originalSrc, newUrl } of replacements) {
+      htmlString = htmlString.replaceAll(originalSrc, newUrl)
+    }
+
     if (createAttachmentPayloads.length) {
+      const attachmentService = new AttachmentsService(this.user)
       await attachmentService.createMultipleAttachments(createAttachmentPayloads)
     }
 
-    const signedUrlPromises = newFilePaths.map(async ({ originalSrc, newFilePath }) => {
-      const newUrl = await getSignedUrl(newFilePath)
-      if (newUrl) {
-        replacements.push({ originalSrc, newUrl })
-      }
-    })
-
-    await Promise.all(signedUrlPromises)
-
-    for (const { originalSrc, newUrl } of replacements) {
-      htmlString = htmlString.replace(originalSrc, newUrl)
+    if (newFilePathsList.length) {
+      await this.db.scrapMedia.updateMany({
+        where: { filePath: { in: newFilePathsList } },
+        data: { commentId },
+      })
     }
-    const filePaths = newFilePaths.map(({ newFilePath }) => newFilePath)
-    await this.db.scrapMedia.updateMany({
-      where: {
-        filePath: {
-          in: filePaths,
-        },
-      },
-      data: {
-        commentId: commentId,
-      },
-    })
-    return htmlString
+
+    return { content: htmlString, oldFilePaths }
   } //todo: make this resuable since this is highly similar to what we are doing on tasks.
 
   async getAllComments(queryFilters: CommentsPublicFilterType): Promise<CommentWithAttachments[]> {

--- a/src/utils/signedUrlReplacer.ts
+++ b/src/utils/signedUrlReplacer.ts
@@ -59,10 +59,61 @@ export const replaceImgSrcs = (body: string, newSrcs: string[], oldSrcs: string[
 
 export const signMediaForComments = async (comments: Comment[]) =>
   await Promise.all(
-    comments.map(async (comment) => {
-      return {
-        ...comment,
-        content: await replaceImageSrc(comment.content, getSignedUrl),
-      }
-    }),
+    comments.map(async (comment) => ({
+      ...comment,
+      content: await rewriteCommentMediaSrcs(comment.content, comment.id),
+    })),
   )
+
+// OUT-3763 fallback for ~26 comments whose stored URLs point at a pre-move
+// path. Attachment tags are only rewritten when the path lacks the
+// comment-scoped segment — downloads use the path, not the token, so healthy
+// attachment tags need no work. Remove this once the backfill lands.
+const IMG_TAG_REGEX = /<img\s+[^>]*src="([^"]+)"[^>]*>/g
+const ATTACHMENT_TAG_REGEX = /<\s*[a-zA-Z]+\s+[^>]*data-type="attachment"[^>]*src="([^"]+)"[^>]*>/g
+
+async function rewriteCommentMediaSrcs(htmlString: string, commentId: string): Promise<string> {
+  const replacements: { originalSrc: string; newUrl: string }[] = []
+  const seen = new Set<string>()
+  let match
+
+  IMG_TAG_REGEX.lastIndex = 0
+  while ((match = IMG_TAG_REGEX.exec(htmlString)) !== null) {
+    const originalSrc = match[1]
+    if (seen.has(originalSrc)) continue
+    seen.add(originalSrc)
+    const filePath = getFilePathFromUrl(originalSrc)
+    if (!filePath) continue
+    const newUrl = await signCommentMediaPath(filePath, commentId)
+    if (newUrl) replacements.push({ originalSrc, newUrl })
+  }
+
+  ATTACHMENT_TAG_REGEX.lastIndex = 0
+  while ((match = ATTACHMENT_TAG_REGEX.exec(htmlString)) !== null) {
+    const originalSrc = match[1]
+    if (seen.has(originalSrc)) continue
+    const filePath = getFilePathFromUrl(originalSrc)
+    if (!filePath) continue
+    if (filePath.includes(`/comments/${commentId}/`)) continue
+    seen.add(originalSrc)
+    const newUrl = await signCommentMediaPath(filePath, commentId)
+    if (newUrl) replacements.push({ originalSrc, newUrl })
+  }
+
+  for (const { originalSrc, newUrl } of replacements) {
+    htmlString = htmlString.replace(originalSrc, newUrl)
+  }
+  return htmlString
+}
+
+async function signCommentMediaPath(filePath: string, commentId: string): Promise<string | undefined> {
+  const primary = await getSignedUrl(filePath)
+  if (primary) return primary
+
+  const segments = filePath.split('/')
+  const fileName = segments.pop()
+  const prefix = segments.join('/')
+  if (!fileName || !prefix) return undefined
+
+  return await getSignedUrl(`${prefix}/comments/${commentId}/${fileName}`)
+}


### PR DESCRIPTION
## Changes

**Write side — stops new comments from getting corrupted.** `CommentService.updateCommentIdOfAttachmentsAfterCreation`:
- `moveAttachment` → `copyAttachment`. The original file stays in place until the rewritten content is committed, so a failure mid-flight is recoverable.
- Signing the new path now retries once after 200ms (handles Supabase's metadata-vs-signer eventual consistency immediately after a write) and **throws** on persistent failure instead of silently dropping the replacement.
- `htmlString.replace` → `htmlString.replaceAll` so the same file embedded twice gets both occurrences rewritten.
- The function returns `{ content, oldFilePaths }` so the caller can defer deletion of the originals until after `comment.update` commits.
- `create()` now re-throws after the rollback `comment.delete` so the activity log, notifications, and webhook below don't fire for a comment that no longer exists.

**Read side — masks the existing ~26 corrupted rows.** `signMediaForComments` now routes through a comment-scoped signer that:
- Always re-signs `<img>` srcs (images need a fresh token to render); on signing failure it falls back to `{prefix}/comments/{commentId}/{fileName}`.
- Only rewrites `<div data-type="attachment">` srcs whose path is missing `/comments/{commentId}/` — healthy attachment tags are untouched (downloads use the path, not the token, so re-signing them does no useful work and just adds Supabase round-trips).

The read-side block is annotated for removal once the corrupted rows are backfilled.

## Testing Criteria

- [x] Create a fresh comment with an image attachment → renders immediately and after reload.
- [x] Create a fresh comment with a PDF/doc attachment → download works immediately and after reload.
- [x] Create a comment that embeds the same image twice (paste twice in the editor) → both occurrences render after reload.
- [x] Proxy into the OUT-3763-affected workspace, open one of the 26 affected comments → image renders; if the comment also has a file attachment, the download works.
- [x] Force a signing failure by temporarily breaking the Supabase storage URL → create a comment → confirm the comment row does not get saved, and confirm no activity log / webhook fires for the failed comment.

## Notes

- This is the immediate-mitigation PR for OUT-3763. The 26 already-corrupted `Comments.content` rows still need a backfill (separate ticket) to permanently rewrite their stored URLs to the comment-scoped path. Once that backfill is verified clean, the read-side fallback block in `src/utils/signedUrlReplacer.ts` can be deleted.
- The identical bug class lives in `tasksShared.service.ts:498` for tasks created with files staged before the task ID existed. Not changed in this PR per scope; worth confirming whether task creation paths are actually exercising the same code today.

## Impact & Surface Area of Change

- **Every comment-create call** now runs through the new copy-not-move + retry-then-throw flow. Failure mode shifts from "silently saves stale content" to "returns 500, comment row deleted". The route handler's existing `withErrorHandler` already surfaces this as a clean HTTP error.
- **Every comment read** (task detail page activity log, replies fetch) now routes through `rewriteCommentMediaSrcs` instead of `replaceImageSrc`. Cost on healthy comments: same as before for `<img>` (one signing call); zero new calls for `<div data-type="attachment">` tags. Cost on the 26 affected comments: one extra failing signing call per stale src.
- `replaceImageSrc` is untouched and still used by task body and template rewrites — no change for those paths.



## TESTING

<img width="1139" height="626" alt="image" src="https://github.com/user-attachments/assets/381f19d5-57fb-45cd-a492-13129ed5c2bd" />
New Upload and copy functionality works as expected. 


BEFORE: 
<img width="851" height="668" alt="image" src="https://github.com/user-attachments/assets/a88db8e0-2b0f-4611-8230-c5f346d0c839" />



AFTER: 
<img width="850" height="570" alt="image" src="https://github.com/user-attachments/assets/1e51a1ee-5dc2-4a6a-a176-e431a8ac0c5e" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)