### PR TITLE
OUT-3863 | Mark as Done gives no immediate feedback

### DIFF
--- a/src/app/_fetchers/OneTaskDataFetcher.tsx
+++ b/src/app/_fetchers/OneTaskDataFetcher.tsx
@@ -26,6 +26,11 @@ export const OneTaskDataFetcher = ({ token, task_id, initialTask }: OneTaskDataF
   const { data } = useSWR(queryString ? `/api/tasks/${task_id}?${queryString}` : null, fetcher, {
     refreshInterval: 0,
     revalidateOnFocus: false,
+    // The mount fetch is redundant — SSR seeds the same getOneTask result into Redux — and races with
+    // in-progress edits, reverting them when it resolves late. Only revalidate when explicitly asked
+    // (realtime nudges this key via globalMutate to refresh access-filtered subtask counts).
+    revalidateOnMount: false,
+    revalidateIfStale: false,
     ...(initialTask
       ? {
           fallbackData: { task: initialTask },

--- a/src/app/detail/ui/Sidebar.tsx
+++ b/src/app/detail/ui/Sidebar.tsx
@@ -17,7 +17,7 @@ import { useOpenSubtaskCount } from '@/hooks/useSubtaskCount'
 import { optimisticallyCascadeSubtasks } from '@/utils/cascadeOptimistic'
 import { useWindowWidth } from '@/hooks/useWindowWidth'
 import { selectAuthDetails } from '@/redux/features/authDetailsSlice'
-import { selectTaskBoard } from '@/redux/features/taskBoardSlice'
+import { selectTaskBoard, setActiveTask } from '@/redux/features/taskBoardSlice'
 import { selectTaskDetails, setShowSidebar, toggleShowConfirmAssignModal } from '@/redux/features/taskDetailsSlice'
 import store from '@/redux/store'
 import { DateStringSchema } from '@/types/date'
@@ -227,6 +227,7 @@ export const Sidebar = ({
       return
     }
     updateStatusValue(next)
+    store.dispatch(setActiveTask({ ...activeTask, workflowStateId: next.id }))
     updateWorkflowState(next)
   }
 
@@ -236,6 +237,7 @@ export const Sidebar = ({
       optimisticallyCascadeSubtasks(activeTask.id, pendingCompleteState.id, accessibleTasks, workflowStates)
     }
     updateStatusValue(pendingCompleteState)
+    store.dispatch(setActiveTask({ ...activeTask, workflowStateId: pendingCompleteState.id }))
     updateWorkflowState(pendingCompleteState, skipSubtaskCascade)
     setPendingCompleteState(null)
   }


### PR DESCRIPTION
## Issue

[OUT-3854 / OUT-3863](https://linear.app/assemblycom/issue/OUT-3854/mark-as-done-gives-no-immediate-feedback) — clicking **Mark as done** (or changing status) while the task detail page is still loading didn't update the UI, even though the task was updated in the backend. Refreshing or returning to the board showed the correct state.

## Root cause

The status pill is derived from Redux `activeTask`. `OneTaskDataFetcher` fired a mount-time `GET /api/tasks/:id` that runs the **same** `getOneTask` the SSR seed already used — so on initial load it was redundant. When that request resolved *after* a click, it overwrote `activeTask` back to the pre-click state, reverting the UI. Because it only fires once on mount, the bad state stuck until a refresh.

## Fix

- **`OneTaskDataFetcher`** — stop revalidating on mount (`revalidateOnMount` / `revalidateIfStale: false`). SSR already seeds the task into Redux; explicit revalidations (archive toggle, realtime subtask-count nudge via `globalMutate`) still refresh `activeTask`.
- **`Sidebar`** — optimistically update `activeTask.workflowStateId` on status change so the detail UI reflects the new status immediately and persists independent of realtime.

## Regression check

- **Inline images** — `getOneTask` signs body image URLs, and SSR's `loadTask` calls the same method, so `initialTask` already has signed URLs. No change.
- **Archive toggle** (`ArchiveWrapper`, shares the SWR key) — uses an explicit `mutate`, which is unaffected by the revalidate flags. Works.
- **Realtime subtask-count refresh** — uses `globalMutate`, an explicit revalidation. Works.

## Testing

- `yarn tsc` + lint clean.
- Verify: open a task and, while it's still loading, click **Mark as done** → pill updates immediately and stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)