### PR TITLE
feat(view-settings): enforce locked client view settings (OUT-3851 hard lock)

### DIFF
--- a/prisma/migrations/20260610095913_add_client_view_settings_lock_to_workspace_settings/migration.sql
+++ b/prisma/migrations/20260610095913_add_client_view_settings_lock_to_workspace_settings/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "WorkspaceSettings" ADD COLUMN     "clientViewSettingsLocked" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema/workspaceSetting.prisma
+++ b/prisma/schema/workspaceSetting.prisma
@@ -1,12 +1,13 @@
 model WorkspaceSetting {
-  id                     String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  workspaceId            String    @unique @db.VarChar(32)
-  autoArchiveAfterDays   Int       @default(0)
-  clientDefaultViewMode  ViewMode  @default(board)
-  clientHideSubtasks     Boolean   @default(false)
-  createdAt              DateTime  @default(now())
-  updatedAt              DateTime  @updatedAt @db.Timestamptz()
-  deletedAt              DateTime? @db.Timestamptz()
+  id                       String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  workspaceId              String    @unique @db.VarChar(32)
+  autoArchiveAfterDays     Int       @default(0)
+  clientDefaultViewMode    ViewMode  @default(board)
+  clientHideSubtasks       Boolean   @default(false)
+  clientViewSettingsLocked Boolean   @default(false)
+  createdAt                DateTime  @default(now())
+  updatedAt                DateTime  @updatedAt @db.Timestamptz()
+  deletedAt                DateTime? @db.Timestamptz()
 
   @@map("WorkspaceSettings")
 }

--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -13,7 +13,7 @@ import { RealTime } from '@/hoc/RealTime'
 import { UrlActionParamsType, Token, TokenSchema } from '@/types/common'
 import { CreateAttachmentRequest } from '@/types/dto/attachments.dto'
 import { TaskResponse } from '@/types/dto/tasks.dto'
-import { CreateViewSettingsDTO } from '@/types/dto/viewSettings.dto'
+import { ViewSettingsResponse } from '@/types/dto/viewSettings.dto'
 import { WorkflowStateResponse } from '@/types/dto/workflowStates.dto'
 import { UserType } from '@/types/interfaces'
 import { CopilotAPI } from '@/utils/CopilotAPI'
@@ -60,7 +60,7 @@ export async function getTokenPayload(token: string): Promise<Token> {
   return payload as Token
 }
 
-export async function getViewSettings(token: string): Promise<CreateViewSettingsDTO> {
+export async function getViewSettings(token: string): Promise<ViewSettingsResponse> {
   const res = await fetch(`${apiUrl}/api/view-settings?token=${token}`, {
     next: { tags: ['getViewSettings'] },
   })

--- a/src/app/api/view-settings/viewSettings.service.ts
+++ b/src/app/api/view-settings/viewSettings.service.ts
@@ -90,8 +90,8 @@ export class ViewSettingsService extends BaseService {
     })
   }
 
