### PR TITLE
OUT-3763 (1/2) | Fall back to comment-scoped path for stale attachment URLs

### DIFF
--- a/src/utils/signedUrlReplacer.ts
+++ b/src/utils/signedUrlReplacer.ts
@@ -59,10 +59,61 @@ export const replaceImgSrcs = (body: string, newSrcs: string[], oldSrcs: string[
 
 export const signMediaForComments = async (comments: Comment[]) =>
   await Promise.all(
-    comments.map(async (comment) => {
-      return {
-        ...comment,
-        content: await replaceImageSrc(comment.content, getSignedUrl),
-      }
-    }),
+    comments.map(async (comment) => ({
+      ...comment,
+      content: await rewriteCommentMediaSrcs(comment.content, comment.id),
+    })),
   )
+
+// OUT-3763 fallback for ~26 comments whose stored URLs point at a pre-move
+// path. Attachment tags are only rewritten when the path lacks the
+// comment-scoped segment — downloads use the path, not the token, so healthy
+// attachment tags need no work. Remove this once the backfill lands.
+const IMG_TAG_REGEX = /<img\s+[^>]*src="([^"]+)"[^>]*>/g
+const ATTACHMENT_TAG_REGEX = /<\s*[a-zA-Z]+\s+[^>]*data-type="attachment"[^>]*src="([^"]+)"[^>]*>/g
+
+async function rewriteCommentMediaSrcs(htmlString: string, commentId: string): Promise<string> {
+  const replacements: { originalSrc: string; newUrl: string }[] = []
+  const seen = new Set<string>()
+  let match
+
+  IMG_TAG_REGEX.lastIndex = 0
+  while ((match = IMG_TAG_REGEX.exec(htmlString)) !== null) {
+    const originalSrc = match[1]
+    if (seen.has(originalSrc)) continue
+    seen.add(originalSrc)
+    const filePath = getFilePathFromUrl(originalSrc)
+    if (!filePath) continue
+    const newUrl = await signCommentMediaPath(filePath, commentId)
+    if (newUrl) replacements.push({ originalSrc, newUrl })
+  }
+
+  ATTACHMENT_TAG_REGEX.lastIndex = 0
+  while ((match = ATTACHMENT_TAG_REGEX.exec(htmlString)) !== null) {
+    const originalSrc = match[1]
+    if (seen.has(originalSrc)) continue
+    const filePath = getFilePathFromUrl(originalSrc)
+    if (!filePath) continue
+    if (filePath.includes(`/comments/${commentId}/`)) continue
+    seen.add(originalSrc)
+    const newUrl = await signCommentMediaPath(filePath, commentId)
+    if (newUrl) replacements.push({ originalSrc, newUrl })
+  }
+
+  for (const { originalSrc, newUrl } of replacements) {
+    htmlString = htmlString.replace(originalSrc, newUrl)
+  }
+  return htmlString
+}
+
+async function signCommentMediaPath(filePath: string, commentId: string): Promise<string | undefined> {
+  const primary = await getSignedUrl(filePath)
+  if (primary) return primary
+
+  const segments = filePath.split('/')
+  const fileName = segments.pop()
+  const prefix = segments.join('/')
+  if (!fileName || !prefix) return undefined
+
+  return await getSignedUrl(`${prefix}/comments/${commentId}/${fileName}`)
+}

--- a/src/utils/signedUrlReplacer.ts
+++ b/src/utils/signedUrlReplacer.ts
@@ -69,16 +69,16 @@ export const signMediaForComments = async (comments: Comment[]) =>
 // path. Attachment tags are only rewritten when the path lacks the
 // comment-scoped segment — downloads use the path, not the token, so healthy
 // attachment tags need no work. Remove this once the backfill lands.
-const IMG_TAG_REGEX = /<img\s+[^>]*src="([^"]+)"[^>]*>/g
-const ATTACHMENT_TAG_REGEX = /<\s*[a-zA-Z]+\s+[^>]*data-type="attachment"[^>]*src="([^"]+)"[^>]*>/g
-
 async function rewriteCommentMediaSrcs(htmlString: string, commentId: string): Promise<string> {
+  // Regexes are created per-call: /g state is mutable and signMediaForComments
+  // runs this concurrently via Promise.all — module-level instances would race.
+  const imgTagRegex = /<img\s+[^>]*src="([^"]+)"[^>]*>/g
+  const attachmentTagRegex = /<\s*[a-zA-Z]+\s+[^>]*data-type="attachment"[^>]*src="([^"]+)"[^>]*>/g
   const replacements: { originalSrc: string; newUrl: string }[] = []
   const seen = new Set<string>()
   let match
 
