### PR TITLE
OUT-3771 | SecurityError: LockManager.request: request() is not allowed in this context

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,7 +1,17 @@
 import { supabaseAnonKey, supabaseProjectUrl } from '@/config'
-import { createClient, type SupabaseClient as SupabaseJSClient } from '@supabase/supabase-js'
+import { createClient, processLock, type SupabaseClient as SupabaseJSClient } from '@supabase/supabase-js'
 
-export const supabase = createClient(supabaseProjectUrl, supabaseAnonKey)
+// We use Supabase purely for realtime with the anon key (auth is handled by Copilot),
+// so there is no user session to persist or coordinate across tabs.
+const authOptions = {
+  auth: {
+    lock: processLock,
+    persistSession: false,
+    autoRefreshToken: false,
+  },
+}
+
+export const supabase = createClient(supabaseProjectUrl, supabaseAnonKey, authOptions)
 
 class SupabaseClient {
   private static client: SupabaseJSClient
@@ -12,7 +22,7 @@ class SupabaseClient {
   static getInstance(): SupabaseJSClient {
     if (!this.client) {
       if (!this.isInitialized) {
-        this.client = createClient(supabaseProjectUrl, supabaseAnonKey)
+        this.client = createClient(supabaseProjectUrl, supabaseAnonKey, authOptions)
         this.isInitialized = true
       }
     }


### PR DESCRIPTION
## Problem

Sentry [TASKS-8C](https://copilot-platforms.sentry.io/issues/TASKS-8C) / OUT-3771:

```
SecurityError: LockManager.request: request() is not allowed in this context
```

The browser Supabase client (`src/lib/supabase.ts`) was created with no auth options. By default `@supabase/auth-js` uses the Web Locks API (`navigator.locks.request`) whenever that object exists. Calling it throws a `SecurityError` in **sandboxed iframes** and **Firefox private browsing** — both apply since the app runs embedded in the Copilot platform iframe (the captured event is Firefox 115 on `/client`, `DOMException.code: 18`).

## Fix

This client is used **only for realtime with the anon key** (user auth is handled by Copilot), so there's no user session to persist or coordinate across tabs. Pass an `auth` config to both `createClient` calls:

- `lock: processLock` — Supabase's in-process lock, avoids `navigator.locks` entirely
- `persistSession: false` + `autoRefreshToken: false` — appropriate for an anon realtime-only client

Fixes TASKS-8C

## Testing

- `tsc --noEmit` passes
- Lint/prettier pass (pre-commit hooks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)