### PR TITLE
OUT-3737 | Send flow: email-only delivery via NotificationService

### DIFF
--- a/src/jobs/notifications/send-reminder-email.test.ts
+++ b/src/jobs/notifications/send-reminder-email.test.ts
@@ -1,0 +1,118 @@
+import { WorkspaceResponse } from '@/types/common'
+import { CopilotAPI } from '@/utils/CopilotAPI'
+import { TaskReminderType } from '@prisma/client'
+import { sendReminderEmail } from './send-reminder-email'
+
+const workspace: WorkspaceResponse = {
+  id: 'ws_1',
+  brandName: 'Acme',
+  labels: {
+    individualTerm: 'client',
+    individualTermPlural: 'clients',
+    groupTerm: 'company',
+    groupTermPlural: 'companies',
+  },
+}
+
+const task = { id: 'task_1', title: 'Submit timesheet', createdById: 'iu_1' }
+
+const buildCopilotMock = (createNotification: jest.Mock) => ({ createNotification }) as unknown as CopilotAPI
+
+describe('sendReminderEmail', () => {
+  it('returns the Copilot notification id', async () => {
+    const createNotification = jest.fn().mockResolvedValue({ id: 'notif_1', createdAt: '2026-05-25T00:00:00Z' })
+
+    const id = await sendReminderEmail({
+      task,
+      recipientClientId: 'client_1',
+      recipientCompanyId: 'company_1',
+      reminderType: TaskReminderType.NO_DUE_DATE_3D,
+      isCompanyRecipient: false,
+      workspace,
+      copilot: buildCopilotMock(createNotification),
+    })
+
+    expect(id).toBe('notif_1')
+  })
+
+  it('builds an email-only payload (no inProduct, IU sender, client recipient)', async () => {
+    const createNotification = jest.fn().mockResolvedValue({ id: 'notif_1', createdAt: '2026-05-25T00:00:00Z' })
+
+    await sendReminderEmail({
+      task,
+      recipientClientId: 'client_1',
+      recipientCompanyId: 'company_1',
+      reminderType: TaskReminderType.NO_DUE_DATE_3D,
+      isCompanyRecipient: false,
+      workspace,
+      copilot: buildCopilotMock(createNotification),
+    })
+
+    expect(createNotification).toHaveBeenCalledTimes(1)
+    const payload = createNotification.mock.calls[0][0]
+    expect(payload).toMatchObject({
+      senderId: 'iu_1',
+      senderType: 'internalUser',
+      recipientClientId: 'client_1',
+      recipientCompanyId: 'company_1',
+    })
+    expect(payload.deliveryTargets.email).toEqual({
+      subject: 'Acme portal: [Reminder] You have a task to complete',
+      header: 'A task was assigned to you',
+      title: 'View task',
+      body: expect.stringContaining('‘Submit timesheet’'),
+    })
+    expect(payload.deliveryTargets.inProduct).toBeUndefined()
+  })
+
+  it('uses the company-recipient header when isCompanyRecipient=true', async () => {
+    const createNotification = jest.fn().mockResolvedValue({ id: 'notif_2', createdAt: '2026-05-25T00:00:00Z' })
+
+    await sendReminderEmail({
+      task,
+      recipientClientId: 'client_1',
+      recipientCompanyId: 'company_1',
+      reminderType: TaskReminderType.DUE_DATE_TODAY,
+      isCompanyRecipient: true,
+      workspace,
+      copilot: buildCopilotMock(createNotification),
+    })
+
+    const payload = createNotification.mock.calls[0][0]
+    expect(payload.deliveryTargets.email.header).toBe('A task was assigned to your company')
+    expect(payload.deliveryTargets.email.subject).toBe('Acme portal: [Due Soon] Task due today')
+  })
+
+  it('omits recipientCompanyId when null', async () => {
+    const createNotification = jest.fn().mockResolvedValue({ id: 'notif_3', createdAt: '2026-05-25T00:00:00Z' })
+
+    await sendReminderEmail({
+      task,
+      recipientClientId: 'client_1',
+      recipientCompanyId: null,
+      reminderType: TaskReminderType.NO_DUE_DATE_3D,
+      isCompanyRecipient: false,
+      workspace,
+      copilot: buildCopilotMock(createNotification),
+    })
+
+    const payload = createNotification.mock.calls[0][0]
+    expect(payload.recipientCompanyId).toBeUndefined()
+  })
+
+  it('propagates errors from Copilot (no ledger compensation here)', async () => {
+    const createNotification = jest.fn().mockRejectedValue(new Error('copilot 5xx'))
+
+    await expect(
+      sendReminderEmail({
+        task,
+        recipientClientId: 'client_1',
+        recipientCompanyId: 'company_1',
+        reminderType: TaskReminderType.NO_DUE_DATE_3D,
+        isCompanyRecipient: false,
+        workspace,
+        copilot: buildCopilotMock(createNotification),
+      }),
+    ).rejects.toThrow('copilot 5xx')
+  })
+})

