### PR TITLE
OUT-3826 | Render + send adapter for the grouped email

### DIFF
--- a/src/app/api/notification/groupedEmail.renderer.test.ts
+++ b/src/app/api/notification/groupedEmail.renderer.test.ts
@@ -1,0 +1,110 @@
+import { GroupedEmailEventType } from '@prisma/client'
+import { GroupedEmailContent } from './groupedEmail.composer'
+import { GROUPED_EMAIL_CTA_TITLE, GROUPED_EMAIL_HEADER, renderGroupedEmail } from './groupedEmail.renderer'
+
+const section = (overrides: Partial<GroupedEmailContent['sections'][number]> = {}) => ({
+  eventType: GroupedEmailEventType.ASSIGNED,
+  count: 1,
+  taskNames: ['Task A'],
+  overflowCount: 0,
+  ...overrides,
+})
+
+describe('renderGroupedEmail', () => {
+  it('renders the PRD sample (assigned + shared + comment) as dashed plain text', () => {
+    const content: GroupedEmailContent = {
+      totalEventCount: 6,
+      sections: [
+        {
+          eventType: GroupedEmailEventType.ASSIGNED,
+          count: 3,
+          taskNames: ['Q4 Tax Document Upload', 'Complete W-9 Form', 'Review Engagement Letter'],
+          overflowCount: 0,
+        },
+        {
+          eventType: GroupedEmailEventType.SHARED,
+          count: 2,
+          taskNames: ['Annual Filing Preparation', 'Bookkeeping Review'],
+          overflowCount: 0,
+        },
+        {
+          eventType: GroupedEmailEventType.COMMENT,
+          count: 1,
+          taskNames: ['Task with a conversation'],
+          overflowCount: 0,
+        },
+      ],
+    }
+
+    const email = renderGroupedEmail(content)
+
+    expect(email.subject).toBe('You have 6 new task updates')
+    expect(email.header).toBe(GROUPED_EMAIL_HEADER)
+    expect(email.title).toBe(GROUPED_EMAIL_CTA_TITLE)
+    expect(email.body).toBe(
+      [
+        '3 tasks assigned to you',
+        '- ‘Q4 Tax Document Upload’',
+        '- ‘Complete W-9 Form’',
+        '- ‘Review Engagement Letter’',
+        '',
+        '2 tasks shared with you',
+        '- ‘Annual Filing Preparation’',
+        '- ‘Bookkeeping Review’',
+        '',
+        '1 comment was added',
+        '- ‘Task with a conversation’',
+      ].join('\n'),
+    )
+  })
+
+  it('renders the "+N other tasks" overflow line', () => {
+    const email = renderGroupedEmail({
+      totalEventCount: 12,
+      sections: [section({ count: 12, taskNames: ['A', 'B', 'C'], overflowCount: 9 })],
+    })
+
+    expect(email.body).toBe(['12 tasks assigned to you', '- ‘A’', '- ‘B’', '- ‘C’', '+9 other tasks'].join('\n'))
+  })
+
+  it('singularizes the overflow line for a single other task', () => {
+    const email = renderGroupedEmail({
+      totalEventCount: 4,
+      sections: [section({ count: 4, taskNames: ['A', 'B', 'C'], overflowCount: 1 })],
+    })
+
+    expect(email.body).toContain('+1 other task')
+    expect(email.body).not.toContain('+1 other tasks')
+  })
+
+  it('uses singular copy for the subject when there is one update', () => {
+    const email = renderGroupedEmail({
+      totalEventCount: 1,
+      sections: [section()],
+    })
+
+    expect(email.subject).toBe('You have 1 new task update')
+  })
+
+  it.each([
+    [GroupedEmailEventType.ASSIGNED, 1, '1 task assigned to you'],
+    [GroupedEmailEventType.ASSIGNED, 3, '3 tasks assigned to you'],
+    [GroupedEmailEventType.SHARED, 1, '1 task shared with you'],
+    [GroupedEmailEventType.SHARED, 2, '2 tasks shared with you'],
+    [GroupedEmailEventType.COMMENT, 1, '1 comment was added'],
+    [GroupedEmailEventType.COMMENT, 4, '4 comments were added'],
+    [GroupedEmailEventType.COMPLETED, 1, '1 task completed'],
+    [GroupedEmailEventType.COMPLETED, 2, '2 tasks completed'],
+  ])('renders the %s heading correctly for count %i', (eventType, count, expected) => {
+    const email = renderGroupedEmail({
+      totalEventCount: count,
+      sections: [section({ eventType, count, taskNames: ['Task A'] })],
+    })
+
+    expect(email.body.split('\n')[0]).toBe(expected)
+  })
+
+  it('returns an empty body when there are no sections', () => {
+    expect(renderGroupedEmail({ totalEventCount: 0, sections: [] }).body).toBe('')
+  })
+})