-  IMG_TAG_REGEX.lastIndex = 0
-  while ((match = IMG_TAG_REGEX.exec(htmlString)) !== null) {
+  while ((match = imgTagRegex.exec(htmlString)) !== null) {
     const originalSrc = match[1]
     if (seen.has(originalSrc)) continue
     seen.add(originalSrc)
@@ -88,8 +88,7 @@ async function rewriteCommentMediaSrcs(htmlString: string, commentId: string): P
     if (newUrl) replacements.push({ originalSrc, newUrl })
   }
 
-  ATTACHMENT_TAG_REGEX.lastIndex = 0
-  while ((match = ATTACHMENT_TAG_REGEX.exec(htmlString)) !== null) {
+  while ((match = attachmentTagRegex.exec(htmlString)) !== null) {
     const originalSrc = match[1]
     if (seen.has(originalSrc)) continue
     const filePath = getFilePathFromUrl(originalSrc)
@@ -101,7 +100,7 @@ async function rewriteCommentMediaSrcs(htmlString: string, commentId: string): P
   }
 
   for (const { originalSrc, newUrl } of replacements) {
-    htmlString = htmlString.replace(originalSrc, newUrl)
+    htmlString = htmlString.replaceAll(originalSrc, newUrl)
   }
   return htmlString
 }


### PR DESCRIPTION
## Changes

Patches the immediate user-visible symptom from OUT-3763: ~26 comments have `Comments.content` URLs pointing at the pre-move task-scoped path (`{ws}/{taskId}/{file}`), while the actual file lives at the comment-scoped path (`{ws}/{taskId}/comments/{commentId}/{file}`). On read, rewrite their srcs so the broken comments render until the backfill makes the stored content correct.

In `src/utils/signedUrlReplacer.ts`:
- `signMediaForComments` routes through a new comment-scoped signer (`signCommentMediaPath`) that tries the stored path first, and on failure retries against `{prefix}/comments/{commentId}/{fileName}`.
- `<img>` srcs always go through the signer (images need a fresh token to render).
- `<div data-type="attachment">` srcs are only rewritten when their stored path lacks `/comments/{commentId}/`. Downloads (`useDownloadFile`) use the path, not the token, so healthy attachment tags don't need a fresh signed URL — and we skip the signing call entirely.
- Original `replaceImageSrc` is untouched and still used by task body and template rewrites — no behavior change for those paths.

Marked for removal in the inline comment once the backfill ticket rewrites the affected `Comments.content` rows.

## Testing Criteria

- [x] Proxy into an OUT-3763-affected workspace, open one of the 26 affected comments → image renders; if the comment has a file attachment, the download works.
- [x] Healthy (non-affected) comments still render normally; check the network tab for `<div data-type="attachment">` srcs — no new signing calls should fire compared to before this PR.
- [x] Comment that has the same image embedded twice still renders both copies (dedup via `seen` set).
- [x] Task body and template body rendering unchanged (they still use `replaceImageSrc`).

## Notes

- This is the immediate-mitigation half of OUT-3763. The underlying-cause fix (write-side) is in a sibling PR — they're independent, either can merge first.
- The 26 stale `Comments.content` rows still need a backfill (separate ticket) to permanently rewrite their URLs. Once that lands, the OUT-3763 block in `signedUrlReplacer.ts` can be removed.

## Impact & Surface Area of Change

- **Every comment read** (task detail page activity log, replies fetch) now routes through `rewriteCommentMediaSrcs` instead of `replaceImageSrc`. For healthy comments: one signing call per `<img>` (unchanged), zero new calls for `<div data-type="attachment">` tags. For the 26 affected comments: one extra failing signing call per stale src, then a successful fallback call.
- `replaceImageSrc` is unchanged and still consumed by tasks and templates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)