--- a/src/jobs/notifications/send-reminder-email.ts
+++ b/src/jobs/notifications/send-reminder-email.ts
@@ -1,0 +1,58 @@
+import 'server-only'
+
+import { getReminderEmailDetails } from '@/app/api/notification/notification.helpers'
+import { NotificationRequestBody, WorkspaceResponse } from '@/types/common'
+import { CopilotAPI } from '@/utils/CopilotAPI'
+import { Task, TaskReminderType } from '@prisma/client'
+
+export type SendReminderEmailArgs = {
+  task: Pick<Task, 'id' | 'title' | 'createdById'>
+  recipientClientId: string
+  recipientCompanyId: string | null
+  reminderType: TaskReminderType
+  isCompanyRecipient: boolean
+  workspace: WorkspaceResponse
+  copilot: CopilotAPI
+}
+
+/**
+ * Dispatches a single task reminder email via Copilot's notification API.
+ *
+ * Email-only delivery: omits `deliveryTargets.inProduct` so no in-product notification
+ * is created. We also deliberately skip writing to `ClientNotification` —
+ * `ClientNotification` tracks read-state for in-product notifications, which reminders
+ * don't create. Reminder dedupe state lives in `TaskReminderSent`, which the caller
+ * inserts on success (the unique constraint is the idempotency primitive).
+ *
+ * Throws on Copilot failure. Callers compensate by NOT inserting into
+ * `TaskReminderSent`, so a future cron run will retry the same `(task, recipient, type)`.
+ */
+export const sendReminderEmail = async ({
+  task,
+  recipientClientId,
+  recipientCompanyId,
+  reminderType,
+  isCompanyRecipient,
+  workspace,
+  copilot,
+}: SendReminderEmailArgs): Promise<string> => {
+  const details = getReminderEmailDetails(workspace, task, isCompanyRecipient)[reminderType]
+
+  const payload: NotificationRequestBody = {
+    senderId: task.createdById,
+    senderType: 'internalUser',
+    recipientClientId,
+    recipientCompanyId: recipientCompanyId ?? undefined,
+    deliveryTargets: {
+      email: {
+        subject: details.subject,
+        header: details.header,
+        title: details.title,
+        body: details.body,
+      },
+    },
+  }
+
+  const notification = await copilot.createNotification(payload)
+  return notification.id
+}


### PR DESCRIPTION
## Changes

- [x] Add `src/jobs/notifications/send-reminder-email.ts` — `sendReminderEmail()` helper that dispatches a single reminder email via `copilot.createNotification` with `deliveryTargets.email` only.
- [x] Add `src/jobs/notifications/send-reminder-email.test.ts` — covers payload shape, return value, company-recipient header branch, null `recipientCompanyId`, and error propagation.

Implements [OUT-3737](https://linear.app/assemblycom/issue/OUT-3737).

### Why not reuse `NotificationService.create`

That method assumes a `NotificationTaskActions` action and writes to `ClientNotification` — which tracks read-state for in-product notifications that reminders don't create. Reminder dedupe state lives in `TaskReminderSent` (OUT-3734), inserted by the caller (OUT-3730 cron) on success as the idempotency primitive.

### What the helper deliberately does NOT do

- No write to `ClientNotification` / `InternalUserNotification`.
- No write to `TaskReminderSent` (caller's responsibility on success).
- No internal Copilot client init — caller passes in a per-workspace `CopilotAPI` so the cron can amortize one client across many tasks per workspace, per the ticket's "do not rely on request-scoped `this.copilot`".

## Testing Criteria

- [x] `yarn test src/jobs/notifications/send-reminder-email.test.ts` — 5/5 passing.
- [x] `yarn lint:check` — 0 errors on new files.
- [x] `yarn prettier:check` — clean.
- [ ] End-to-end verification deferred to OUT-3730 (cron that calls this) + OUT-3732 (staging dry-run).

## Notes

- Base branch is `feature/email-reminders`, not `main`. Bundles into PR #1256.
- Depends on OUT-3734 (`TaskReminderType` enum), OUT-3735 (`getReminderEmailDetails`) — both already merged into `feature/email-reminders`.
- Unblocks OUT-3730 (Trigger.dev scheduled task) which will import `sendReminderEmail` and own the per-workspace fan-out, company member resolution via `getCompanyClients`, and ledger inserts.
- `senderId = task.createdById` per the ticket. Flag in review if reminders should use a different sender identity (e.g. a system user).

## Impact & Surface Area of Change

- **Net new code only** — no existing notification flow (assign, comment, reassign, etc.) is touched. `NotificationService.create` is untouched, as is `getEmailDetails`. No DB schema change. No Trigger.dev registration.
- The helper is not wired up anywhere yet — it will only run once OUT-3730 lands and calls it. Until then there is zero production behavior change from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)