### PR TITLE
feat(view-settings): workspace-level client view setting columns (OUT-3851 foundation)

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -11,6 +11,7 @@ const nextConfig = {
       },
     },
   },
+  allowedDevOrigins: ['*.ngrok-free.dev'],
   async redirects() {
     return [
       {

--- a/prisma/migrations/20260610074631_add_client_view_settings_to_workspace_settings/migration.sql
+++ b/prisma/migrations/20260610074631_add_client_view_settings_to_workspace_settings/migration.sql
@@ -1,3 +1,3 @@
 -- AlterTable
-ALTER TABLE "WorkspaceSettings" ADD COLUMN     "clientDefaultViewMode" "ViewMode" NOT NULL DEFAULT 'board',
-ADD COLUMN     "clientHideSubtasks" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "WorkspaceSettings" ADD COLUMN     "clientDefaultViewMode" "ViewMode",
+ADD COLUMN     "clientHideSubtasks" BOOLEAN;

--- a/prisma/migrations/20260610074631_add_client_view_settings_to_workspace_settings/migration.sql
+++ b/prisma/migrations/20260610074631_add_client_view_settings_to_workspace_settings/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "WorkspaceSettings" ADD COLUMN     "clientDefaultViewMode" "ViewMode",
+ADD COLUMN     "clientLockShowSubtasks" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "clientLockViewMode" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "clientShowSubtasks" BOOLEAN;

--- a/prisma/migrations/20260610074631_add_client_view_settings_to_workspace_settings/migration.sql
+++ b/prisma/migrations/20260610074631_add_client_view_settings_to_workspace_settings/migration.sql
@@ -1,5 +1,3 @@
 -- AlterTable
-ALTER TABLE "WorkspaceSettings" ADD COLUMN     "clientDefaultViewMode" "ViewMode",
-ADD COLUMN     "clientLockShowSubtasks" BOOLEAN NOT NULL DEFAULT false,
-ADD COLUMN     "clientLockViewMode" BOOLEAN NOT NULL DEFAULT false,
-ADD COLUMN     "clientShowSubtasks" BOOLEAN;
+ALTER TABLE "WorkspaceSettings" ADD COLUMN     "clientDefaultViewMode" "ViewMode" NOT NULL DEFAULT 'board',
+ADD COLUMN     "clientHideSubtasks" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema/workspaceSetting.prisma
+++ b/prisma/schema/workspaceSetting.prisma
@@ -2,8 +2,8 @@ model WorkspaceSetting {
   id                     String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   workspaceId            String    @unique @db.VarChar(32)
   autoArchiveAfterDays   Int       @default(0)
-  clientDefaultViewMode  ViewMode  @default(board)
-  clientHideSubtasks     Boolean   @default(false)
+  clientDefaultViewMode  ViewMode?
+  clientHideSubtasks     Boolean?
   createdAt              DateTime  @default(now())
   updatedAt              DateTime  @updatedAt @db.Timestamptz()
   deletedAt              DateTime? @db.Timestamptz()

--- a/prisma/schema/workspaceSetting.prisma
+++ b/prisma/schema/workspaceSetting.prisma
@@ -1,10 +1,16 @@
 model WorkspaceSetting {
-  id                   String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  workspaceId          String    @unique @db.VarChar(32)
-  autoArchiveAfterDays Int       @default(0)
-  createdAt            DateTime  @default(now())
-  updatedAt            DateTime  @updatedAt @db.Timestamptz()
-  deletedAt            DateTime? @db.Timestamptz()
+  id                     String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  workspaceId            String    @unique @db.VarChar(32)
+  autoArchiveAfterDays   Int       @default(0)
+  // Client-facing view defaults set by IUs. null = no workspace opinion (client controls).
+  // A lock takes effect only when its paired value is set; locked = enforced, unlocked = default for new clients.
+  clientDefaultViewMode  ViewMode?
+  clientShowSubtasks     Boolean?
+  clientLockViewMode     Boolean   @default(false)
+  clientLockShowSubtasks Boolean   @default(false)
+  createdAt              DateTime  @default(now())
+  updatedAt              DateTime  @updatedAt @db.Timestamptz()
+  deletedAt              DateTime? @db.Timestamptz()
 
   @@map("WorkspaceSettings")
 }

--- a/prisma/schema/workspaceSetting.prisma
+++ b/prisma/schema/workspaceSetting.prisma
@@ -2,12 +2,8 @@ model WorkspaceSetting {
   id                     String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   workspaceId            String    @unique @db.VarChar(32)
   autoArchiveAfterDays   Int       @default(0)
-  // Client-facing view defaults set by IUs. null = no workspace opinion (client controls).
-  // A lock takes effect only when its paired value is set; locked = enforced, unlocked = default for new clients.
-  clientDefaultViewMode  ViewMode?
-  clientShowSubtasks     Boolean?
-  clientLockViewMode     Boolean   @default(false)
-  clientLockShowSubtasks Boolean   @default(false)
+  clientDefaultViewMode  ViewMode  @default(board)
+  clientHideSubtasks     Boolean   @default(false)
   createdAt              DateTime  @default(now())
   updatedAt              DateTime  @updatedAt @db.Timestamptz()
   deletedAt              DateTime? @db.Timestamptz()

--- a/src/app/api/view-settings/viewSettings.service.ts
+++ b/src/app/api/view-settings/viewSettings.service.ts
@@ -5,7 +5,7 @@ import { emptyAssignee } from '@/utils/assignee'
 import { BaseService } from '@api/core/services/base.service'
 import { PoliciesService } from '@api/core/services/policies.service'
 import { Resource } from '@api/core/types/api'
-import { UserAction } from '@api/core/types/user'
+import { UserAction, UserRole } from '@api/core/types/user'
 import { ViewMode } from '@prisma/client'
 
 export class ViewSettingsService extends BaseService {
@@ -74,10 +74,11 @@ export class ViewSettingsService extends BaseService {
   }
 
   private async createInitialViewSettings(userIds: ViewSettingUserIdsType) {
+    const { viewMode, showSubtasks } = await this.resolveInitialDisplayDefaults()
     const data = {
       ...userIds,
       workspaceId: this.user.workspaceId,
-      viewMode: this.DEFAULT_VIEW_MODE,
+      viewMode,
       filterOptions: {
         [FilterOptions.ASSIGNEE]: emptyAssignee,
         [FilterOptions.ASSOCIATION]: emptyAssignee,
@@ -87,11 +88,33 @@ export class ViewSettingsService extends BaseService {
       },
       showUnarchived: true,
       showArchived: false,
-      showSubtasks: true, // If we DO need to default to false for IUs, we can add a condition here after confirmation
+      showSubtasks,
     }
 
     return await this.db.viewSetting.create({
       data,
     })
+  }
+
+  // Workspace-level client view settings seed a CU's first view setting row.
+  // IUs are unaffected and keep the hardcoded defaults. Unset (null) overrides
+  // fall back to those same defaults, so existing behavior is preserved.
+  private async resolveInitialDisplayDefaults(): Promise<{ viewMode: ViewMode; showSubtasks: boolean }> {
+    const fallback = { viewMode: this.DEFAULT_VIEW_MODE, showSubtasks: true }
+    if (this.user.role !== UserRole.Client) {
+      return fallback
+    }
+
+    const workspaceSetting = await this.db.workspaceSetting.findUnique({
+      where: { workspaceId: this.user.workspaceId },
+      select: { clientDefaultViewMode: true, clientHideSubtasks: true },
+    })
+
+    return {
+      viewMode: workspaceSetting?.clientDefaultViewMode ?? fallback.viewMode,
+      // clientHideSubtasks is the inverse of showSubtasks.
+      showSubtasks:
+        workspaceSetting?.clientHideSubtasks != null ? !workspaceSetting.clientHideSubtasks : fallback.showSubtasks,
+    }
   }
 }

--- a/src/app/api/workspace-settings/workspaceSettings.controller.ts
+++ b/src/app/api/workspace-settings/workspaceSettings.controller.ts
@@ -20,7 +20,7 @@ export const updateWorkspaceSettings = async (req: NextRequest) => {
   const data = UpdateWorkspaceSettingsSchema.parse(await req.json())
 
   const workspaceSettingsService = new WorkspaceSettingsService(user)
-  const workspaceSetting = await workspaceSettingsService.updateWorkspaceSettings(data)
+  const workspaceSetting = await workspaceSettingsService.overrideExistingClientViewSettings({ data })
 
   return NextResponse.json(workspaceSetting)
 }

--- a/src/app/api/workspace-settings/workspaceSettings.service.ts
+++ b/src/app/api/workspace-settings/workspaceSettings.service.ts
@@ -3,7 +3,7 @@ import { BaseService } from '@api/core/services/base.service'
 import { PoliciesService } from '@api/core/services/policies.service'
 import { Resource } from '@api/core/types/api'
 import { UserAction } from '@api/core/types/user'
-import { Prisma, PrismaClient, WorkspaceSetting } from '@prisma/client'
+import { Prisma, PrismaClient } from '@prisma/client'
 
 export class WorkspaceSettingsService extends BaseService {
   async getWorkspaceSettings() {
@@ -11,15 +11,26 @@ export class WorkspaceSettingsService extends BaseService {
     policyGate.authorize(UserAction.Read, Resource.WorkspaceSetting)
 
     const workspaceId = this.user.workspaceId
-    let workspaceSetting = await this.db.workspaceSetting.findUnique({ where: { workspaceId } })
-    if (!workspaceSetting) {
-      workspaceSetting = await this.db.workspaceSetting.create({ data: { workspaceId } })
-    }
+    const workspaceSetting = await this.db.workspaceSetting.findUnique({ where: { workspaceId } })
 
-    return workspaceSetting
+    return workspaceSetting ?? (await this.db.workspaceSetting.create({ data: { workspaceId } }))
   }
 
   async updateWorkspaceSettings(data: UpdateWorkspaceSettingsDTO) {
+    const policyGate = new PoliciesService(this.user)
+    policyGate.authorize(UserAction.Update, Resource.WorkspaceSetting)
+
+    const workspaceId = this.user.workspaceId
+    return await this.db.workspaceSetting.upsert({
+      where: { workspaceId },
+      create: { workspaceId, ...data },
+      update: data,
+    })
+  }
+
+  // Updates the workspace settings and cascades the new client defaults to every existing
+  // client's view settings atomically, so a cascade failure rolls back the settings change too.
+  async overrideExistingClientViewSettings({ data }: { data: UpdateWorkspaceSettingsDTO }) {
     const policyGate = new PoliciesService(this.user)
     policyGate.authorize(UserAction.Update, Resource.WorkspaceSetting)
 
@@ -29,48 +40,30 @@ export class WorkspaceSettingsService extends BaseService {
       this.setTransaction(tx as PrismaClient)
       try {
         const previous = await this.db.workspaceSetting.findUnique({ where: { workspaceId } })
+        const updated = await this.updateWorkspaceSettings(data)
 
-        // The settings row is created lazily on read (getWorkspaceSettings), so by the
-        // time a setting is changed it always exists — update only, never insert.
-        const updated = await this.db.workspaceSetting.update({
-          where: { workspaceId },
-          data,
-        })
+        const cascade: Prisma.ViewSettingUpdateManyMutationInput = {}
 
-        await this.overrideExistingClientViewSettings({ previous, data })
+        if (data.clientDefaultViewMode != null && data.clientDefaultViewMode !== previous?.clientDefaultViewMode) {
+          cascade.viewMode = data.clientDefaultViewMode
+        }
+        // clientHideSubtasks is the inverse of the per-user showSubtasks flag.
+        if (data.clientHideSubtasks != null && data.clientHideSubtasks !== previous?.clientHideSubtasks) {
+          cascade.showSubtasks = !data.clientHideSubtasks
+        }
+
+        if (Object.keys(cascade).length > 0) {
+          await this.db.viewSetting.updateMany({
+            where: { workspaceId, clientId: { not: null } },
+            data: cascade,
+          })
+        }
 
         return updated
       } finally {
         // Always restore the shared db handle, even if the cascade throws.
         this.unsetTransaction()
       }
-    })
-  }
-
-  private async overrideExistingClientViewSettings({
-    previous,
-    data,
-  }: {
-    previous: WorkspaceSetting | null
-    data: UpdateWorkspaceSettingsDTO
-  }) {
-    const cascade: Prisma.ViewSettingUpdateManyMutationInput = {}
-
-    if (data.clientDefaultViewMode != null && data.clientDefaultViewMode !== previous?.clientDefaultViewMode) {
-      cascade.viewMode = data.clientDefaultViewMode
-    }
-    // clientHideSubtasks is the inverse of the per-user showSubtasks flag.
-    if (data.clientHideSubtasks != null && data.clientHideSubtasks !== previous?.clientHideSubtasks) {
-      cascade.showSubtasks = !data.clientHideSubtasks
-    }
-
-    if (Object.keys(cascade).length === 0) {
-      return
-    }
-
-    await this.db.viewSetting.updateMany({
-      where: { workspaceId: this.user.workspaceId, clientId: { not: null } },
-      data: cascade,
     })
   }
 }

--- a/src/app/api/workspace-settings/workspaceSettings.service.ts
+++ b/src/app/api/workspace-settings/workspaceSettings.service.ts
@@ -23,10 +23,11 @@ export class WorkspaceSettingsService extends BaseService {
     policyGate.authorize(UserAction.Update, Resource.WorkspaceSetting)
 
     const workspaceId = this.user.workspaceId
-    return await this.db.workspaceSetting.upsert({
+    // The settings row is created lazily on read (getWorkspaceSettings), so by the
+    // time a setting is changed it always exists — update only, never insert.
+    return await this.db.workspaceSetting.update({
       where: { workspaceId },
-      create: { workspaceId, ...data },
-      update: data,
+      data,
     })
   }
 }

--- a/src/app/api/workspace-settings/workspaceSettings.service.ts
+++ b/src/app/api/workspace-settings/workspaceSettings.service.ts
@@ -3,6 +3,7 @@ import { BaseService } from '@api/core/services/base.service'
 import { PoliciesService } from '@api/core/services/policies.service'
 import { Resource } from '@api/core/types/api'
 import { UserAction } from '@api/core/types/user'
+import { Prisma, PrismaClient, WorkspaceSetting } from '@prisma/client'
 
 export class WorkspaceSettingsService extends BaseService {
   async getWorkspaceSettings() {
@@ -23,11 +24,53 @@ export class WorkspaceSettingsService extends BaseService {
     policyGate.authorize(UserAction.Update, Resource.WorkspaceSetting)
 
     const workspaceId = this.user.workspaceId
-    // The settings row is created lazily on read (getWorkspaceSettings), so by the
-    // time a setting is changed it always exists — update only, never insert.
-    return await this.db.workspaceSetting.update({
-      where: { workspaceId },
-      data,
+
+    return this.db.$transaction(async (tx) => {
+      this.setTransaction(tx as PrismaClient)
+      try {
+        const previous = await this.db.workspaceSetting.findUnique({ where: { workspaceId } })
+
+        // The settings row is created lazily on read (getWorkspaceSettings), so by the
+        // time a setting is changed it always exists — update only, never insert.
+        const updated = await this.db.workspaceSetting.update({
+          where: { workspaceId },
+          data,
+        })
+
+        await this.overrideExistingClientViewSettings({ previous, data })
+
+        return updated
+      } finally {
+        // Always restore the shared db handle, even if the cascade throws.
+        this.unsetTransaction()
+      }
+    })
+  }
+
+  private async overrideExistingClientViewSettings({
+    previous,
+    data,
+  }: {
+    previous: WorkspaceSetting | null
+    data: UpdateWorkspaceSettingsDTO
+  }) {
+    const cascade: Prisma.ViewSettingUpdateManyMutationInput = {}
+
+    if (data.clientDefaultViewMode != null && data.clientDefaultViewMode !== previous?.clientDefaultViewMode) {
+      cascade.viewMode = data.clientDefaultViewMode
+    }
+    // clientHideSubtasks is the inverse of the per-user showSubtasks flag.
+    if (data.clientHideSubtasks != null && data.clientHideSubtasks !== previous?.clientHideSubtasks) {
+      cascade.showSubtasks = !data.clientHideSubtasks
+    }
+
+    if (Object.keys(cascade).length === 0) {
+      return
+    }
+
+    await this.db.viewSetting.updateMany({
+      where: { workspaceId: this.user.workspaceId, clientId: { not: null } },
+      data: cascade,
     })
   }
 }

--- a/src/app/configure-tasks-app/page.tsx
+++ b/src/app/configure-tasks-app/page.tsx
@@ -89,10 +89,8 @@ export default async function ConfigureTasksAppPage(props: ConfigureTasksAppPage
           <AutoArchiveSection initialAutoArchiveAfterDays={workspaceSetting.autoArchiveAfterDays} token={token} />
           <ClientViewSettingsSection
             initialSettings={{
-              clientDefaultViewMode: workspaceSetting.clientDefaultViewMode ?? null,
-              clientShowSubtasks: workspaceSetting.clientShowSubtasks ?? null,
-              clientLockViewMode: workspaceSetting.clientLockViewMode ?? false,
-              clientLockShowSubtasks: workspaceSetting.clientLockShowSubtasks ?? false,
+              clientDefaultViewMode: workspaceSetting.clientDefaultViewMode,
+              clientHideSubtasks: workspaceSetting.clientHideSubtasks,
             }}
             token={token}
           />

--- a/src/app/configure-tasks-app/page.tsx
+++ b/src/app/configure-tasks-app/page.tsx
@@ -14,7 +14,9 @@ import { RealTimeTemplates } from '@/hoc/RealtimeTemplates'
 import { Token, TokenSchema } from '@/types/common'
 import { ConfigureTasksAppBridge } from '@/app/configure-tasks-app/ui/ConfigureTasksAppBridge'
 import { AutoArchiveSection } from '@/app/configure-tasks-app/ui/AutoArchiveSection'
+import { ClientViewSettingsSection } from '@/app/configure-tasks-app/ui/ClientViewSettingsSection'
 import { StatusCustomizationSection } from '@/app/configure-tasks-app/ui/StatusCustomizationSection'
+import { ClientViewSettings } from '@/types/dto/workspaceSettings.dto'
 import { Stack } from '@mui/material'
 
 async function getAllWorkflowStates(token: string): Promise<WorkflowStateResponse[]> {
@@ -51,7 +53,7 @@ async function getTokenPayload(token: string): Promise<Token> {
   return TokenSchema.parse(await copilotClient.getTokenPayload())
 }
 
-async function getWorkspaceSetting(token: string): Promise<{ autoArchiveAfterDays: number }> {
+async function getWorkspaceSetting(token: string): Promise<{ autoArchiveAfterDays: number } & ClientViewSettings> {
   const res = await fetch(`${apiUrl}/api/workspace-settings?token=${token}`, { cache: 'no-store' })
   return await res.json()
 }
@@ -85,6 +87,15 @@ export default async function ConfigureTasksAppPage(props: ConfigureTasksAppPage
       <RealTimeTemplates tokenPayload={tokenPayload} token={token}>
         <Stack direction="column" rowGap="32px" sx={{ paddingTop: '24px', paddingBottom: '12px', paddingX: '12px' }}>
           <AutoArchiveSection initialAutoArchiveAfterDays={workspaceSetting.autoArchiveAfterDays} token={token} />
+          <ClientViewSettingsSection
+            initialSettings={{
+              clientDefaultViewMode: workspaceSetting.clientDefaultViewMode ?? null,
+              clientShowSubtasks: workspaceSetting.clientShowSubtasks ?? null,
+              clientLockViewMode: workspaceSetting.clientLockViewMode ?? false,
+              clientLockShowSubtasks: workspaceSetting.clientLockShowSubtasks ?? false,
+            }}
+            token={token}
+          />
           <StatusCustomizationSection initialWorkflowStates={workflowStates} token={token} />
           <TemplateBoard
             handleCreateTemplate={async (payload: CreateTemplateRequest) => {

--- a/src/app/configure-tasks-app/ui/ClientViewSettingsSection.tsx
+++ b/src/app/configure-tasks-app/ui/ClientViewSettingsSection.tsx
@@ -4,11 +4,14 @@ import { useState, type MouseEvent } from 'react'
 import { Box, Menu, MenuItem, Stack, Typography } from '@mui/material'
 import { Icon } from 'copilot-design-system'
 import { ViewMode } from '@prisma/client'
+import { useSelector } from 'react-redux'
 import { StyledSwitch } from '@/components/inputs/StyledSwitch'
 import { StyledModal } from '@/app/detail/ui/styledComponent'
 import { ConfirmUI } from '@/components/layouts/ConfirmUI'
 import { updateWorkspaceSettings } from '@/app/configure-tasks-app/actions'
 import { ClientViewSettings } from '@/types/dto/workspaceSettings.dto'
+import { selectAuthDetails } from '@/redux/features/authDetailsSlice'
+import { getWorkspaceLabels } from '@/utils/getWorkspaceLabels'
 
 interface ClientViewSettingsSectionProps {
   initialSettings: ClientViewSettings
@@ -21,6 +24,9 @@ const VIEW_MODE_OPTIONS: { label: string; value: ViewMode }[] = [
 ]
 
 export const ClientViewSettingsSection = ({ initialSettings, token }: ClientViewSettingsSectionProps) => {
+  const { workspace } = useSelector(selectAuthDetails)
+  const { individualTermPlural } = getWorkspaceLabels(workspace)
+
   const [settings, setSettings] = useState<ClientViewSettings>(initialSettings)
   // Holds the change awaiting confirmation; the controls keep showing `settings` until confirmed.
   const [pendingSettings, setPendingSettings] = useState<ClientViewSettings | null>(null)
@@ -46,7 +52,7 @@ export const ClientViewSettingsSection = ({ initialSettings, token }: ClientView
   return (
     <Box sx={{ width: '100%', maxWidth: '640px', margin: '0 auto', px: { xs: 2, sm: 0 } }}>
       <Typography variant="lg" sx={{ display: 'block', mb: '12px' }}>
-        Client view settings
+        Default display settings
       </Typography>
 
       <Box
@@ -58,7 +64,7 @@ export const ClientViewSettingsSection = ({ initialSettings, token }: ClientView
         }}
       >
         <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ px: '16px', py: '14px' }}>
-          <Typography variant="bodyMd">Default view</Typography>
+          <Typography variant="bodyMd">View</Typography>
           <ViewModeDropdown
             value={settings.clientDefaultViewMode}
             onChange={(value) =>
@@ -89,14 +95,9 @@ export const ClientViewSettingsSection = ({ initialSettings, token }: ClientView
         <ConfirmUI
           handleCancel={() => setPendingSettings(null)}
           handleConfirm={handleConfirm}
-          buttonText="Apply to all clients"
-          title="Update view for all clients?"
-          description={
-            <>
-              This changes the view for <strong>every client</strong> in this workspace right now, replacing any view a
-              client has set for themselves. New and existing clients will all see this view.
-            </>
-          }
+          buttonText="Confirm & Apply"
+          title={`Override current display settings for ${individualTermPlural}?`}
+          description={`Applying this change will override the current display settings for ${individualTermPlural} while they view tasks.`}
         />
       </StyledModal>
     </Box>

--- a/src/app/configure-tasks-app/ui/ClientViewSettingsSection.tsx
+++ b/src/app/configure-tasks-app/ui/ClientViewSettingsSection.tsx
@@ -5,6 +5,8 @@ import { Box, Menu, MenuItem, Stack, Typography } from '@mui/material'
 import { Icon } from 'copilot-design-system'
 import { ViewMode } from '@prisma/client'
 import { StyledSwitch } from '@/components/inputs/StyledSwitch'
+import { StyledModal } from '@/app/detail/ui/styledComponent'
+import { ConfirmUI } from '@/components/layouts/ConfirmUI'
 import { updateWorkspaceSettings } from '@/app/configure-tasks-app/actions'
 import { ClientViewSettings } from '@/types/dto/workspaceSettings.dto'
 
@@ -20,6 +22,8 @@ const VIEW_MODE_OPTIONS: { label: string; value: ViewMode }[] = [
 
 export const ClientViewSettingsSection = ({ initialSettings, token }: ClientViewSettingsSectionProps) => {
   const [settings, setSettings] = useState<ClientViewSettings>(initialSettings)
+  // Holds the change awaiting confirmation; the controls keep showing `settings` until confirmed.
+  const [pendingSettings, setPendingSettings] = useState<ClientViewSettings | null>(null)
 
   const persist = async (next: ClientViewSettings) => {
     const previous = settings
@@ -30,6 +34,13 @@ export const ClientViewSettingsSection = ({ initialSettings, token }: ClientView
       console.error('Failed to save client view settings', err)
       setSettings(previous)
     }
+  }
+
+  const handleConfirm = async () => {
+    if (!pendingSettings) return
+    const next = pendingSettings
+    setPendingSettings(null)
+    await persist(next)
   }
 
   return (
@@ -50,7 +61,9 @@ export const ClientViewSettingsSection = ({ initialSettings, token }: ClientView
           <Typography variant="bodyMd">Default view</Typography>
           <ViewModeDropdown
             value={settings.clientDefaultViewMode}
-            onChange={(value) => persist({ ...settings, clientDefaultViewMode: value })}
+            onChange={(value) =>
+              value !== settings.clientDefaultViewMode && setPendingSettings({ ...settings, clientDefaultViewMode: value })
+            }
           />
         </Stack>
         <Stack
@@ -62,10 +75,30 @@ export const ClientViewSettingsSection = ({ initialSettings, token }: ClientView
           <Typography variant="bodyMd">Hide subtasks</Typography>
           <StyledSwitch
             checked={settings.clientHideSubtasks ?? false}
-            onChange={(e) => persist({ ...settings, clientHideSubtasks: e.target.checked })}
+            onChange={(e) => setPendingSettings({ ...settings, clientHideSubtasks: e.target.checked })}
           />
         </Stack>
       </Box>
+
+      <StyledModal
+        open={!!pendingSettings}
+        onClose={() => setPendingSettings(null)}
+        aria-labelledby="confirm-client-view-settings-modal"
+        aria-describedby="confirm-client-view-settings"
+      >
+        <ConfirmUI
+          handleCancel={() => setPendingSettings(null)}
+          handleConfirm={handleConfirm}
+          buttonText="Apply to all clients"
+          title="Update view for all clients?"
+          description={
+            <>
+              This changes the view for <strong>every client</strong> in this workspace right now, replacing any view a
+              client has set for themselves. New and existing clients will all see this view.
+            </>
+          }
+        />
+      </StyledModal>
     </Box>
   )
 }

--- a/src/app/configure-tasks-app/ui/ClientViewSettingsSection.tsx
+++ b/src/app/configure-tasks-app/ui/ClientViewSettingsSection.tsx
@@ -13,21 +13,9 @@ interface ClientViewSettingsSectionProps {
   token: string
 }
 
-interface DropdownOption<T> {
-  label: string
-  value: T
-}
-
-const VIEW_MODE_OPTIONS: DropdownOption<ViewMode | null>[] = [
-  { label: 'Client decides', value: null },
+const VIEW_MODE_OPTIONS: { label: string; value: ViewMode }[] = [
   { label: 'List', value: ViewMode.list },
   { label: 'Board', value: ViewMode.board },
-]
-
-const SHOW_SUBTASKS_OPTIONS: DropdownOption<boolean | null>[] = [
-  { label: 'Client decides', value: null },
-  { label: 'Shown', value: true },
-  { label: 'Hidden', value: false },
 ]
 
 export const ClientViewSettingsSection = ({ initialSettings, token }: ClientViewSettingsSectionProps) => {
@@ -44,22 +32,6 @@ export const ClientViewSettingsSection = ({ initialSettings, token }: ClientView
     }
   }
 
-  const handleViewModeChange = (value: ViewMode | null) => {
-    persist({
-      ...settings,
-      clientDefaultViewMode: value,
-      clientLockViewMode: value != null ? settings.clientLockViewMode : false,
-    })
-  }
-
-  const handleShowSubtasksChange = (value: boolean | null) => {
-    persist({
-      ...settings,
-      clientShowSubtasks: value,
-      clientLockShowSubtasks: value != null ? settings.clientLockShowSubtasks : false,
-    })
-  }
-
   return (
     <Box sx={{ width: '100%', maxWidth: '640px', margin: '0 auto', px: { xs: 2, sm: 0 } }}>
       <Typography variant="lg" sx={{ display: 'block', mb: '12px' }}>
@@ -74,66 +46,34 @@ export const ClientViewSettingsSection = ({ initialSettings, token }: ClientView
           overflow: 'hidden',
         }}
       >
-        <SettingRow
-          label="Default view"
-          options={VIEW_MODE_OPTIONS}
-          value={settings.clientDefaultViewMode ?? null}
-          onChange={handleViewModeChange}
-          locked={settings.clientLockViewMode ?? false}
-          onLockChange={(locked) => persist({ ...settings, clientLockViewMode: locked })}
-        />
-        <SettingRow
-          label="Show subtasks"
-          options={SHOW_SUBTASKS_OPTIONS}
-          value={settings.clientShowSubtasks ?? null}
-          onChange={handleShowSubtasksChange}
-          locked={settings.clientLockShowSubtasks ?? false}
-          onLockChange={(locked) => persist({ ...settings, clientLockShowSubtasks: locked })}
-          topBorder
-        />
+        <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ px: '16px', py: '14px' }}>
+          <Typography variant="bodyMd">Default view</Typography>
+          <ViewModeDropdown
+            value={settings.clientDefaultViewMode}
+            onChange={(value) => persist({ ...settings, clientDefaultViewMode: value })}
+          />
+        </Stack>
+        <Stack
+          direction="row"
+          alignItems="center"
+          justifyContent="space-between"
+          sx={{ px: '16px', py: '14px', borderTop: (theme) => `1px solid ${theme.color.borders.border}` }}
+        >
+          <Typography variant="bodyMd">Hide subtasks</Typography>
+          <StyledSwitch
+            checked={settings.clientHideSubtasks}
+            onChange={(e) => persist({ ...settings, clientHideSubtasks: e.target.checked })}
+          />
+        </Stack>
       </Box>
     </Box>
   )
 }
 
-interface SettingRowProps<T> {
-  label: string
-  options: DropdownOption<T>[]
-  value: T
-  onChange: (value: T) => void
-  locked: boolean
-  onLockChange: (locked: boolean) => void
-  topBorder?: boolean
-}
-
-const SettingRow = <T,>({ label, options, value, onChange, locked, onLockChange, topBorder }: SettingRowProps<T>) => {
-  const hasOverride = value !== null
-
-  return (
-    <Box sx={{ borderTop: (theme) => (topBorder ? `1px solid ${theme.color.borders.border}` : 'none') }}>
-      <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ px: '16px', py: '14px' }}>
-        <Typography variant="bodyMd">{label}</Typography>
-        <OptionDropdown options={options} value={value} onChange={onChange} />
-      </Stack>
-      <Stack
-        direction="row"
-        alignItems="center"
-        justifyContent="space-between"
-        sx={{ px: '16px', pb: '14px', opacity: hasOverride ? 1 : 0.5 }}
-      >
-        <Typography variant="bodySm" sx={{ color: (theme) => theme.color.gray[600] }}>
-          Lock for clients
-        </Typography>
-        <StyledSwitch checked={locked} disabled={!hasOverride} onChange={(e) => onLockChange(e.target.checked)} />
-      </Stack>
-    </Box>
-  )
-}
-
-const OptionDropdown = <T,>({ options, value, onChange }: Pick<SettingRowProps<T>, 'options' | 'value' | 'onChange'>) => {
+const ViewModeDropdown = ({ value, onChange }: { value: ViewMode; onChange: (value: ViewMode) => void }) => {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
   const isOpen = Boolean(anchorEl)
-  const selected = options.find((option) => option.value === value) ?? options[0]
+  const selected = VIEW_MODE_OPTIONS.find((option) => option.value === value) ?? VIEW_MODE_OPTIONS[0]
 
   return (
     <>
@@ -198,9 +138,9 @@ const OptionDropdown = <T,>({ options, value, onChange }: Pick<SettingRowProps<T
           },
         }}
       >
-        {options.map((option) => (
+        {VIEW_MODE_OPTIONS.map((option) => (
           <MenuItem
-            key={option.label}
+            key={option.value}
             disableRipple
             selected={option.value === value}
             onClick={() => {

--- a/src/app/configure-tasks-app/ui/ClientViewSettingsSection.tsx
+++ b/src/app/configure-tasks-app/ui/ClientViewSettingsSection.tsx
@@ -48,7 +48,7 @@ export const ClientViewSettingsSection = ({ initialSettings, token }: ClientView
     persist({
       ...settings,
       clientDefaultViewMode: value,
-      clientLockViewMode: value !== null ? settings.clientLockViewMode : false,
+      clientLockViewMode: value != null ? settings.clientLockViewMode : false,
     })
   }
 
@@ -56,7 +56,7 @@ export const ClientViewSettingsSection = ({ initialSettings, token }: ClientView
     persist({
       ...settings,
       clientShowSubtasks: value,
-      clientLockShowSubtasks: value === null ? false : settings.clientLockShowSubtasks,
+      clientLockShowSubtasks: value != null ? settings.clientLockShowSubtasks : false,
     })
   }
 

--- a/src/app/configure-tasks-app/ui/ClientViewSettingsSection.tsx
+++ b/src/app/configure-tasks-app/ui/ClientViewSettingsSection.tsx
@@ -1,0 +1,213 @@
+'use client'
+
+import { useState, type MouseEvent } from 'react'
+import { Box, Menu, MenuItem, Stack, Typography } from '@mui/material'
+import { Icon } from 'copilot-design-system'
+import { ViewMode } from '@prisma/client'
+import { StyledSwitch } from '@/components/inputs/StyledSwitch'
+import { updateWorkspaceSettings } from '@/app/configure-tasks-app/actions'
+import { ClientViewSettings } from '@/types/dto/workspaceSettings.dto'
+
+interface ClientViewSettingsSectionProps {
+  initialSettings: ClientViewSettings
+  token: string
+}
+
+interface DropdownOption<T> {
+  label: string
+  value: T
+}
+
+const VIEW_MODE_OPTIONS: DropdownOption<ViewMode | null>[] = [
+  { label: 'Client decides', value: null },
+  { label: 'List', value: ViewMode.list },
+  { label: 'Board', value: ViewMode.board },
+]
+
+const SHOW_SUBTASKS_OPTIONS: DropdownOption<boolean | null>[] = [
+  { label: 'Client decides', value: null },
+  { label: 'Shown', value: true },
+  { label: 'Hidden', value: false },
+]
+
+export const ClientViewSettingsSection = ({ initialSettings, token }: ClientViewSettingsSectionProps) => {
+  const [settings, setSettings] = useState<ClientViewSettings>(initialSettings)
+
+  const persist = async (next: ClientViewSettings) => {
+    const previous = settings
+    setSettings(next)
+    try {
+      await updateWorkspaceSettings(token, next)
+    } catch (err) {
+      console.error('Failed to save client view settings', err)
+      setSettings(previous)
+    }
+  }
+
+  const handleViewModeChange = (value: ViewMode | null) => {
+    persist({ ...settings, clientDefaultViewMode: value, clientLockViewMode: value ? settings.clientLockViewMode : false })
+  }
+
+  const handleShowSubtasksChange = (value: boolean | null) => {
+    persist({
+      ...settings,
+      clientShowSubtasks: value,
+      clientLockShowSubtasks: value === null ? false : settings.clientLockShowSubtasks,
+    })
+  }
+
+  return (
+    <Box sx={{ width: '100%', maxWidth: '640px', margin: '0 auto', px: { xs: 2, sm: 0 } }}>
+      <Typography variant="lg" sx={{ display: 'block', mb: '12px' }}>
+        Client view settings
+      </Typography>
+
+      <Box
+        sx={{
+          border: (theme) => `1px solid ${theme.color.borders.border}`,
+          borderRadius: '4px',
+          background: (theme) => theme.color.base.white,
+          overflow: 'hidden',
+        }}
+      >
+        <SettingRow
+          label="Default view"
+          options={VIEW_MODE_OPTIONS}
+          value={settings.clientDefaultViewMode ?? null}
+          onChange={handleViewModeChange}
+          locked={settings.clientLockViewMode ?? false}
+          onLockChange={(locked) => persist({ ...settings, clientLockViewMode: locked })}
+        />
+        <SettingRow
+          label="Show subtasks"
+          options={SHOW_SUBTASKS_OPTIONS}
+          value={settings.clientShowSubtasks ?? null}
+          onChange={handleShowSubtasksChange}
+          locked={settings.clientLockShowSubtasks ?? false}
+          onLockChange={(locked) => persist({ ...settings, clientLockShowSubtasks: locked })}
+          topBorder
+        />
+      </Box>
+    </Box>
+  )
+}
+
+interface SettingRowProps<T> {
+  label: string
+  options: DropdownOption<T>[]
+  value: T
+  onChange: (value: T) => void
+  locked: boolean
+  onLockChange: (locked: boolean) => void
+  topBorder?: boolean
+}
+
+const SettingRow = <T,>({ label, options, value, onChange, locked, onLockChange, topBorder }: SettingRowProps<T>) => {
+  const hasOverride = value !== null
+
+  return (
+    <Box sx={{ borderTop: (theme) => (topBorder ? `1px solid ${theme.color.borders.border}` : 'none') }}>
+      <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ px: '16px', py: '14px' }}>
+        <Typography variant="bodyMd">{label}</Typography>
+        <OptionDropdown options={options} value={value} onChange={onChange} />
+      </Stack>
+      <Stack
+        direction="row"
+        alignItems="center"
+        justifyContent="space-between"
+        sx={{ px: '16px', pb: '14px', opacity: hasOverride ? 1 : 0.5 }}
+      >
+        <Typography variant="bodySm" sx={{ color: (theme) => theme.color.gray[600] }}>
+          Lock for clients
+        </Typography>
+        <StyledSwitch checked={locked} disabled={!hasOverride} onChange={(e) => onLockChange(e.target.checked)} />
+      </Stack>
+    </Box>
+  )
+}
+
+const OptionDropdown = <T,>({ options, value, onChange }: Pick<SettingRowProps<T>, 'options' | 'value' | 'onChange'>) => {
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
+  const isOpen = Boolean(anchorEl)
+  const selected = options.find((option) => option.value === value) ?? options[0]
+
+  return (
+    <>
+      <Box
+        component="button"
+        type="button"
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
+        onClick={(e: MouseEvent<HTMLButtonElement>) => setAnchorEl(e.currentTarget)}
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          minWidth: '160px',
+          padding: '8px 12px',
+          bgcolor: (theme) => theme.color.base.white,
+          border: (theme) => `1px solid ${isOpen ? theme.color.gray[700] : theme.color.borders.border2}`,
+          borderRadius: '6px',
+          cursor: 'pointer',
+          font: 'inherit',
+          textAlign: 'left',
+          outline: 'none',
+          '&:hover': { borderColor: (theme) => (isOpen ? theme.color.gray[700] : theme.color.gray[200]) },
+          '&:focus-visible': { borderColor: (theme) => theme.color.gray[700] },
+        }}
+      >
+        <Typography sx={{ fontSize: '14px', color: (theme) => theme.color.text.text }}>{selected.label}</Typography>
+        <Box
+          sx={{
+            display: 'flex',
+            color: (theme) => theme.color.gray[500],
+            transform: isOpen ? 'rotate(180deg)' : 'rotate(0deg)',
+          }}
+        >
+          <Icon icon="ChevronDown" width={16} height={16} />
+        </Box>
+      </Box>
+      <Menu
+        anchorEl={anchorEl}
+        open={isOpen}
+        onClose={() => setAnchorEl(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+        transitionDuration={0}
+        slotProps={{
+          paper: {
+            sx: {
+              mt: '4px',
+              width: anchorEl ? `${anchorEl.clientWidth}px` : undefined,
+              borderRadius: '6px',
+              border: (theme) => `1px solid ${theme.color.borders.border2}`,
+              boxShadow: '0px 6px 20px 0px rgba(0, 0, 0, 0.07)',
+              '& .MuiList-root': { padding: '4px 0' },
+              '& .MuiMenuItem-root': {
+                padding: '8px 12px',
+                fontSize: '14px',
+                '&:hover, &.Mui-selected, &.Mui-selected:hover': {
+                  backgroundColor: (theme) => theme.color.gray[100],
+                },
+              },
+            },
+          },
+        }}
+      >
+        {options.map((option) => (
+          <MenuItem
+            key={option.label}
+            disableRipple
+            selected={option.value === value}
+            onClick={() => {
+              onChange(option.value)
+              setAnchorEl(null)
+            }}
+          >
+            {option.label}
+          </MenuItem>
+        ))}
+      </Menu>
+    </>
+  )
+}

--- a/src/app/configure-tasks-app/ui/ClientViewSettingsSection.tsx
+++ b/src/app/configure-tasks-app/ui/ClientViewSettingsSection.tsx
@@ -45,7 +45,11 @@ export const ClientViewSettingsSection = ({ initialSettings, token }: ClientView
   }
 
   const handleViewModeChange = (value: ViewMode | null) => {
-    persist({ ...settings, clientDefaultViewMode: value, clientLockViewMode: value ? settings.clientLockViewMode : false })
+    persist({
+      ...settings,
+      clientDefaultViewMode: value,
+      clientLockViewMode: value !== null ? settings.clientLockViewMode : false,
+    })
   }
 
   const handleShowSubtasksChange = (value: boolean | null) => {

--- a/src/app/configure-tasks-app/ui/ClientViewSettingsSection.tsx
+++ b/src/app/configure-tasks-app/ui/ClientViewSettingsSection.tsx
@@ -61,7 +61,7 @@ export const ClientViewSettingsSection = ({ initialSettings, token }: ClientView
         >
           <Typography variant="bodyMd">Hide subtasks</Typography>
           <StyledSwitch
-            checked={settings.clientHideSubtasks}
+            checked={settings.clientHideSubtasks ?? false}
             onChange={(e) => persist({ ...settings, clientHideSubtasks: e.target.checked })}
           />
         </Stack>
@@ -70,10 +70,10 @@ export const ClientViewSettingsSection = ({ initialSettings, token }: ClientView
   )
 }
 
-const ViewModeDropdown = ({ value, onChange }: { value: ViewMode; onChange: (value: ViewMode) => void }) => {
+const ViewModeDropdown = ({ value, onChange }: { value: ViewMode | null; onChange: (value: ViewMode) => void }) => {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
   const isOpen = Boolean(anchorEl)
-  const selected = VIEW_MODE_OPTIONS.find((option) => option.value === value) ?? VIEW_MODE_OPTIONS[0]
+  const selected = VIEW_MODE_OPTIONS.find((option) => option.value === value)
 
   return (
     <>
@@ -100,7 +100,9 @@ const ViewModeDropdown = ({ value, onChange }: { value: ViewMode; onChange: (val
           '&:focus-visible': { borderColor: (theme) => theme.color.gray[700] },
         }}
       >
-        <Typography sx={{ fontSize: '14px', color: (theme) => theme.color.text.text }}>{selected.label}</Typography>
+        <Typography sx={{ fontSize: '14px', color: (theme) => (selected ? theme.color.text.text : theme.color.gray[500]) }}>
+          {selected ? selected.label : 'Select view'}
+        </Typography>
         <Box
           sx={{
             display: 'flex',

--- a/src/app/configure-tasks-app/ui/StatusCustomizationSection.tsx
+++ b/src/app/configure-tasks-app/ui/StatusCustomizationSection.tsx
@@ -94,7 +94,7 @@ export const StatusCustomizationSection = ({ initialWorkflowStates, token }: Sta
   return (
     <Box sx={{ width: '100%', maxWidth: '640px', margin: '0 auto', px: { xs: 2, sm: 0 } }}>
       <Typography variant="lg" sx={{ display: 'block', mb: '12px' }}>
-        Status Customization
+        Status customization
       </Typography>
 
       <Box

--- a/src/types/dto/workspaceSettings.dto.ts
+++ b/src/types/dto/workspaceSettings.dto.ts
@@ -23,7 +23,9 @@ export const UpdateWorkspaceSettingsSchema = z
 
 export type UpdateWorkspaceSettingsDTO = z.infer<typeof UpdateWorkspaceSettingsSchema>
 
-export type ClientViewSettings = Pick<
-  UpdateWorkspaceSettingsDTO,
-  'clientDefaultViewMode' | 'clientShowSubtasks' | 'clientLockViewMode' | 'clientLockShowSubtasks'
->
+export type ClientViewSettings = {
+  clientDefaultViewMode: ViewMode | null
+  clientShowSubtasks: boolean | null
+  clientLockViewMode: boolean
+  clientLockShowSubtasks: boolean
+}

--- a/src/types/dto/workspaceSettings.dto.ts
+++ b/src/types/dto/workspaceSettings.dto.ts
@@ -14,18 +14,14 @@ export const UpdateWorkspaceSettingsSchema = z
         message: `autoArchiveAfterDays must be one of ${AUTO_ARCHIVE_AFTER_DAYS_OPTIONS.join(', ')}`,
       })
       .optional(),
-    clientDefaultViewMode: z.nativeEnum(ViewMode).nullable().optional(),
-    clientShowSubtasks: z.boolean().nullable().optional(),
-    clientLockViewMode: z.boolean().optional(),
-    clientLockShowSubtasks: z.boolean().optional(),
+    clientDefaultViewMode: z.nativeEnum(ViewMode).optional(),
+    clientHideSubtasks: z.boolean().optional(),
   })
   .strict()
 
 export type UpdateWorkspaceSettingsDTO = z.infer<typeof UpdateWorkspaceSettingsSchema>
 
 export type ClientViewSettings = {
-  clientDefaultViewMode: ViewMode | null
-  clientShowSubtasks: boolean | null
-  clientLockViewMode: boolean
-  clientLockShowSubtasks: boolean
+  clientDefaultViewMode: ViewMode
+  clientHideSubtasks: boolean
 }

--- a/src/types/dto/workspaceSettings.dto.ts
+++ b/src/types/dto/workspaceSettings.dto.ts
@@ -5,19 +5,17 @@ export const AUTO_ARCHIVE_AFTER_DAYS_OPTIONS = [0, 7, 14, 30, 60, 90] as const
 
 export type AutoArchiveAfterDays = (typeof AUTO_ARCHIVE_AFTER_DAYS_OPTIONS)[number]
 
-export const UpdateWorkspaceSettingsSchema = z
-  .object({
-    autoArchiveAfterDays: z
-      .number()
-      .int()
-      .refine((val): val is AutoArchiveAfterDays => (AUTO_ARCHIVE_AFTER_DAYS_OPTIONS as readonly number[]).includes(val), {
-        message: `autoArchiveAfterDays must be one of ${AUTO_ARCHIVE_AFTER_DAYS_OPTIONS.join(', ')}`,
-      })
-      .optional(),
-    clientDefaultViewMode: z.nativeEnum(ViewMode).optional(),
-    clientHideSubtasks: z.boolean().optional(),
-  })
-  .strict()
+export const UpdateWorkspaceSettingsSchema = z.object({
+  autoArchiveAfterDays: z
+    .number()
+    .int()
+    .refine((val): val is AutoArchiveAfterDays => (AUTO_ARCHIVE_AFTER_DAYS_OPTIONS as readonly number[]).includes(val), {
+      message: `autoArchiveAfterDays must be one of ${AUTO_ARCHIVE_AFTER_DAYS_OPTIONS.join(', ')}`,
+    })
+    .optional(),
+  clientDefaultViewMode: z.nativeEnum(ViewMode).optional(),
+  clientHideSubtasks: z.boolean().optional(),
+})
 
 export type UpdateWorkspaceSettingsDTO = z.infer<typeof UpdateWorkspaceSettingsSchema>
 

--- a/src/types/dto/workspaceSettings.dto.ts
+++ b/src/types/dto/workspaceSettings.dto.ts
@@ -13,13 +13,13 @@ export const UpdateWorkspaceSettingsSchema = z.object({
       message: `autoArchiveAfterDays must be one of ${AUTO_ARCHIVE_AFTER_DAYS_OPTIONS.join(', ')}`,
     })
     .optional(),
-  clientDefaultViewMode: z.nativeEnum(ViewMode).optional(),
-  clientHideSubtasks: z.boolean().optional(),
+  clientDefaultViewMode: z.nativeEnum(ViewMode).nullish(),
+  clientHideSubtasks: z.boolean().nullish(),
 })
 
 export type UpdateWorkspaceSettingsDTO = z.infer<typeof UpdateWorkspaceSettingsSchema>
 
 export type ClientViewSettings = {
-  clientDefaultViewMode: ViewMode
-  clientHideSubtasks: boolean
+  clientDefaultViewMode: ViewMode | null
+  clientHideSubtasks: boolean | null
 }

--- a/src/types/dto/workspaceSettings.dto.ts
+++ b/src/types/dto/workspaceSettings.dto.ts
@@ -1,16 +1,29 @@
+import { ViewMode } from '@prisma/client'
 import { z } from 'zod'
 
 export const AUTO_ARCHIVE_AFTER_DAYS_OPTIONS = [0, 7, 14, 30, 60, 90] as const
 
 export type AutoArchiveAfterDays = (typeof AUTO_ARCHIVE_AFTER_DAYS_OPTIONS)[number]
 
-export const UpdateWorkspaceSettingsSchema = z.object({
-  autoArchiveAfterDays: z
-    .number()
-    .int()
-    .refine((val): val is AutoArchiveAfterDays => (AUTO_ARCHIVE_AFTER_DAYS_OPTIONS as readonly number[]).includes(val), {
-      message: `autoArchiveAfterDays must be one of ${AUTO_ARCHIVE_AFTER_DAYS_OPTIONS.join(', ')}`,
-    }),
-})
+export const UpdateWorkspaceSettingsSchema = z
+  .object({
+    autoArchiveAfterDays: z
+      .number()
+      .int()
+      .refine((val): val is AutoArchiveAfterDays => (AUTO_ARCHIVE_AFTER_DAYS_OPTIONS as readonly number[]).includes(val), {
+        message: `autoArchiveAfterDays must be one of ${AUTO_ARCHIVE_AFTER_DAYS_OPTIONS.join(', ')}`,
+      })
+      .optional(),
+    clientDefaultViewMode: z.nativeEnum(ViewMode).nullable().optional(),
+    clientShowSubtasks: z.boolean().nullable().optional(),
+    clientLockViewMode: z.boolean().optional(),
+    clientLockShowSubtasks: z.boolean().optional(),
+  })
+  .strict()
 
 export type UpdateWorkspaceSettingsDTO = z.infer<typeof UpdateWorkspaceSettingsSchema>
+
+export type ClientViewSettings = Pick<
+  UpdateWorkspaceSettingsDTO,
+  'clientDefaultViewMode' | 'clientShowSubtasks' | 'clientLockViewMode' | 'clientLockShowSubtasks'
+>


### PR DESCRIPTION
Foundation PR for [OUT-3851](https://linear.app/assemblycom/issue/OUT-3851/allow-iu-to-set-view-settings-for-cu) — *Allow IU to set view settings for CU*.

## Changes summary
- [x] Add new UI options/flow for IU to set default view settings for CU
- [x] Respect the default view settings override by IU when creating a new view setting for users

## Test cases
<img width="829" height="261" alt="Screenshot 2026-06-10 at 17 42 06" src="https://github.com/user-attachments/assets/677e469e-1c8c-4c98-99d6-c8cd093df160" />
<img width="761" height="746" alt="Screenshot 2026-06-10 at 17 41 43" src="https://github.com/user-attachments/assets/1965a569-7c45-48b5-8577-3e88c021b085" />


https://github.com/user-attachments/assets/624e1e53-cb77-4bf2-8a2f-ce9eb183b9e7