--- a/src/app/api/notification/groupedEmail.renderer.ts
+++ b/src/app/api/notification/groupedEmail.renderer.ts
@@ -1,0 +1,37 @@
+import { GroupedEmailEventType } from '@prisma/client'
+import { GroupedEmailContent, GroupedEmailSection } from './groupedEmail.composer'
+
+export const GROUPED_EMAIL_HEADER = 'Catch up on task activity'
+export const GROUPED_EMAIL_CTA_TITLE = 'View all tasks'
+
+export interface GroupedEmailDetails {
+  subject: string
+  header: string
+  title: string
+  body: string
+}
+
+const pluralize = (count: number, singular: string, plural: string): string => (count === 1 ? singular : plural)
+
+const sectionHeading: Record<GroupedEmailEventType, (count: number) => string> = {
+  [GroupedEmailEventType.ASSIGNED]: (count) => `${count} ${pluralize(count, 'task', 'tasks')} assigned to you`,
+  [GroupedEmailEventType.SHARED]: (count) => `${count} ${pluralize(count, 'task', 'tasks')} shared with you`,
+  [GroupedEmailEventType.COMMENT]: (count) =>
+    `${count} ${pluralize(count, 'comment', 'comments')} ${pluralize(count, 'was', 'were')} added`,
+  [GroupedEmailEventType.COMPLETED]: (count) => `${count} ${pluralize(count, 'task', 'tasks')} completed`,
+}
+
+const renderSection = (section: GroupedEmailSection): string => {
+  const lines = [sectionHeading[section.eventType](section.count), ...section.taskNames.map((name) => `- ‘${name}’`)]
+  if (section.overflowCount > 0) {
+    lines.push(`+${section.overflowCount} other ${pluralize(section.overflowCount, 'task', 'tasks')}`)
+  }
+  return lines.join('\n')
+}
+
+export const renderGroupedEmail = (content: GroupedEmailContent): GroupedEmailDetails => ({
+  subject: `You have ${content.totalEventCount} new task ${pluralize(content.totalEventCount, 'update', 'updates')}`,
+  header: GROUPED_EMAIL_HEADER,
+  title: GROUPED_EMAIL_CTA_TITLE,
+  body: content.sections.map(renderSection).join('\n\n'),
+})

--- a/src/jobs/notifications/send-grouped-email.test.ts
+++ b/src/jobs/notifications/send-grouped-email.test.ts
@@ -1,0 +1,90 @@
+import { GroupedEmailContent } from '@/app/api/notification/groupedEmail.composer'
+import { CopilotAPI } from '@/utils/CopilotAPI'
+import { GroupedEmailEventType } from '@prisma/client'
+import { sendGroupedEmail } from './send-grouped-email'
+
+const content: GroupedEmailContent = {
+  totalEventCount: 2,
+  sections: [
+    {
+      eventType: GroupedEmailEventType.ASSIGNED,
+      count: 2,
+      taskNames: ['Task A', 'Task B'],
+      overflowCount: 0,
+    },
+  ],
+}
+
+const buildCopilotMock = (createNotification: jest.Mock) => ({ createNotification }) as unknown as CopilotAPI
+
+describe('sendGroupedEmail', () => {
+  it('returns the Copilot notification id', async () => {
+    const createNotification = jest.fn().mockResolvedValue({ id: 'notif_1', createdAt: '2026-06-09T00:00:00Z' })
+
+    const id = await sendGroupedEmail({
+      content,
+      senderId: 'iu_1',
+      recipientClientId: 'client_1',
+      recipientCompanyId: 'company_1',
+      copilot: buildCopilotMock(createNotification),
+    })
+
+    expect(id).toBe('notif_1')
+  })
+
+  it('builds an email-only payload (no inProduct, IU sender, client recipient)', async () => {
+    const createNotification = jest.fn().mockResolvedValue({ id: 'notif_1', createdAt: '2026-06-09T00:00:00Z' })
+
+    await sendGroupedEmail({
+      content,
+      senderId: 'iu_1',
+      recipientClientId: 'client_1',
+      recipientCompanyId: 'company_1',
+      copilot: buildCopilotMock(createNotification),
+    })
+
+    expect(createNotification).toHaveBeenCalledTimes(1)
+    const payload = createNotification.mock.calls[0][0]
+    expect(payload).toMatchObject({
+      senderId: 'iu_1',
+      senderType: 'internalUser',
+      recipientClientId: 'client_1',
+      recipientCompanyId: 'company_1',
+    })
+    expect(payload.deliveryTargets.email).toEqual({
+      subject: 'You have 2 new task updates',
+      header: 'Catch up on task activity',
+      title: 'View all tasks',
+      body: expect.stringContaining('2 tasks assigned to you'),
+    })
+    expect(payload.deliveryTargets.inProduct).toBeUndefined()
+  })
+
+  it('omits recipientCompanyId when null', async () => {
+    const createNotification = jest.fn().mockResolvedValue({ id: 'notif_2', createdAt: '2026-06-09T00:00:00Z' })
+
+    await sendGroupedEmail({
+      content,
+      senderId: 'iu_1',
+      recipientClientId: 'client_1',
+      recipientCompanyId: null,
+      copilot: buildCopilotMock(createNotification),
+    })
+
+    expect(createNotification.mock.calls[0][0].recipientCompanyId).toBeUndefined()
+  })
+
+  it('propagates errors from Copilot', async () => {
+    const createNotification = jest.fn().mockRejectedValue(new Error('copilot 5xx'))
+
+    await expect(
+      sendGroupedEmail({
+        content,
+        senderId: 'iu_1',
+        recipientClientId: 'client_1',
+        recipientCompanyId: 'company_1',
+        copilot: buildCopilotMock(createNotification),
+      }),
+    ).rejects.toThrow('copilot 5xx')
+  })
+})

