### PR TITLE
OUT-3750 | SyntaxError: Unexpected token 'A', "An error o"... is not valid JSON

### DIFF
--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -27,11 +27,10 @@ import { RealTimeTemplates } from '@/hoc/RealtimeTemplates'
 export const maxDuration = 300
 
 export async function getAllWorkflowStates(token: string): Promise<WorkflowStateResponse[]> {
-  const res = await fetch(`${apiUrl}/api/workflow-states?token=${token}`, {
-    next: { tags: ['getAllWorkflowStates'] },
-  })
-
-  const data = await res.json()
+  const data = await fetchWithErrorHandler<{ workflowStates: WorkflowStateResponse[] }>(
+    `${apiUrl}/api/workflow-states?token=${token}`,
+    { next: { tags: ['getAllWorkflowStates'] } },
+  )
   return data.workflowStates
 }
 
@@ -61,12 +60,9 @@ export async function getTokenPayload(token: string): Promise<Token> {
 }
 
 export async function getViewSettings(token: string): Promise<CreateViewSettingsDTO> {
-  const res = await fetch(`${apiUrl}/api/view-settings?token=${token}`, {
+  return fetchWithErrorHandler<CreateViewSettingsDTO>(`${apiUrl}/api/view-settings?token=${token}`, {
     next: { tags: ['getViewSettings'] },
   })
-  const resp = await res.json()
-
-  return resp
 }
 
 export default async function Main(props: {

--- a/src/app/_fetchers/AllTasksFetcher.tsx
+++ b/src/app/_fetchers/AllTasksFetcher.tsx
@@ -1,14 +1,14 @@
 export const fetchCache = 'force-no-store'
 
 import { apiUrl } from '@/config'
+import { fetchWithErrorHandler } from '@/app/_fetchers/fetchWithErrorHandler'
 import { ClientSideStateUpdate } from '@/hoc/ClientSideStateUpdate'
 import { TaskResponse } from '@/types/dto/tasks.dto'
 import { PropsWithToken } from '@/types/interfaces'
 import { PropsWithChildren } from 'react'
 
 const getAllAccessibleTasks = async (token: string): Promise<TaskResponse[]> => {
-  const res = await fetch(`${apiUrl}/api/tasks?token=${token}&all=1`)
-  const { tasks } = await res.json()
+  const { tasks } = await fetchWithErrorHandler<{ tasks: TaskResponse[] }>(`${apiUrl}/api/tasks?token=${token}&all=1`)
   return tasks
 }
 

--- a/src/app/_fetchers/TemplatesFetcher.tsx
+++ b/src/app/_fetchers/TemplatesFetcher.tsx
@@ -1,15 +1,15 @@
 export const fetchCache = 'force-no-store'
 
 import { apiUrl } from '@/config'
+import { fetchWithErrorHandler } from '@/app/_fetchers/fetchWithErrorHandler'
 import { ClientSideStateUpdate } from '@/hoc/ClientSideStateUpdate'
 import { ITemplate, PropsWithToken } from '@/types/interfaces'
 import { PropsWithChildren } from 'react'
 
 const getAllTemplates = async (token: string): Promise<ITemplate[]> => {
-  const res = await fetch(`${apiUrl}/api/tasks/templates?token=${token}`, {
+  const { data } = await fetchWithErrorHandler<{ data: ITemplate[] }>(`${apiUrl}/api/tasks/templates?token=${token}`, {
     next: { tags: ['getAllTemplates'] },
   })
-  const { data } = await res.json()
   return data
 }
 

--- a/src/app/_fetchers/WorkflowStateFetcher.tsx
+++ b/src/app/_fetchers/WorkflowStateFetcher.tsx
@@ -1,17 +1,17 @@
 export const fetchCache = 'force-no-store'
 
 import { apiUrl } from '@/config'
+import { fetchWithErrorHandler } from '@/app/_fetchers/fetchWithErrorHandler'
 import { ClientSideStateUpdate } from '@/hoc/ClientSideStateUpdate'
 import { WorkflowStateResponse } from '@/types/dto/workflowStates.dto'
 import { PropsWithToken } from '@/types/interfaces'
 import { PropsWithChildren } from 'react'
 
 const getAllWorkflowStates = async (token: string): Promise<WorkflowStateResponse[]> => {
-  const res = await fetch(`${apiUrl}/api/workflow-states?token=${token}`, {
-    next: { tags: ['getAllWorkflowStates'] },
-  })
-
-  const data = await res.json()
+  const data = await fetchWithErrorHandler<{ workflowStates: WorkflowStateResponse[] }>(
+    `${apiUrl}/api/workflow-states?token=${token}`,
+    { next: { tags: ['getAllWorkflowStates'] } },
+  )
 
   return data.workflowStates
 }

--- a/src/app/detail/[task_id]/[user_type]/actions.ts
+++ b/src/app/detail/[task_id]/[user_type]/actions.ts
@@ -3,9 +3,10 @@
 import { advancedFeatureFlag, apiUrl } from '@/config'
 import { ScrapMediaRequest } from '@/types/common'
 import { CreateAttachmentRequest } from '@/types/dto/attachments.dto'
-import { CreateComment, UpdateComment } from '@/types/dto/comment.dto'
+import { CreateComment, UpdateComment, CommentResponse } from '@/types/dto/comment.dto'
 import { UpdateTaskRequest, Associations } from '@/types/dto/tasks.dto'
 import { getForwardedAssemblyHeaders } from '@/utils/serverHeaders'
+import { fetchWithErrorHandler } from '@/app/_fetchers/fetchWithErrorHandler'
 
 export const updateTaskDetail = async ({
   token,
@@ -108,20 +109,22 @@ export const deleteAttachment = async (token: string, id: string) => {
 }
 
 export const postComment = async (token: string, payload: CreateComment) => {
-  const res = await fetch(`${apiUrl}/api/comments?token=${token}`, {
-    method: 'POST',
-    body: JSON.stringify(payload),
-  })
-  const data = await res.json()
+  // retries=0: this is a non-idempotent create, retrying a dropped-but-succeeded POST would duplicate the comment
+  const data = await fetchWithErrorHandler<{ comment: CommentResponse }>(
+    `${apiUrl}/api/comments?token=${token}`,
+    { method: 'POST', body: JSON.stringify(payload) },
+    0,
+  )
   return data.comment
 }
 
 export const updateComment = async (token: string, id: string, payload: UpdateComment) => {
-  const res = await fetch(`${apiUrl}/api/comments/${id}?token=${token}`, {
-    method: 'PATCH',
-    body: JSON.stringify(payload),
-  })
-  const data = await res.json()
+  // retries=0: non-idempotent update, avoid re-applying a write whose response was lost
+  const data = await fetchWithErrorHandler<{ comment: CommentResponse }>(
+    `${apiUrl}/api/comments/${id}?token=${token}`,
+    { method: 'PATCH', body: JSON.stringify(payload) },
+    0,
+  )
   return data.comment
 }
 


### PR DESCRIPTION
## What & why

Fixes [OUT-3750](https://linear.app/assemblycom/issue/OUT-3750) / Sentry **TASKS-88**.

The `(home)` page loaders, the `_fetchers/*` components, and the comment server actions fetch the app's **own** API over HTTP (`apiUrl` resolves to the deployment's own URL) and then call `res.json()` directly.

When the inner serverless function fails at the **Vercel platform level** (timeout / crash / dropped connection — *not* a handled app error, which `withErrorHandler` always returns as JSON), Vercel returns a non-JSON body — `"An error occurred with this application."`, `"Internal Server Error"`, or an empty response. `JSON.parse` then throws `SyntaxError: Unexpected token ...` / `Unexpected end of JSON input`, and with no error boundary the whole render 500s.

The 4 Sentry events confirm this across `GET /`, `GET /detail/...`, and `POST /detail/...`, with three distinct non-JSON bodies.

## Change

Route these raw `res.json()` reads through the existing `fetchWithErrorHandler`, which checks `res.ok`/status **before** parsing and retries transient failures with backoff:

- `(home)/page.tsx` — `getAllWorkflowStates`, `getViewSettings`
- `_fetchers/TemplatesFetcher.tsx`, `WorkflowStateFetcher.tsx`, `AllTasksFetcher.tsx`
- `detail/[task_id]/[user_type]/actions.ts` — `postComment`, `updateComment`

The comment create/update use `retries=0` — they are **non-idempotent** mutations, and retrying a POST/PATCH whose response was lost could duplicate/re-apply the write. They still get the safe parse + clean error, just no retry.

## Scope / follow-ups

- This is the **mitigation** (`fetchWithErrorHandler` + retry), not the root-cause fix. The durable fix is removing the HTTP self-fetch loopback and calling the service layer directly (the detail `loaders.ts` already does this). Tracked separately.
- Three other SSR pages have the same loopback pattern but weren't in the TASKS-88 events and are intentionally left out of this PR: `configure-tasks-app/page.tsx`, `client/page.tsx`, `manage-templates/[template_id]/page.tsx`.

## Testing

- `tsc --noEmit` clean
- `eslint` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)