-  // Locked client view settings configured at workspace level win over a client's own values.
-  // Returns the enforced value per field, or null when the field is not locked (IUs are never locked).
+  // When the workspace locks client view settings, the configured defaults win over a client's
+  // own values. Returns enforced values per field, or null per field when not locked (IUs are never locked).
   private async getEnforcedClientView(): Promise<{ viewMode: ViewMode | null; showSubtasks: boolean | null }> {
     if (this.user.internalUserId) {
       return { viewMode: null, showSubtasks: null }
@@ -99,15 +99,12 @@ export class ViewSettingsService extends BaseService {
     const workspaceSetting = await this.db.workspaceSetting.findUnique({
       where: { workspaceId: this.user.workspaceId },
     })
+    if (!workspaceSetting?.clientViewSettingsLocked) {
+      return { viewMode: null, showSubtasks: null }
+    }
     return {
-      viewMode:
-        workspaceSetting?.clientLockViewMode && workspaceSetting.clientDefaultViewMode
-          ? workspaceSetting.clientDefaultViewMode
-          : null,
-      showSubtasks:
-        workspaceSetting?.clientLockShowSubtasks && workspaceSetting.clientShowSubtasks != null
-          ? workspaceSetting.clientShowSubtasks
-          : null,
+      viewMode: workspaceSetting.clientDefaultViewMode,
+      showSubtasks: !workspaceSetting.clientHideSubtasks,
     }
   }
 

--- a/src/app/api/view-settings/viewSettings.service.ts
+++ b/src/app/api/view-settings/viewSettings.service.ts
@@ -40,7 +40,21 @@ export class ViewSettingsService extends BaseService {
       viewSettings.filterOptions = { ...filterOptions, [FilterOptions.ASSOCIATION]: emptyAssignee }
     }
 
-    return viewSettings
+    const enforced = await this.getEnforcedClientView()
+    if (enforced.viewMode) {
+      viewSettings.viewMode = enforced.viewMode
+    }
+    if (enforced.showSubtasks !== null) {
+      viewSettings.showSubtasks = enforced.showSubtasks
+    }
+
+    return {
+      ...viewSettings,
+      clientLocks: {
+        viewMode: enforced.viewMode !== null,
+        showSubtasks: enforced.showSubtasks !== null,
+      },
+    }
   }
 
   async createOrUpdateViewSettings(data: CreateViewSettingsDTO) {
@@ -53,8 +67,11 @@ export class ViewSettingsService extends BaseService {
       companyId: this.user.companyId || null,
     }
     const parsedUserIds = ViewSettingUserIds.parse(userIds)
+    const enforced = await this.getEnforcedClientView()
     const newViewSettingData = {
       ...data,
+      ...(enforced.viewMode ? { viewMode: enforced.viewMode } : {}),
+      ...(enforced.showSubtasks !== null ? { showSubtasks: enforced.showSubtasks } : {}),
       ...parsedUserIds,
       workspaceId: this.user.workspaceId,
     }
@@ -71,6 +88,27 @@ export class ViewSettingsService extends BaseService {
       where: { id: viewSettings.id },
       data: newViewSettingData,
     })
+  }
+
+  // Locked client view settings configured at workspace level win over a client's own values.
+  // Returns the enforced value per field, or null when the field is not locked (IUs are never locked).
+  private async getEnforcedClientView(): Promise<{ viewMode: ViewMode | null; showSubtasks: boolean | null }> {
+    if (this.user.internalUserId) {
+      return { viewMode: null, showSubtasks: null }
+    }
+    const workspaceSetting = await this.db.workspaceSetting.findUnique({
+      where: { workspaceId: this.user.workspaceId },
+    })
+    return {
+      viewMode:
+        workspaceSetting?.clientLockViewMode && workspaceSetting.clientDefaultViewMode
+          ? workspaceSetting.clientDefaultViewMode
+          : null,
+      showSubtasks:
+        workspaceSetting?.clientLockShowSubtasks && workspaceSetting.clientShowSubtasks !== null
+          ? workspaceSetting.clientShowSubtasks
+          : null,
+    }
   }
 
   private async createInitialViewSettings(userIds: ViewSettingUserIdsType) {

--- a/src/app/api/view-settings/viewSettings.service.ts
+++ b/src/app/api/view-settings/viewSettings.service.ts
@@ -41,18 +41,18 @@ export class ViewSettingsService extends BaseService {
     }
 
     const enforced = await this.getEnforcedClientView()
-    if (enforced.viewMode !== null) {
+    if (enforced.viewMode != null) {
       viewSettings.viewMode = enforced.viewMode
     }
-    if (enforced.showSubtasks !== null) {
+    if (enforced.showSubtasks != null) {
       viewSettings.showSubtasks = enforced.showSubtasks
     }
 
     return {
       ...viewSettings,
       clientLocks: {
-        viewMode: enforced.viewMode !== null,
-        showSubtasks: enforced.showSubtasks !== null,
+        viewMode: enforced.viewMode != null,
+        showSubtasks: enforced.showSubtasks != null,
       },
     }
   }
@@ -70,8 +70,8 @@ export class ViewSettingsService extends BaseService {
     const enforced = await this.getEnforcedClientView()
     const newViewSettingData = {
       ...data,
-      ...(enforced.viewMode !== null ? { viewMode: enforced.viewMode } : {}),
-      ...(enforced.showSubtasks !== null ? { showSubtasks: enforced.showSubtasks } : {}),
+      ...(enforced.viewMode != null ? { viewMode: enforced.viewMode } : {}),
+      ...(enforced.showSubtasks != null ? { showSubtasks: enforced.showSubtasks } : {}),
       ...parsedUserIds,
       workspaceId: this.user.workspaceId,
     }
@@ -105,7 +105,7 @@ export class ViewSettingsService extends BaseService {
           ? workspaceSetting.clientDefaultViewMode
           : null,
       showSubtasks:
-        workspaceSetting?.clientLockShowSubtasks && workspaceSetting.clientShowSubtasks !== null
+        workspaceSetting?.clientLockShowSubtasks && workspaceSetting.clientShowSubtasks != null
           ? workspaceSetting.clientShowSubtasks
           : null,
     }

--- a/src/app/api/view-settings/viewSettings.service.ts
+++ b/src/app/api/view-settings/viewSettings.service.ts
@@ -41,7 +41,7 @@ export class ViewSettingsService extends BaseService {
     }
 
     const enforced = await this.getEnforcedClientView()
-    if (enforced.viewMode) {
+    if (enforced.viewMode !== null) {
       viewSettings.viewMode = enforced.viewMode
     }
     if (enforced.showSubtasks !== null) {
@@ -70,7 +70,7 @@ export class ViewSettingsService extends BaseService {
     const enforced = await this.getEnforcedClientView()
     const newViewSettingData = {
       ...data,
-      ...(enforced.viewMode ? { viewMode: enforced.viewMode } : {}),
+      ...(enforced.viewMode !== null ? { viewMode: enforced.viewMode } : {}),
       ...(enforced.showSubtasks !== null ? { showSubtasks: enforced.showSubtasks } : {}),
       ...parsedUserIds,
       workspaceId: this.user.workspaceId,

--- a/src/app/configure-tasks-app/page.tsx
+++ b/src/app/configure-tasks-app/page.tsx
@@ -91,6 +91,7 @@ export default async function ConfigureTasksAppPage(props: ConfigureTasksAppPage
             initialSettings={{
               clientDefaultViewMode: workspaceSetting.clientDefaultViewMode,
               clientHideSubtasks: workspaceSetting.clientHideSubtasks,
+              clientViewSettingsLocked: workspaceSetting.clientViewSettingsLocked,
             }}
             token={token}
           />

--- a/src/app/configure-tasks-app/ui/ClientViewSettingsSection.tsx
+++ b/src/app/configure-tasks-app/ui/ClientViewSettingsSection.tsx
@@ -65,6 +65,23 @@ export const ClientViewSettingsSection = ({ initialSettings, token }: ClientView
             onChange={(e) => persist({ ...settings, clientHideSubtasks: e.target.checked })}
           />
         </Stack>
+        <Stack
+          direction="row"
+          alignItems="center"
+          justifyContent="space-between"
+          sx={{ px: '16px', py: '14px', borderTop: (theme) => `1px solid ${theme.color.borders.border}` }}
+        >
+          <Stack>
+            <Typography variant="bodyMd">Lock for clients</Typography>
+            <Typography variant="bodySm" sx={{ color: (theme) => theme.color.gray[600] }}>
+              Clients can&apos;t change these settings
+            </Typography>
+          </Stack>
+          <StyledSwitch
+            checked={settings.clientViewSettingsLocked}
+            onChange={(e) => persist({ ...settings, clientViewSettingsLocked: e.target.checked })}
+          />
+        </Stack>
       </Box>
     </Box>
   )

--- a/src/app/detail/[task_id]/[user_type]/loaders.ts
+++ b/src/app/detail/[task_id]/[user_type]/loaders.ts
@@ -5,7 +5,7 @@ import { TasksService } from '@api/tasks/tasks.service'
 import { ViewSettingsService } from '@api/view-settings/viewSettings.service'
 import httpStatus from 'http-status'
 import type { AncestorTaskResponse, SubTaskStatusResponse, TaskResponse } from '@/types/dto/tasks.dto'
-import type { CreateViewSettingsDTO } from '@/types/dto/viewSettings.dto'
+import type { ViewSettingsResponse } from '@/types/dto/viewSettings.dto'
 
 // this is needed since we are no longer making api round trip our dates are actual dates when we need it as string.
 const toJsonSafe = <T>(value: T): T => JSON.parse(JSON.stringify(value)) as T
@@ -38,5 +38,5 @@ export const loadSubtaskStatus = async (user: User, taskId: string): Promise<Sub
   }
 }
 
-export const loadViewSettings = async (user: User): Promise<CreateViewSettingsDTO> =>
-  toJsonSafe(await new ViewSettingsService(user).getViewSettingsForUser()) as unknown as CreateViewSettingsDTO
+export const loadViewSettings = async (user: User): Promise<ViewSettingsResponse> =>
+  toJsonSafe(await new ViewSettingsService(user).getViewSettingsForUser()) as unknown as ViewSettingsResponse

--- a/src/components/inputs/DisplaySelector.tsx
+++ b/src/components/inputs/DisplaySelector.tsx
@@ -14,6 +14,8 @@ interface DisplaySelectorProps {
   displayOptions: DisplayOptions
   handleDisplayOptionsChange: (displayOptions: DisplayOptions) => void
   mobileView?: boolean
+  lockViewMode?: boolean
+  lockShowSubtasks?: boolean
 }
 
 export const DisplaySelector = ({
@@ -22,6 +24,8 @@ export const DisplaySelector = ({
   displayOptions,
   handleDisplayOptionsChange,
   mobileView,
+  lockViewMode,
+  lockShowSubtasks,
 }: DisplaySelectorProps) => {
   const [anchorEl, setAnchorEl] = useState<null | Element>(null)
   const open = Boolean(anchorEl)
@@ -97,6 +101,8 @@ export const DisplaySelector = ({
             alignItems: 'flex-start',
             alignSelf: 'stretch',
             paddingBottom: '8px',
+            opacity: lockViewMode ? 0.5 : 1,
+            pointerEvents: lockViewMode ? 'none' : 'auto',
           }}
         >
           <IconContainer
@@ -140,6 +146,7 @@ export const DisplaySelector = ({
           <Typography variant="bodyMd"> Show subtasks</Typography>
           <StyledSwitch
             checked={displayOptions.showSubtasks}
+            disabled={lockShowSubtasks}
             onChange={(e) =>
               handleDisplayOptionsChange({
                 ...displayOptions,

--- a/src/components/layouts/FilterBar.tsx
+++ b/src/components/layouts/FilterBar.tsx
@@ -26,17 +26,9 @@ interface FilterBarProps {
 }
 
 export const FilterBar = ({ mode }: FilterBarProps) => {
-  const {
-    view,
-    filterOptions,
-    viewSettingsTemp,
-    showArchived,
-    showUnarchived,
-    showSubtasks,
-    previewMode,
-    tasks,
-    clientViewLocks,
-  } = useSelector(selectTaskBoard)
+  const { view, filterOptions, viewSettingsTemp, showArchived, showUnarchived, showSubtasks, previewMode, tasks } =
+    useSelector(selectTaskBoard)
+  const { clientViewLocks } = useSelector(selectTaskBoard)
 
   const { updateViewModeSetting, handleFilterOptionsChange, iuFilterButtons, clientFilterButtons, previewFilterButtons } =
     useFilterBar()

--- a/src/components/layouts/FilterBar.tsx
+++ b/src/components/layouts/FilterBar.tsx
@@ -26,8 +26,17 @@ interface FilterBarProps {
 }
 
 export const FilterBar = ({ mode }: FilterBarProps) => {
-  const { view, filterOptions, viewSettingsTemp, showArchived, showUnarchived, showSubtasks, previewMode, tasks } =
-    useSelector(selectTaskBoard)
+  const {
+    view,
+    filterOptions,
+    viewSettingsTemp,
+    showArchived,
+    showUnarchived,
+    showSubtasks,
+    previewMode,
+    tasks,
+    clientViewLocks,
+  } = useSelector(selectTaskBoard)
 
   const { updateViewModeSetting, handleFilterOptionsChange, iuFilterButtons, clientFilterButtons, previewFilterButtons } =
     useFilterBar()
@@ -148,6 +157,8 @@ export const FilterBar = ({ mode }: FilterBarProps) => {
               }}
               displayOptions={displayOptions}
               handleDisplayOptionsChange={handleDisplayOptionsChange}
+              lockViewMode={clientViewLocks.viewMode}
+              lockShowSubtasks={clientViewLocks.showSubtasks}
             />
             {previewMode && (
               <IconBtn
@@ -221,6 +232,8 @@ export const FilterBar = ({ mode }: FilterBarProps) => {
                 }}
                 displayOptions={displayOptions}
                 handleDisplayOptionsChange={handleDisplayOptionsChange}
+                lockViewMode={clientViewLocks.viewMode}
+                lockShowSubtasks={clientViewLocks.showSubtasks}
               />
             </Stack>
           </Stack>

--- a/src/hoc/ClientSideStateUpdate.tsx
+++ b/src/hoc/ClientSideStateUpdate.tsx
@@ -8,6 +8,7 @@ import {
   setFilteredAssigneeList,
   setPreviewMode,
   setTasks,
+  setClientViewLocks,
   setToken,
   setUrlActionParams,
   setViewSettings,
@@ -19,7 +20,7 @@ import store from '@/redux/store'
 import { Token, UrlActionParamsType, WorkspaceResponse } from '@/types/common'
 import { HomeParamActions } from '@/types/constants'
 import { TaskResponse } from '@/types/dto/tasks.dto'
-import { CreateViewSettingsDTO } from '@/types/dto/viewSettings.dto'
+import { ViewSettingsResponse } from '@/types/dto/viewSettings.dto'
 import { WorkflowStateResponse } from '@/types/dto/workflowStates.dto'
 import { FilterOptionsKeywords, IAssigneeCombined, IAssigneeSuggestions, ITemplate } from '@/types/interfaces'
 import { filterOptionsMap } from '@/types/objectMaps'
@@ -32,7 +33,7 @@ type ClientSideStateUpdateProps = {
   workflowStates?: WorkflowStateResponse[]
   tasks?: TaskResponse[]
   assignee?: IAssigneeCombined[]
-  viewSettings?: CreateViewSettingsDTO
+  viewSettings?: ViewSettingsResponse
   token?: string
   tokenPayload?: Token | null
   templates?: ITemplate[]
@@ -94,6 +95,7 @@ export const ClientSideStateUpdate = ({
         viewSettingsCopy.filterOptions.type = FilterOptionsKeywords.CLIENTS
       }
       store.dispatch(setViewSettings(viewSettingsCopy))
+      store.dispatch(setClientViewLocks(viewSettings.clientLocks ?? { viewMode: false, showSubtasks: false }))
       const view = viewSettingsTemp ? viewSettingsTemp.filterOptions : viewSettingsCopy.filterOptions
       store.dispatch(
         setFilteredAssigneeList({

--- a/src/redux/features/taskBoardSlice.tsx
+++ b/src/redux/features/taskBoardSlice.tsx
@@ -1,7 +1,7 @@
 import { RootState } from '@/redux/store'
 import { PreviewClientCompanyType, PreviewMode, UrlActionParamsType } from '@/types/common'
 import { TaskResponse } from '@/types/dto/tasks.dto'
-import { CreateViewSettingsDTO, FilterOptionsType } from '@/types/dto/viewSettings.dto'
+import { ClientViewLocks, CreateViewSettingsDTO, FilterOptionsType } from '@/types/dto/viewSettings.dto'
 import { WorkflowStateResponse } from '@/types/dto/workflowStates.dto'
 import { FilterByOptions, FilterOptions, IAssigneeCombined, IFilterOptions, UserIds } from '@/types/interfaces'
 import { emptyAssignee, UserIdsType } from '@/utils/assignee'
@@ -21,6 +21,7 @@ interface IInitialState {
   showUnarchived: boolean | undefined
   showSubtasks: boolean | undefined
   viewSettingsTemp: CreateViewSettingsDTO | undefined
+  clientViewLocks: ClientViewLocks
   isTasksLoading: boolean
   activeTask: TaskResponse | undefined
   previewMode: PreviewMode
@@ -53,6 +54,7 @@ const initialState: IInitialState = {
   showUnarchived: undefined,
   showSubtasks: undefined,
   viewSettingsTemp: undefined,
+  clientViewLocks: { viewMode: false, showSubtasks: false },
   // Use this state as a global loading flag for tasks
   isTasksLoading: true,
   activeTask: undefined,
@@ -153,6 +155,10 @@ const taskBoardSlice = createSlice({
 
     setViewSettingsTemp: (state, action: { payload: CreateViewSettingsDTO }) => {
       state.viewSettingsTemp = action.payload
+    },
+
+    setClientViewLocks: (state, action: { payload: ClientViewLocks }) => {
+      state.clientViewLocks = action.payload
     },
 
     setFilterOptions: (state, action: { payload: { optionType: FilterOptions; newValue: string | null | UserIdsType } }) => {
@@ -273,6 +279,7 @@ export const {
   setFilterOptions,
   setFilteredAssigneeList,
   setViewSettingsTemp,
+  setClientViewLocks,
   setIsTasksLoading,
   setActiveTask,
   setPreviewMode,

--- a/src/types/dto/viewSettings.dto.ts
+++ b/src/types/dto/viewSettings.dto.ts
@@ -28,3 +28,10 @@ export const CreateViewSettingsSchema = z.object({
   showSubtasks: z.boolean().optional(),
 })
 export type CreateViewSettingsDTO = z.infer<typeof CreateViewSettingsSchema>
+
+export type ClientViewLocks = {
+  viewMode: boolean
+  showSubtasks: boolean
+}
+
+export type ViewSettingsResponse = CreateViewSettingsDTO & { clientLocks?: ClientViewLocks }

--- a/src/types/dto/workspaceSettings.dto.ts
+++ b/src/types/dto/workspaceSettings.dto.ts
@@ -15,6 +15,7 @@ export const UpdateWorkspaceSettingsSchema = z.object({
     .optional(),
   clientDefaultViewMode: z.nativeEnum(ViewMode).optional(),
   clientHideSubtasks: z.boolean().optional(),
+  clientViewSettingsLocked: z.boolean().optional(),
 })
 
 export type UpdateWorkspaceSettingsDTO = z.infer<typeof UpdateWorkspaceSettingsSchema>
@@ -22,4 +23,5 @@ export type UpdateWorkspaceSettingsDTO = z.infer<typeof UpdateWorkspaceSettingsS
 export type ClientViewSettings = {
   clientDefaultViewMode: ViewMode
   clientHideSubtasks: boolean
+  clientViewSettingsLocked: boolean
 }


### PR DESCRIPTION
## What & why

PR2 of [OUT-3851](https://linear.app/assemblycom/issue/OUT-3851/allow-iu-to-set-view-settings-for-cu) — the **hard lock** behavior. Builds on the foundation PR (#1308) and targets that branch.

When an IU **locks** a client view setting at the workspace level (value set + lock on), that value is enforced for clients: it wins over the client's own stored value on read, and the matching control is disabled in the UI. Because enforcement happens at read time, it covers **existing clients with no backfill**.

## How

**Server** (`viewSettings.service.ts`)
- New `getEnforcedClientView()` — for a client user, reads the workspace setting and returns the enforced value per field (or `null` when not locked). IUs always get `null`.
- `getViewSettingsForUser` overlays enforced values onto the returned row and attaches `clientLocks: { viewMode, showSubtasks }`.
- `createOrUpdateViewSettings` overwrites locked fields with the enforced value before persisting, so a client cannot save over a locked field.

**Client**
- `clientLocks` flows through the view-settings response → `ViewSettingsResponse` type → Redux (`clientViewLocks`, set in `ClientSideStateUpdate`).
- `FilterBar` passes the locks to `DisplaySelector`, which disables the view-mode toggle and/or the Show-subtasks switch when locked.

## Scope notes

- IUs are never affected.
- Preview mode (IU viewing as a client) keeps the IU's own settings — locks are not applied in preview. Can revisit if needed.
- Cache: the view-settings GET is fetch-cached per user (tag `getViewSettings`). A client picks up a newly-changed workspace lock on their next uncached load — acceptable eventual consistency; no per-CU invalidation added.

## Testing
- `yarn tsc` clean for all changed files (fresh-worktree SVG/testcontainer noise aside), eslint 0 errors, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
