### PR TITLE
Cascade client view default to existing clients with confirmation

### DIFF
--- a/src/app/api/workspace-settings/workspaceSettings.service.ts
+++ b/src/app/api/workspace-settings/workspaceSettings.service.ts
@@ -3,6 +3,7 @@ import { BaseService } from '@api/core/services/base.service'
 import { PoliciesService } from '@api/core/services/policies.service'
 import { Resource } from '@api/core/types/api'
 import { UserAction } from '@api/core/types/user'
+import { Prisma, PrismaClient, WorkspaceSetting } from '@prisma/client'
 
 export class WorkspaceSettingsService extends BaseService {
   async getWorkspaceSettings() {
@@ -23,11 +24,50 @@ export class WorkspaceSettingsService extends BaseService {
     policyGate.authorize(UserAction.Update, Resource.WorkspaceSetting)
 
     const workspaceId = this.user.workspaceId
-    // The settings row is created lazily on read (getWorkspaceSettings), so by the
-    // time a setting is changed it always exists — update only, never insert.
-    return await this.db.workspaceSetting.update({
-      where: { workspaceId },
-      data,
+
+    return this.db.$transaction(async (tx) => {
+      this.setTransaction(tx as PrismaClient)
+
+      const previous = await this.db.workspaceSetting.findUnique({ where: { workspaceId } })
+
+      // The settings row is created lazily on read (getWorkspaceSettings), so by the
+      // time a setting is changed it always exists — update only, never insert.
+      const updated = await this.db.workspaceSetting.update({
+        where: { workspaceId },
+        data,
+      })
+
+      await this.overrideExistingClientViewSettings({ previous, data })
+
+      this.unsetTransaction()
+      return updated
+    })
+  }
+
+  private async overrideExistingClientViewSettings({
+    previous,
+    data,
+  }: {
+    previous: WorkspaceSetting | null
+    data: UpdateWorkspaceSettingsDTO
+  }) {
+    const cascade: Prisma.ViewSettingUpdateManyMutationInput = {}
+
+    if (data.clientDefaultViewMode != null && data.clientDefaultViewMode !== previous?.clientDefaultViewMode) {
+      cascade.viewMode = data.clientDefaultViewMode
+    }
+    // clientHideSubtasks is the inverse of the per-user showSubtasks flag.
+    if (data.clientHideSubtasks != null && data.clientHideSubtasks !== previous?.clientHideSubtasks) {
+      cascade.showSubtasks = !data.clientHideSubtasks
+    }
+
+    if (Object.keys(cascade).length === 0) {
+      return
+    }
+
+    await this.db.viewSetting.updateMany({
+      where: { workspaceId: this.user.workspaceId, clientId: { not: null } },
+      data: cascade,
     })
   }
 }

--- a/src/app/api/workspace-settings/workspaceSettings.service.ts
+++ b/src/app/api/workspace-settings/workspaceSettings.service.ts
@@ -27,20 +27,23 @@ export class WorkspaceSettingsService extends BaseService {
 
     return this.db.$transaction(async (tx) => {
       this.setTransaction(tx as PrismaClient)
+      try {
+        const previous = await this.db.workspaceSetting.findUnique({ where: { workspaceId } })
 
-      const previous = await this.db.workspaceSetting.findUnique({ where: { workspaceId } })
+        // The settings row is created lazily on read (getWorkspaceSettings), so by the
+        // time a setting is changed it always exists — update only, never insert.
+        const updated = await this.db.workspaceSetting.update({
+          where: { workspaceId },
+          data,
+        })
 
-      // The settings row is created lazily on read (getWorkspaceSettings), so by the
-      // time a setting is changed it always exists — update only, never insert.
-      const updated = await this.db.workspaceSetting.update({
-        where: { workspaceId },
-        data,
-      })
+        await this.overrideExistingClientViewSettings({ previous, data })
 
-      await this.overrideExistingClientViewSettings({ previous, data })
-
-      this.unsetTransaction()
-      return updated
+        return updated
+      } finally {
+        // Always restore the shared db handle, even if the cascade throws.
+        this.unsetTransaction()
+      }
     })
   }
 

--- a/src/app/configure-tasks-app/ui/ClientViewSettingsSection.tsx
+++ b/src/app/configure-tasks-app/ui/ClientViewSettingsSection.tsx
@@ -5,6 +5,8 @@ import { Box, Menu, MenuItem, Stack, Typography } from '@mui/material'
 import { Icon } from 'copilot-design-system'
 import { ViewMode } from '@prisma/client'
 import { StyledSwitch } from '@/components/inputs/StyledSwitch'
+import { StyledModal } from '@/app/detail/ui/styledComponent'
+import { ConfirmUI } from '@/components/layouts/ConfirmUI'
 import { updateWorkspaceSettings } from '@/app/configure-tasks-app/actions'
 import { ClientViewSettings } from '@/types/dto/workspaceSettings.dto'
 
@@ -20,6 +22,8 @@ const VIEW_MODE_OPTIONS: { label: string; value: ViewMode }[] = [
 
 export const ClientViewSettingsSection = ({ initialSettings, token }: ClientViewSettingsSectionProps) => {
   const [settings, setSettings] = useState<ClientViewSettings>(initialSettings)
+  // Holds the change awaiting confirmation; the controls keep showing `settings` until confirmed.
+  const [pendingSettings, setPendingSettings] = useState<ClientViewSettings | null>(null)
 
   const persist = async (next: ClientViewSettings) => {
     const previous = settings
@@ -30,6 +34,13 @@ export const ClientViewSettingsSection = ({ initialSettings, token }: ClientView
       console.error('Failed to save client view settings', err)
       setSettings(previous)
     }
+  }
+
+  const handleConfirm = async () => {
+    if (!pendingSettings) return
+    const next = pendingSettings
+    setPendingSettings(null)
+    await persist(next)
   }
 
   return (
@@ -50,7 +61,9 @@ export const ClientViewSettingsSection = ({ initialSettings, token }: ClientView
           <Typography variant="bodyMd">Default view</Typography>
           <ViewModeDropdown
             value={settings.clientDefaultViewMode}
-            onChange={(value) => persist({ ...settings, clientDefaultViewMode: value })}
+            onChange={(value) =>
+              value !== settings.clientDefaultViewMode && setPendingSettings({ ...settings, clientDefaultViewMode: value })
+            }
           />
         </Stack>
         <Stack
@@ -62,10 +75,30 @@ export const ClientViewSettingsSection = ({ initialSettings, token }: ClientView
           <Typography variant="bodyMd">Hide subtasks</Typography>
           <StyledSwitch
             checked={settings.clientHideSubtasks ?? false}
-            onChange={(e) => persist({ ...settings, clientHideSubtasks: e.target.checked })}
+            onChange={(e) => setPendingSettings({ ...settings, clientHideSubtasks: e.target.checked })}
           />
         </Stack>
       </Box>
+
+      <StyledModal
+        open={!!pendingSettings}
+        onClose={() => setPendingSettings(null)}
+        aria-labelledby="confirm-client-view-settings-modal"
+        aria-describedby="confirm-client-view-settings"
+      >
+        <ConfirmUI
+          handleCancel={() => setPendingSettings(null)}
+          handleConfirm={handleConfirm}
+          buttonText="Apply to all clients"
+          title="Update view for all clients?"
+          description={
+            <>
+              This changes the view for <strong>every client</strong> in this workspace right now, replacing any view a
+              client has set for themselves. New and existing clients will all see this view.
+            </>
+          }
+        />
+      </StyledModal>
     </Box>
   )
 }


### PR DESCRIPTION
## What

Applies a workspace client-view default change to **every existing client's** view setting, with an IU confirmation step before the destructive override.

Stacked on top of `anit/out-3851-cu-view-settings-foundation`.

## Changes

**`workspaceSettings.service.ts`**
- Wrap the workspace-setting update and the per-client cascade `updateMany` in a single `$transaction` (using the repo's `setTransaction`/`unsetTransaction` pattern) so they commit atomically.
- Only cascade values that actually changed (diff against the previous row).
- `clientHideSubtasks` maps to the inverse of the per-user `showSubtasks` flag.

**`ClientViewSettingsSection.tsx`**
- Confirmation modal before applying a default change ("Update view for all clients?").
- Optimistic update with rollback preserved through the confirm flow.
- Guard no-op dropdown changes so the modal doesn't pop when the value is unchanged.

## Notes

- The aria ids on `StyledModal` follow the existing repo-wide `ConfirmUI` convention.

## Screenshots
### New confirmation UI
<img width="837" height="522" alt="Screenshot 2026-06-15 at 16 14 59" src="https://github.com/user-attachments/assets/8f647f5f-0180-43ac-a2f1-fc3c22837300" />


https://github.com/user-attachments/assets/64053af0-0e01-451f-b651-185d0c56decf



🤖 Generated with [Claude Code](https://claude.com/claude-code)