--- a/src/jobs/notifications/send-grouped-email.ts
+++ b/src/jobs/notifications/send-grouped-email.ts
@@ -1,0 +1,42 @@
+import 'server-only'
+
+import { GroupedEmailContent } from '@/app/api/notification/groupedEmail.composer'
+import { renderGroupedEmail } from '@/app/api/notification/groupedEmail.renderer'
+import { NotificationRequestBody } from '@/types/common'
+import { CopilotAPI } from '@/utils/CopilotAPI'
+
+export type SendGroupedEmailArgs = {
+  content: GroupedEmailContent
+  senderId: string
+  recipientClientId: string
+  recipientCompanyId: string | null
+  copilot: CopilotAPI
+}
+
+export const sendGroupedEmail = async ({
+  content,
+  senderId,
+  recipientClientId,
+  recipientCompanyId,
+  copilot,
+}: SendGroupedEmailArgs): Promise<string> => {
+  const email = renderGroupedEmail(content)
+
+  const payload: NotificationRequestBody = {
+    senderId,
+    senderType: 'internalUser',
+    recipientClientId,
+    recipientCompanyId: recipientCompanyId ?? undefined,
+    deliveryTargets: {
+      email: {
+        subject: email.subject,
+        header: email.header,
+        title: email.title,
+        body: email.body,
+      },
+    },
+  }
+
+  const notification = await copilot.createNotification(payload)
+  return notification.id
+}


### PR DESCRIPTION
## What

Turns the composer's `GroupedEmailContent` into a sent email — one email-only Copilot notification per recipient. Two pieces, mirroring the reminder pipeline's render/send split:

- **`groupedEmail.renderer.ts`** (pure) — `renderGroupedEmail(content) → { subject, header, title, body }`
- **`send-grouped-email.ts`** (`jobs/notifications/`) — thin `copilot.createNotification` wrapper, email-only

Linear: [OUT-3826](https://linear.app/assemblycom/issue/OUT-3826)

> Stacked on #1303 (OUT-3825 composer) — base is `OUT-3825`. Retarget as the stack merges.

## Rendering — plain text, not markdown

Per the M2 descope, the **markdown dependency (OUT-3830) is dropped** — we render plain text with dashes, no bold/italic. So this ticket is **no longer blocked** and ships end-to-end.

Example body (PRD sample):
```
3 tasks assigned to you
- ‘Q4 Tax Document Upload’
- ‘Complete W-9 Form’
- ‘Review Engagement Letter’

2 tasks shared with you
- ‘Annual Filing Preparation’
- ‘Bookkeeping Review’

1 comment was added
- ‘Task with a conversation’
```

- Section headings per type with correct pluralization: `N task(s) assigned to you` / `shared with you` / `N comment(s) was/were added` / `N task(s) completed`.
- Task names as `- ‘Name’` dashed lines; `+N other task(s)` overflow line; sections separated by blank lines.
- `subject` = `You have N new task update(s)` — **no `{Brand} portal:` prefix** (Copilot prepends it; see `notification.helpers.ts`). `header` = "Catch up on task activity". CTA `title` = "View all tasks".

## Send

`sendGroupedEmail()` builds an **email-only** `deliveryTargets` (no `inProduct` — in-product notifications stay immediate at event time), `senderType: 'internalUser'`, workspace-scoped token. Mirrors `send-reminder-email.ts`.

## Decisions worth a look

- **Sender is caller-provided.** A grouped email aggregates many tasks with no single creator, and the buffer stores none — so `senderId` is resolved by the OUT-3824 dispatcher and passed in, rather than derived here.
- **Renderer takes no `workspace`.** The ticket signature was `render(content, workspace)`, but the section copy is recipient-agnostic ("to you") and email branding is applied by Copilot's template (same as reminders) — so `workspace` would be unused. Dropped it for KISS; easy to thread back if company-specific wording is ever wanted.
- **The CTA links to the Tasks app default**, not a specific task — the email `deliveryTargets` schema has no `ctaParams` (the reminder email passes none either).

## Testing

17 unit tests — PRD sample exact body, overflow line + singular/plural, subject pluralization, every section heading via `it.each`, empty body, and the send payload (email-only shape, IU sender, `recipientCompanyId` omitted when null, error propagation). `tsc`/eslint/prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)