### PR TITLE
OUT-3823 | Interception: divert CU email into the grouped buffer

### DIFF
--- a/src/app/api/notification/notification.service.test.ts
+++ b/src/app/api/notification/notification.service.test.ts
@@ -186,6 +186,33 @@ describe('NotificationService grouped-email interception', () => {
       expect(mockCreateNotification).not.toHaveBeenCalled()
     })
 
+    it('buffers one row per company client and keeps the fan-out', async () => {
+      await buildService().createBulkNotification(
+        NotificationTaskActions.SharedToCompany,
+        makeTask(),
+        ['cu_a', 'cu_b', 'cu_c'],
+        {
+          email: true,
+        },
+      )
+
+      expect(mockGroupedCreateMany).toHaveBeenCalledTimes(3)
+      const recipients = mockGroupedCreateMany.mock.calls.map((c) => c[0].data[0].recipientClientId)
+      expect(recipients).toEqual(['cu_a', 'cu_b', 'cu_c'])
+    })
+
+    it('falls back to the association company when the shared task has no companyId', async () => {
+      const assocCompany = '88888888-8888-8888-8888-888888888888'
+      const task = makeTask({
+        companyId: null,
+        associations: [{ companyId: assocCompany }] as unknown as Task['associations'],
+      })
+
+      await buildService().createBulkNotification(NotificationTaskActions.SharedToCompany, task, ['cu_a'], { email: true })
+
+      expect(mockGroupedCreateMany.mock.calls[0][0].data[0].recipientCompanyId).toBe(assocCompany)
+    })
+
     it('does not buffer for a bulk action that carries no email', async () => {
       await buildService().createBulkNotification(NotificationTaskActions.Commented, makeTask(), ['cu_a'], {
         email: false,

--- a/src/app/api/notification/notification.service.test.ts
+++ b/src/app/api/notification/notification.service.test.ts
@@ -1,0 +1,200 @@
+import { NotificationTaskActions } from '@/app/api/core/types/tasks'
+import { UserRole } from '@/app/api/core/types/user'
+import { AssigneeType, GroupedEmailEventType, Task } from '@prisma/client'
+
+const mockEnqueueFlush = jest.fn()
+
+const mockFindFirst = jest.fn()
+const mockFindMany = jest.fn()
+const mockClientNotifCreate = jest.fn()
+const mockClientNotifCreateMany = jest.fn()
+const mockQueryRaw = jest.fn()
+const mockGroupedCreateMany = jest.fn()
+
+const mockGetWorkspace = jest.fn()
+const mockMe = jest.fn()
+const mockCreateNotification = jest.fn()
+
+jest.mock('@/jobs/notifications/flush-grouped-email', () => ({
+  enqueueGroupedEmailFlush: (...args: unknown[]) => mockEnqueueFlush(...args),
+}))
+
+jest.mock('@/lib/db', () => ({
+  __esModule: true,
+  default: {
+    getInstance: () => ({
+      clientNotification: {
+        findFirst: (...args: unknown[]) => mockFindFirst(...args),
+        findMany: (...args: unknown[]) => mockFindMany(...args),
+        create: (...args: unknown[]) => mockClientNotifCreate(...args),
+        createMany: (...args: unknown[]) => mockClientNotifCreateMany(...args),
+      },
+      groupedEmailEvent: { createMany: (...args: unknown[]) => mockGroupedCreateMany(...args) },
+      $queryRaw: (...args: unknown[]) => mockQueryRaw(...args),
+    }),
+  },
+}))
+
+jest.mock('@/utils/CopilotAPI', () => ({
+  CopilotAPI: jest.fn().mockImplementation(() => ({
+    getWorkspace: (...args: unknown[]) => mockGetWorkspace(...args),
+    me: (...args: unknown[]) => mockMe(...args),
+    createNotification: (...args: unknown[]) => mockCreateNotification(...args),
+  })),
+}))
+
+import { NotificationService } from './notification.service'
+
+const user = {
+  token: 'tok',
+  role: UserRole.IU,
+  workspaceId: 'ws_1',
+  internalUserId: 'iu_1',
+} as unknown as ConstructorParameters<typeof NotificationService>[0]
+
+const makeTask = (overrides: Partial<Task> = {}): Task =>
+  ({
+    id: '11111111-1111-1111-1111-111111111111',
+    workspaceId: 'ws_1',
+    title: 'My task',
+    companyId: '22222222-2222-2222-2222-222222222222',
+    clientId: null,
+    assigneeId: '33333333-3333-3333-3333-333333333333',
+    assigneeType: AssigneeType.client,
+    createdById: 'creator_1',
+    associations: [],
+    isArchived: false,
+    ...overrides,
+  }) as unknown as Task
+
+const buildService = () => {
+  const service = new NotificationService(user)
+  jest.spyOn(service, 'getNotificationParties').mockResolvedValue({
+    senderId: 'creator_1',
+    senderCompanyId: undefined,
+    recipientId: '33333333-3333-3333-3333-333333333333',
+    recipientIds: [],
+    actionUser: 'Jane IU',
+    companyName: undefined,
+  })
+  return service
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockGetWorkspace.mockResolvedValue({ labels: {} })
+  mockMe.mockResolvedValue({ id: 'creator_1', givenName: 'Jane', familyName: 'IU' })
+  mockFindFirst.mockResolvedValue(null)
+  mockFindMany.mockResolvedValue([])
+  mockQueryRaw.mockResolvedValue([])
+  mockGroupedCreateMany.mockResolvedValue({ count: 1 })
+  mockClientNotifCreate.mockResolvedValue({})
+  mockClientNotifCreateMany.mockResolvedValue({ count: 1 })
+  mockCreateNotification.mockResolvedValue({
+    id: 'notif_1',
+    createdAt: '2026-06-15T10:00:00.000Z',
+    recipientClientId: '33333333-3333-3333-3333-333333333333',
+  })
+})
+
+const deliveryTargetsOf = (call: number) => mockCreateNotification.mock.calls[call][0].deliveryTargets
+
+describe('NotificationService grouped-email interception', () => {
+  describe('create()', () => {
+    it('buffers an Assigned CU email, opens a window, and still sends the in-product notification without email', async () => {
+      const task = makeTask()
+      await buildService().create(NotificationTaskActions.Assigned, task)
+
+      expect(mockGroupedCreateMany).toHaveBeenCalledTimes(1)
+      const row = mockGroupedCreateMany.mock.calls[0][0].data[0]
+      expect(row).toMatchObject({
+        workspaceId: 'ws_1',
+        recipientClientId: task.assigneeId,
+        recipientCompanyId: task.companyId,
+        eventType: GroupedEmailEventType.ASSIGNED,
+        taskId: task.id,
+        taskTitleSnapshot: 'My task',
+        commentId: null,
+      })
+      // window is scoped to the (clientId, companyId) pair, not the client alone
+      expect(row.windowKey).toMatch(new RegExp(`^${task.assigneeId}:${task.companyId}:`))
+      expect(mockQueryRaw.mock.calls[0]).toContain(task.companyId)
+      expect(mockEnqueueFlush).toHaveBeenCalledWith({ workspaceId: 'ws_1', windowKey: row.windowKey })
+
+      // in-product still fires, email is stripped
+      expect(mockCreateNotification).toHaveBeenCalledTimes(1)
+      expect(deliveryTargetsOf(0).inProduct).toBeDefined()
+      expect(deliveryTargetsOf(0).email).toBeUndefined()
+    })
+
+    it('reuses an existing unclaimed window and does not enqueue a second timer', async () => {
+      mockQueryRaw.mockResolvedValue([{ windowKey: 'existing-window-key' }])
+
+      await buildService().create(NotificationTaskActions.Assigned, makeTask())
+
+      expect(mockGroupedCreateMany.mock.calls[0][0].data[0].windowKey).toBe('existing-window-key')
+      expect(mockEnqueueFlush).not.toHaveBeenCalled()
+    })
+
+    it('keys the window on (clientId, companyId) so a multi-company client does not get merged', async () => {
+      const companyB = '99999999-9999-9999-9999-999999999999'
+      await buildService().create(NotificationTaskActions.Assigned, makeTask({ companyId: companyB }))
+
+      const row = mockGroupedCreateMany.mock.calls[0][0].data[0]
+      expect(row.recipientCompanyId).toBe(companyB)
+      expect(row.windowKey).toMatch(new RegExp(`^33333333-3333-3333-3333-333333333333:${companyB}:`))
+      expect(mockQueryRaw.mock.calls[0]).toContain(companyB)
+    })
+
+    it('does not buffer or strip email for a non-target action (byte-for-byte)', async () => {
+      await buildService().create(
+        NotificationTaskActions.CompletedToSharedCU,
+        makeTask({ assigneeType: AssigneeType.internalUser }),
+      )
+
+      expect(mockGroupedCreateMany).not.toHaveBeenCalled()
+      expect(mockEnqueueFlush).not.toHaveBeenCalled()
+      expect(mockCreateNotification).toHaveBeenCalledTimes(1)
+      expect(deliveryTargetsOf(0).email).toBeDefined()
+    })
+
+    it('does not buffer when there is no CU email (e.g. disableEmail / IU recipient)', async () => {
+      await buildService().create(NotificationTaskActions.Assigned, makeTask(), { disableEmail: true })
+
+      expect(mockGroupedCreateMany).not.toHaveBeenCalled()
+      expect(mockEnqueueFlush).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('createBulkNotification()', () => {
+    it('buffers a Commented CU email per recipient and skips the Copilot dispatch (no in-product)', async () => {
+      const task = makeTask()
+      await buildService().createBulkNotification(NotificationTaskActions.Commented, task, ['cu_a', 'cu_b'], {
+        email: true,
+        disableInProduct: true,
+        commentId: '44444444-4444-4444-4444-444444444444',
+      })
+
+      expect(mockGroupedCreateMany).toHaveBeenCalledTimes(2)
+      const recipients = mockGroupedCreateMany.mock.calls.map((c) => c[0].data[0].recipientClientId)
+      expect(recipients).toEqual(['cu_a', 'cu_b'])
+      expect(mockGroupedCreateMany.mock.calls[0][0].data[0]).toMatchObject({
+        eventType: GroupedEmailEventType.COMMENT,
+        commentId: '44444444-4444-4444-4444-444444444444',
+      })
+      // nothing left to deliver → Copilot is never called
+      expect(mockCreateNotification).not.toHaveBeenCalled()
+    })
+
+    it('does not buffer for a bulk action that carries no email', async () => {
+      await buildService().createBulkNotification(NotificationTaskActions.Commented, makeTask(), ['cu_a'], {
+        email: false,
+        disableInProduct: false,
+        commentId: '44444444-4444-4444-4444-444444444444',
+      })
+
+      expect(mockGroupedCreateMany).not.toHaveBeenCalled()
+      expect(mockCreateNotification).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/src/app/api/notification/notification.service.test.ts
+++ b/src/app/api/notification/notification.service.test.ts
@@ -125,6 +125,11 @@ describe('NotificationService grouped-email interception', () => {
       expect(mockCreateNotification).toHaveBeenCalledTimes(1)
       expect(deliveryTargetsOf(0).inProduct).toBeDefined()
       expect(deliveryTargetsOf(0).email).toBeUndefined()
+
+      // and it must still be routed to the client, not misclassified as an IU
+      const sent = mockCreateNotification.mock.calls[0][0]
+      expect(sent.recipientClientId).toBe(task.assigneeId)
+      expect(sent.recipientInternalUserId).toBeUndefined()
     })
 
     it('reuses an existing unclaimed window and does not enqueue a second timer', async () => {

--- a/src/app/api/notification/notification.service.ts
+++ b/src/app/api/notification/notification.service.ts
@@ -161,6 +161,8 @@ export class NotificationService extends BaseService {
       const clientNotifications = []
       const iuNotifications = []
 
+      const association = AssociationsSchema.parse(task.associations)?.[0]
+
       // NOTE: The reason we are skipping using NotificationService#create and implementing notification dispatch + save manually is because
       // we can just do one `createMany` DB call instead of one per notification, saving a ton of DB calls
       for (let recipientId of recipientIds) {
@@ -180,7 +182,7 @@ export class NotificationService extends BaseService {
             await this.bufferGroupedEmailEvent({
               task,
               recipientClientId: recipientId,
-              recipientCompanyId: task.companyId ?? null,
+              recipientCompanyId: task.companyId ?? association?.companyId ?? null,
               eventType: groupedType,
               commentId: opts?.commentId,
             })

--- a/src/app/api/notification/notification.service.ts
+++ b/src/app/api/notification/notification.service.ts
@@ -13,7 +13,9 @@ import APIError from '@api/core/exceptions/api'
 import { BaseService } from '@api/core/services/base.service'
 import { NotificationTaskActions } from '@api/core/types/tasks'
 import { getEmailDetails, getInProductNotificationDetails } from '@api/notification/notification.helpers'
-import { AssigneeType, ClientNotification, Task } from '@prisma/client'
+import { AssigneeType, ClientNotification, GroupedEmailEventType, Task } from '@prisma/client'
+import { randomUUID } from 'crypto'
+import { enqueueGroupedEmailFlush } from '@/jobs/notifications/flush-grouped-email'
 import Bottleneck from 'bottleneck'
 import httpStatus from 'http-status'
 import { z } from 'zod'
@@ -53,9 +55,23 @@ export class NotificationService extends BaseService {
       const inProduct = opts.disableInProduct
         ? undefined
         : getInProductNotificationDetails(workspace, actionUser, task, { companyName, commentId: opts?.commentId })[action]
-      const email = opts.disableEmail
+      let email = opts.disableEmail
         ? undefined
         : getEmailDetails(workspace, actionUser, task, { commentId: opts?.commentId })[action]
+
+      const groupedType = this.groupedEventTypeFor(action)
+      if (email && groupedType && recipientId) {
+        const association = AssociationsSchema.parse(task.associations)?.[0]
+        await this.bufferGroupedEmailEvent({
+          task,
+          recipientClientId: recipientId,
+          recipientCompanyId: task.companyId ?? association?.companyId ?? null,
+          eventType: groupedType,
+          commentId: opts.commentId,
+        })
+        email = undefined
+      }
+      if (!inProduct && !email) return
 
       const notificationDetails = this.buildNotificationDetails(
         task,
@@ -159,12 +175,24 @@ export class NotificationService extends BaseService {
             continue
           }
 
+          const groupedType = this.groupedEventTypeFor(action)
+          if (email && groupedType) {
+            await this.bufferGroupedEmailEvent({
+              task,
+              recipientClientId: recipientId,
+              recipientCompanyId: task.companyId ?? null,
+              eventType: groupedType,
+              commentId: opts?.commentId,
+            })
+            if (!inProduct) continue
+          }
+
           // 2. Dispatch notification to Copilot
           const notificationDetails = this.buildNotificationDetails(
             task,
             senderId,
             recipientId,
-            { inProduct, email },
+            { inProduct, email: groupedType ? undefined : email },
             opts?.senderCompanyId,
           )
 
@@ -533,6 +561,66 @@ export class NotificationService extends BaseService {
     return await this.db.clientNotification.findMany({
       where: { taskId: { in: taskIds }, clientId: this.user.clientId, companyId: this.user.companyId },
     })
+  }
+
+  private groupedEventTypeFor(action: NotificationTaskActions): GroupedEmailEventType | null {
+    switch (action) {
+      case NotificationTaskActions.Assigned:
+      case NotificationTaskActions.AssignedToCompany:
+        return GroupedEmailEventType.ASSIGNED
+      case NotificationTaskActions.Shared:
+      case NotificationTaskActions.SharedToCompany:
+        return GroupedEmailEventType.SHARED
+      case NotificationTaskActions.Commented:
+        return GroupedEmailEventType.COMMENT
+      default:
+        return null
+    }
+  }
+
+  private async bufferGroupedEmailEvent(args: {
+    task: Task
+    recipientClientId: string
+    recipientCompanyId: string | null
+    eventType: GroupedEmailEventType
+    commentId?: string
+  }): Promise<void> {
+    const { task, recipientClientId, recipientCompanyId, eventType, commentId } = args
+
+    const activeWindow = await this.db.$queryRaw<{ windowKey: string }[]>`
+      SELECT "windowKey" FROM "GroupedEmailEvents"
+      WHERE "workspaceId" = ${task.workspaceId}
+        AND "recipientClientId" = ${recipientClientId}::uuid
+        AND "recipientCompanyId" IS NOT DISTINCT FROM ${recipientCompanyId}::uuid
+        AND "sentAt" IS NULL
+        AND "createdAt" > now() - interval '5 minutes'
+      ORDER BY "createdAt" DESC
+      LIMIT 1`
+
+    const isNewWindow = activeWindow.length === 0
+    const windowKey = isNewWindow
+      ? `${recipientClientId}:${recipientCompanyId ?? 'none'}:${randomUUID()}`
+      : activeWindow[0].windowKey
+
+    await this.db.groupedEmailEvent.createMany({
+      data: [
+        {
+          workspaceId: task.workspaceId,
+          recipientClientId,
+          recipientCompanyId,
+          eventType,
+          taskId: task.id,
+          taskTitleSnapshot: task.title,
+          commentId: commentId ?? null,
+          windowKey,
+        },
+      ],
+      skipDuplicates: true,
+    })
+
+    if (isNewWindow) {
+      await enqueueGroupedEmailFlush({ workspaceId: task.workspaceId, windowKey })
+    }
   }
 
   private async handleIfSenderCompanyIdError(e: unknown, notificationDetails: NotificationRequestBody) {

--- a/src/app/api/notification/notification.service.ts
+++ b/src/app/api/notification/notification.service.ts
@@ -72,16 +72,17 @@ export class NotificationService extends BaseService {
         })
       }
 
-      const deliveryEmail = groupedType ? undefined : email
-      if (!inProduct && !deliveryEmail) return
-
+      // Build with the email so the recipient is routed as a client, then drop the email target
+      // once it has been diverted to the buffer (the in-product notification still fires now).
       const notificationDetails = this.buildNotificationDetails(
         task,
         senderId,
         recipientId,
-        { inProduct, email: deliveryEmail },
+        { inProduct, email },
         senderCompanyId,
       )
+      if (groupedType) notificationDetails.deliveryTargets = { inProduct }
+      if (!inProduct && !notificationDetails.deliveryTargets?.email) return
       console.info('NotificationService#create | Creating single notification:', notificationDetails)
 
       let notification: NotificationCreatedResponse
@@ -192,14 +193,16 @@ export class NotificationService extends BaseService {
             if (!inProduct) continue
           }
 
-          // 2. Dispatch notification to Copilot
+          // 2. Dispatch notification to Copilot. Build with the email so the recipient is routed as a
+          // client, then drop the email target once it has been diverted (in-product still fires).
           const notificationDetails = this.buildNotificationDetails(
             task,
             senderId,
             recipientId,
-            { inProduct, email: groupedType ? undefined : email },
+            { inProduct, email },
             opts?.senderCompanyId,
           )
+          if (groupedType) notificationDetails.deliveryTargets = { inProduct }
 
           console.info('NotificationService#bulkCreate | Creating single notification:', notificationDetails)
           let notification: NotificationCreatedResponse

--- a/src/app/api/notification/notification.service.ts
+++ b/src/app/api/notification/notification.service.ts
@@ -55,12 +55,13 @@ export class NotificationService extends BaseService {
       const inProduct = opts.disableInProduct
         ? undefined
         : getInProductNotificationDetails(workspace, actionUser, task, { companyName, commentId: opts?.commentId })[action]
-      let email = opts.disableEmail
+      const email = opts.disableEmail
         ? undefined
         : getEmailDetails(workspace, actionUser, task, { commentId: opts?.commentId })[action]
 
-      const groupedType = this.groupedEventTypeFor(action)
-      if (email && groupedType && recipientId) {
+      // Non-null only when this CU email should be diverted into the grouped buffer.
+      const groupedType = email && recipientId ? this.groupedEventTypeFor(action) : null
+      if (groupedType) {
         const association = AssociationsSchema.parse(task.associations)?.[0]
         await this.bufferGroupedEmailEvent({
           task,
@@ -69,15 +70,16 @@ export class NotificationService extends BaseService {
           eventType: groupedType,
           commentId: opts.commentId,
         })
-        email = undefined
       }
-      if (!inProduct && !email) return
+
+      const deliveryEmail = groupedType ? undefined : email
+      if (!inProduct && !deliveryEmail) return
 
       const notificationDetails = this.buildNotificationDetails(
         task,
         senderId,
         recipientId,
-        { inProduct, email },
+        { inProduct, email: deliveryEmail },
         senderCompanyId,
       )
       console.info('NotificationService#create | Creating single notification:', notificationDetails)
@@ -162,6 +164,8 @@ export class NotificationService extends BaseService {
       const iuNotifications = []
 
       const association = AssociationsSchema.parse(task.associations)?.[0]
+      // Non-null only when these CU emails should be diverted into the grouped buffer.
+      const groupedType = email ? this.groupedEventTypeFor(action) : null
 
       // NOTE: The reason we are skipping using NotificationService#create and implementing notification dispatch + save manually is because
       // we can just do one `createMany` DB call instead of one per notification, saving a ton of DB calls
@@ -177,8 +181,7 @@ export class NotificationService extends BaseService {
             continue
           }
 
-          const groupedType = this.groupedEventTypeFor(action)
-          if (email && groupedType) {
+          if (groupedType) {
             await this.bufferGroupedEmailEvent({
               task,
               recipientClientId: recipientId,


### PR DESCRIPTION
## What & why

Wires the **front door** of the grouped-email pipeline (M2). Today every CU task event (Assigned / Shared / Comment) sends one immediate email → spam on bulk-assign. This intercepts those emails centrally in `NotificationService` and writes them to the `GroupedEmailEvent` buffer instead, so the 5-minute dispatcher (OUT-3824) can send **one grouped summary per recipient**. In-product notifications still fire immediately.

Linear: [OUT-3823](https://linear.app/assemblycom/issue/OUT-3823)

## Approach

All CU email paths converge on `NotificationService.create()` and `createBulkNotification()`, so interception is central — not at the ~6 call sites.

- New `groupedEventTypeFor(action)` maps `Assigned*`→`ASSIGNED`, `Shared*`→`SHARED`, `Commented`→`COMMENT` (else `null`).
- New `bufferGroupedEmailEvent(...)`: finds/opens a grouping window, inserts the event (`createMany` + `skipDuplicates` → DB unique index dedups repeat events), and enqueues the 5-min flush timer **only on a new window**.
- `create()` and `createBulkNotification()`: when a target action carries a CU email, buffer it and strip `email` from the dispatch. For comment-to-CU (email-only, in-product disabled) the Copilot call is skipped entirely.

### Window identity = (clientId, companyId)
A client can belong to multiple companies (`companyIds[]`), and the rest of the system keys CU notifications on **(clientId, companyId)**. The window lookup and `windowKey` are scoped to the pair so a multi-company client isn't merged. The dispatcher needs no change — each `windowKey` now contains exactly one pair.

## Deviation from the ticket
Ticket step 1 (`isGroupedEmailEnabled` flag) is **stale** — OUT-3822 was cancelled (no gate). Interception always diverts; isolation is preview env + a test workspace. "Flag OFF: byte-for-byte" → **non-target actions and IU recipients are unchanged.**

## Out of scope
Real-DB idempotency & concurrent window-open races → **OUT-3827** (integration tier). Unit tests cover the logic deterministically.

## Tests
New `notification.service.test.ts` (7 cases): buffer + window open, window reuse, **(client, company) scoping**, non-target byte-for-byte, no-email skip, comment bulk skips dispatch, no-email bulk. `yarn tsc` / lint / prettier clean; full notification + jobs suites green (74).

🤖 Generated with [Claude Code](https://claude.com/claude-code)