### PR TITLE
OUT-3738 | Observability: structured logging + Sentry for reminder cron

### DIFF
--- a/src/jobs/notifications/dispatch-reminder-email.test.ts
+++ b/src/jobs/notifications/dispatch-reminder-email.test.ts
@@ -3,6 +3,7 @@ import { TaskReminderType } from '@prisma/client'
 const mockSendReminderEmail = jest.fn()
 const mockTaskReminderSentDelete = jest.fn()
 const mockCopilotApiCtor = jest.fn()
+const mockCaptureException = jest.fn()
 
 jest.mock('@trigger.dev/sdk/v3', () => ({
   task: ({ run }: { run: (payload: unknown) => unknown }) => ({ run }),
@@ -11,6 +12,10 @@ jest.mock('@trigger.dev/sdk/v3', () => ({
 }))
 
 jest.mock('@/config', () => ({ copilotAPIKey: 'test-api-key' }))
+
+jest.mock('@/jobs/sentry', () => ({
+  Sentry: { captureException: (...args: unknown[]) => mockCaptureException(...args) },
+}))
 
 jest.mock('@/lib/db', () => ({
   __esModule: true,
@@ -56,6 +61,7 @@ describe('dispatchReminderEmail', () => {
     mockSendReminderEmail.mockReset()
     mockTaskReminderSentDelete.mockReset()
     mockCopilotApiCtor.mockReset()
+    mockCaptureException.mockReset()
   })
 
   describe('run', () => {
@@ -81,6 +87,7 @@ describe('dispatchReminderEmail', () => {
 
       await expect(dispatchReminderEmailRun(buildPayload())).rejects.toThrow('copilot 5xx')
       expect(mockTaskReminderSentDelete).not.toHaveBeenCalled() // compensation is onFailure's job, not run's
+      expect(mockCaptureException).not.toHaveBeenCalled() // capture waits for retries to exhaust (onFailure)
     })
   })
 
@@ -94,6 +101,23 @@ describe('dispatchReminderEmail', () => {
       })
 
       expect(mockTaskReminderSentDelete).toHaveBeenCalledWith({ where: { id: 'ledger_1' } })
+    })
+
+    it('captures the terminal failure to Sentry with task/recipient/reminder/workspace tags', async () => {
+      mockTaskReminderSentDelete.mockResolvedValueOnce({ id: 'ledger_1' })
+      const error = new Error('copilot 500 after retries')
+
+      await dispatchReminderEmailOnFailure({ payload: buildPayload(), error })
+
+      expect(mockCaptureException).toHaveBeenCalledWith(error, {
+        tags: {
+          job: 'dispatch-reminder-email',
+          taskId: 'task_1',
+          recipientId: 'client_1',
+          reminderType: TaskReminderType.NO_DUE_DATE_3D,
+          workspaceId: 'ws_1',
+        },
+      })
     })
 
     it('does not throw if the ledger DELETE itself fails (logs and moves on)', async () => {

--- a/src/jobs/notifications/dispatch-reminder-email.ts
+++ b/src/jobs/notifications/dispatch-reminder-email.ts
@@ -1,6 +1,7 @@
 import 'server-only'
 
 import { copilotAPIKey } from '@/config'
+import { Sentry } from '@/jobs/sentry'
 import DBClient from '@/lib/db'
 import { WorkspaceResponse } from '@/types/common'
 import { CopilotAPI } from '@/utils/CopilotAPI'
@@ -42,6 +43,17 @@ export const dispatchReminderEmailRun = async (payload: DispatchReminderEmailPay
 // The SDK types the hook's payload as `unknown`; we cast once via destructure.
 export const dispatchReminderEmailOnFailure = async ({ payload, error }: { payload: unknown; error: unknown }) => {
   const { ledgerId, workspaceId, task, recipientClientId, reminderType } = payload as DispatchReminderEmailPayload
+  // Terminal send failure (Copilot 500 etc. survived all retries). Capture here, not in
+  // run's catch, so transient errors a retry recovers don't generate Sentry noise.
+  Sentry.captureException(error, {
+    tags: {
+      job: 'dispatch-reminder-email',
+      taskId: task.id,
+      recipientId: recipientClientId,
+      reminderType,
+      workspaceId,
+    },
+  })
   logger.error('dispatch-reminder-email: retries exhausted, compensating ledger', {
     ledgerId,
     workspaceId,

--- a/src/jobs/notifications/send-task-reminders.test.ts
+++ b/src/jobs/notifications/send-task-reminders.test.ts
@@ -7,6 +7,7 @@ const mockBatchTrigger = jest.fn()
 const mockGetWorkspace = jest.fn()
 const mockGetCompanyClients = jest.fn()
 const mockCopilotApiCtor = jest.fn()
+const mockCaptureException = jest.fn()
 
 jest.mock('@trigger.dev/sdk/v3', () => ({
   schedules: {
@@ -16,6 +17,10 @@ jest.mock('@trigger.dev/sdk/v3', () => ({
 }))
 
 jest.mock('@/config', () => ({ copilotAPIKey: 'test-api-key' }))
+
+jest.mock('@/jobs/sentry', () => ({
+  Sentry: { captureException: (...args: unknown[]) => mockCaptureException(...args) },
+}))
 
 jest.mock('@/lib/db', () => ({
   __esModule: true,
@@ -90,6 +95,7 @@ describe('sendTaskReminders', () => {
     mockGetWorkspace.mockReset()
     mockGetCompanyClients.mockReset()
     mockCopilotApiCtor.mockReset()
+    mockCaptureException.mockReset()
     mockGetWorkspace.mockResolvedValue(workspace)
     mockBatchTrigger.mockResolvedValue({ batchId: 'b1' })
   })
@@ -159,6 +165,19 @@ describe('sendTaskReminders', () => {
 
     expect(result).toEqual({ enqueued: 0, skipped: 1, workspaceCount: 1 })
     expect(mockBatchTrigger).not.toHaveBeenCalled()
+    // ON CONFLICT dedupe is normal — it must never reach Sentry.
+    expect(mockCaptureException).not.toHaveBeenCalled()
+  })
+
+  it('captures eligibility-query failures to Sentry and rethrows so the run fails', async () => {
+    const boom = new Error('eligibility SQL blew up')
+    mockGetEligibleReminders.mockRejectedValueOnce(boom)
+
+    await expect(runJob()).rejects.toThrow('eligibility SQL blew up')
+    expect(mockCaptureException).toHaveBeenCalledWith(boom, {
+      tags: { job: 'send-task-reminders', phase: 'eligibility' },
+    })
+    expect(mockTaskReminderSentCreateManyAndReturn).not.toHaveBeenCalled()
   })
 
   it('fans out a company-assigned task to one dispatch per current member', async () => {

--- a/src/jobs/notifications/send-task-reminders.ts
+++ b/src/jobs/notifications/send-task-reminders.ts
@@ -1,6 +1,7 @@
 import 'server-only'
 
 import { copilotAPIKey } from '@/config'
+import { Sentry } from '@/jobs/sentry'
 import DBClient from '@/lib/db'
 import { CopilotAPI } from '@/utils/CopilotAPI'
 import { serializeError } from '@/utils/serializeError'
@@ -32,7 +33,16 @@ export const sendTaskReminders = schedules.task({
   run: async (payload) => {
     const db = DBClient.getInstance()
 
-    const eligibleTasks = await getEligibleReminders(db)
+    let eligibleTasks: EligibilityRow[]
+    try {
+      eligibleTasks = await getEligibleReminders(db)
+    } catch (err) {
+      // A broken eligibility query means zero reminders go out for the day — make it loud.
+      // Rethrow so Trigger.dev also marks the run failed; the Sentry event carries the cause.
+      Sentry.captureException(err, { tags: { job: 'send-task-reminders', phase: 'eligibility' } })
+      logger.error('send-task-reminders: eligibility query failed', { error: serializeError(err) })
+      throw err
+    }
     const tasks = eligibleTasks.filter((t) => t.assigneeType !== AssigneeType.internalUser)
 
     const tasksByWorkspace = new Map<string, EligibilityRow[]>()
@@ -80,10 +90,16 @@ export const sendTaskReminders = schedules.task({
       ),
     )
 
-    logger.log('send-task-reminders: sweep complete', {
-      ...totals,
-      workspaceCount,
-      totalEligible: eligibleTasks.length,
+    // One greppable structured summary per run. `enqueued`/`skipped` are what this
+    // orchestrator can know: it fans out to dispatch-reminder-email rather than sending
+    // inline, so per-email sent/failed counts live in that task's Trigger.dev run metrics
+    // and its onFailure Sentry capture, not here. `skipped` is ON CONFLICT dedupe, not a failure.
+    logger.log('send-task-reminders: run summary', {
+      eligibleWorkspaces: workspaceCount,
+      totalEligibleTasks: eligibleTasks.length,
+      enqueued: totals.enqueued,
+      skipped: totals.skipped,
+      runAt: payload.timestamp,
     })
 
     return { ...totals, workspaceCount }

--- a/src/jobs/sentry.ts
+++ b/src/jobs/sentry.ts
@@ -1,0 +1,24 @@
+import 'server-only'
+
+import * as Sentry from '@sentry/nextjs'
+
+// Trigger.dev runs jobs in a standalone Node process, separate from the Next.js server, so
+// `sentry.server.config.ts` (loaded via instrumentation.ts) never executes here — without
+// this init, `Sentry.captureException` from a job would be a silent no-op. We reuse the
+// already-installed @sentry/nextjs (its exports delegate to @sentry/node on the server)
+// rather than pulling in a second SDK. Module-level side effect: ESM evaluates this once,
+// the first time a job imports it, which is exactly when we need the client ready.
+const dsn = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN
+
+if (dsn) {
+  Sentry.init({
+    dsn,
+    // Keep the runtime lean: targeted captureException calls don't need the full default
+    // integration set (matches Trigger.dev's documented Sentry setup).
+    defaultIntegrations: false,
+    environment: process.env.SENTRY_ENVIRONMENT || process.env.NODE_ENV || 'development',
+    ignoreErrors: [/fetch failed/i],
+  })
+}
+
+export { Sentry }


### PR DESCRIPTION
## What

Observability for the reminder cron ([OUT-3738](https://linear.app/assemblycom/issue/OUT-3738)). Targets `feature/email-reminders` since the reminder stack isn't on `staging` yet.

- **Wire Sentry into the Trigger.dev runtime** (`src/jobs/sentry.ts`). Jobs run in a standalone Node process, separate from the Next.js server, so `sentry.server.config.ts` (loaded via `instrumentation.ts`) never executes there — without this, `captureException` from a job was a silent no-op. Reuses the already-installed `@sentry/nextjs` (no new deps); one-time init guarded on DSN presence, `defaultIntegrations: false` to stay lean (matches Trigger.dev's documented setup).
- **`send-task-reminders`** — wrap `getEligibleReminders` so an eligibility-query failure is captured (tags `job`, `phase: eligibility`), logged, and rethrown (run still fails visibly). End-of-run log reshaped into one greppable structured summary: `{ eligibleWorkspaces, totalEligibleTasks, enqueued, skipped, runAt }`.
- **`dispatch-reminder-email`** — capture the *terminal* send failure in `onFailure` (after retries exhaust) with tags `taskId`, `recipientId`, `reminderType`, `workspaceId`. ON CONFLICT dedupe skips are never captured.

## Deliberate divergences from the ticket

1. **Summary fields.** The ticket lists `totalEmailsSent/Failed/Attempted`, but this cron fans out — it only *enqueues* `dispatch-reminder-email` jobs and never sends inline, so send outcomes aren't knowable at the orchestrator. They live in the dispatcher's Trigger.dev run metrics + its onFailure Sentry events. The summary reports what the orchestrator actually knows (`enqueued`/`skipped`).
2. **"Mirror auto-archive."** Auto-archive has no Sentry at all, so the Sentry wiring is net-new; only the per-workspace log *format* was mirrored.

## ⚠️ Deploy requirement

For captures to transmit in staging/prod, `SENTRY_DSN` (or `NEXT_PUBLIC_SENTRY_DSN`) must be set on the **Trigger.dev environment** (same place as `COPILOT_ENV`). Without it, `Sentry.init` no-ops and the acceptance check ("force a Copilot 500 → Sentry event") won't fire.

## Testing

- `send-task-reminders.test.ts`: eligibility failure captures + rethrows; ON CONFLICT skip path asserts no capture.
- `dispatch-reminder-email.test.ts`: onFailure capture carries the exact tags; `run()` failure does **not** capture (waits for onFailure).
- All suites pass · `tsc --noEmit` clean · eslint clean.
- Acceptance: forcing a Copilot 500 in staging → tagged Sentry event — pending manual staging verification (needs the DSN env var above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)