### PR TITLE
feat(view-settings): seed client view defaults for new clients (OUT-3851 soft default)

### DIFF
--- a/src/app/api/view-settings/viewSettings.service.ts
+++ b/src/app/api/view-settings/viewSettings.service.ts
@@ -74,10 +74,11 @@ export class ViewSettingsService extends BaseService {
   }
 
   private async createInitialViewSettings(userIds: ViewSettingUserIdsType) {
+    const clientDefaults = await this.getClientViewDefaults()
     const data = {
       ...userIds,
       workspaceId: this.user.workspaceId,
-      viewMode: this.DEFAULT_VIEW_MODE,
+      viewMode: clientDefaults?.viewMode ?? this.DEFAULT_VIEW_MODE,
       filterOptions: {
         [FilterOptions.ASSIGNEE]: emptyAssignee,
         [FilterOptions.ASSOCIATION]: emptyAssignee,
@@ -87,11 +88,28 @@ export class ViewSettingsService extends BaseService {
       },
       showUnarchived: true,
       showArchived: false,
-      showSubtasks: true, // If we DO need to default to false for IUs, we can add a condition here after confirmation
+      showSubtasks: clientDefaults?.showSubtasks ?? true,
     }
 
     return await this.db.viewSetting.create({
       data,
     })
+  }
+
+  // Workspace-level client defaults seed a new client's first view settings. IUs keep the hardcoded defaults.
+  private async getClientViewDefaults(): Promise<{ viewMode: ViewMode | null; showSubtasks: boolean | null } | null> {
+    if (this.user.internalUserId) {
+      return null
+    }
+    const workspaceSetting = await this.db.workspaceSetting.findUnique({
+      where: { workspaceId: this.user.workspaceId },
+    })
+    if (!workspaceSetting) {
+      return null
+    }
+    return {
+      viewMode: workspaceSetting.clientDefaultViewMode,
+      showSubtasks: workspaceSetting.clientShowSubtasks,
+    }
   }
 }

--- a/src/app/api/view-settings/viewSettings.service.ts
+++ b/src/app/api/view-settings/viewSettings.service.ts
@@ -109,7 +109,7 @@ export class ViewSettingsService extends BaseService {
     }
     return {
       viewMode: workspaceSetting.clientDefaultViewMode,
-      showSubtasks: workspaceSetting.clientShowSubtasks,
+      showSubtasks: !workspaceSetting.clientHideSubtasks,
     }
   }
 }


### PR DESCRIPTION
## What & why

PR3 of [OUT-3851](https://linear.app/assemblycom/issue/OUT-3851/allow-iu-to-set-view-settings-for-cu) — the **soft default** behavior. Builds on the foundation PR (#1308) and targets that branch.

When a client user gets their **first** `ViewSettings` row, seed `viewMode` / `showSubtasks` from the workspace-level client defaults (when set), instead of the hardcoded `board` / `showSubtasks: true`. The client keeps full control afterward.

## How

`viewSettings.service.ts` only:
- New `getClientViewDefaults()` — for a client user, returns the workspace `clientDefaultViewMode` / `clientShowSubtasks`; `null` for IUs.
- `createInitialViewSettings` uses those values with fallback to the existing hardcoded defaults.

## Scope notes

- Seeding runs **only** when no row exists for the user → **new client users only**. Existing clients (already have a row) and IUs are unaffected.
- Lock flags are irrelevant here — only the default *values* matter for seeding. Enforcement against existing clients is PR2's job.

## Testing
- `yarn tsc` clean for the changed file, eslint 0 errors, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
