### PR TITLE
OUT-3880 | Single-event window: send the original individual email

### DIFF
--- a/prisma/migrations/20260616072600_add_individual_email_snapshot_to_grouped_email_events/migration.sql
+++ b/prisma/migrations/20260616072600_add_individual_email_snapshot_to_grouped_email_events/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "GroupedEmailEvents" ADD COLUMN "individualEmail" JSONB;

--- a/prisma/schema/groupedEmailEvent.prisma
+++ b/prisma/schema/groupedEmailEvent.prisma
@@ -25,6 +25,9 @@ model GroupedEmailEvent {
   windowKey String
   createdAt DateTime @default(now())
 
+  /// Email-only notification payload, replayed verbatim when the window has a single live event.
+  individualEmail Json? @db.JsonB
+
   batchId String?   @db.Uuid
   sentAt  DateTime?
 

--- a/src/app/api/notification/notification.service.test.ts
+++ b/src/app/api/notification/notification.service.test.ts
@@ -121,6 +121,11 @@ describe('NotificationService grouped-email interception', () => {
       expect(mockQueryRaw.mock.calls[0]).toContain(task.companyId)
       expect(mockEnqueueFlush).toHaveBeenCalledWith({ workspaceId: 'ws_1', windowKey: row.windowKey })
 
+      // the row snapshots the exact individual email to replay for a single-event window
+      expect(row.individualEmail.recipientClientId).toBe(task.assigneeId)
+      expect(row.individualEmail.deliveryTargets.email).toBeDefined()
+      expect(row.individualEmail.deliveryTargets.inProduct).toBeUndefined()
+
       // in-product still fires, email is stripped
       expect(mockCreateNotification).toHaveBeenCalledTimes(1)
       expect(deliveryTargetsOf(0).inProduct).toBeDefined()

--- a/src/app/api/notification/notification.service.ts
+++ b/src/app/api/notification/notification.service.ts
@@ -13,7 +13,7 @@ import APIError from '@api/core/exceptions/api'
 import { BaseService } from '@api/core/services/base.service'
 import { NotificationTaskActions } from '@api/core/types/tasks'
 import { getEmailDetails, getInProductNotificationDetails } from '@api/notification/notification.helpers'
-import { AssigneeType, ClientNotification, GroupedEmailEventType, Task } from '@prisma/client'
+import { AssigneeType, ClientNotification, GroupedEmailEventType, Prisma, Task } from '@prisma/client'
 import { randomUUID } from 'crypto'
 import { enqueueGroupedEmailFlush } from '@/jobs/notifications/flush-grouped-email'
 import Bottleneck from 'bottleneck'
@@ -69,6 +69,7 @@ export class NotificationService extends BaseService {
           recipientCompanyId: task.companyId ?? association?.companyId ?? null,
           eventType: groupedType,
           commentId: opts.commentId,
+          individualEmail: this.buildNotificationDetails(task, senderId, recipientId, { email }, senderCompanyId),
         })
       }
 
@@ -189,6 +190,7 @@ export class NotificationService extends BaseService {
               recipientCompanyId: task.companyId ?? association?.companyId ?? null,
               eventType: groupedType,
               commentId: opts?.commentId,
+              individualEmail: this.buildNotificationDetails(task, senderId, recipientId, { email }, opts?.senderCompanyId),
             })
             if (!inProduct) continue
           }
@@ -592,8 +594,9 @@ export class NotificationService extends BaseService {
     recipientCompanyId: string | null
     eventType: GroupedEmailEventType
     commentId?: string
+    individualEmail: NotificationRequestBody
   }): Promise<void> {
-    const { task, recipientClientId, recipientCompanyId, eventType, commentId } = args
+    const { task, recipientClientId, recipientCompanyId, eventType, commentId, individualEmail } = args
 
     const activeWindow = await this.db.$queryRaw<{ windowKey: string }[]>`
       SELECT "windowKey" FROM "GroupedEmailEvents"
@@ -621,6 +624,7 @@ export class NotificationService extends BaseService {
           taskTitleSnapshot: task.title,
           commentId: commentId ?? null,
           windowKey,
+          individualEmail: individualEmail as unknown as Prisma.InputJsonValue,
         },
       ],
       skipDuplicates: true,

--- a/src/jobs/notifications/flush-grouped-email.test.ts
+++ b/src/jobs/notifications/flush-grouped-email.test.ts
@@ -63,11 +63,14 @@ const row = (overrides: Record<string, unknown> = {}) => {
   // the snapshotted individual email captured at interception (replayed for single-event windows)
   return {
     ...base,
-    individualEmail: {
-      senderId: 'actor_1',
-      recipientClientId: base.recipientClientId,
-      deliveryTargets: { email: { subject: base.taskTitleSnapshot } },
-    },
+    individualEmail:
+      'individualEmail' in overrides
+        ? overrides.individualEmail
+        : {
+            senderId: 'actor_1',
+            recipientClientId: base.recipientClientId,
+            deliveryTargets: { email: { subject: base.taskTitleSnapshot } },
+          },
   }
 }
 
@@ -112,6 +115,16 @@ describe('flushGroupedEmailRun', () => {
     expect(mockGetInternalUsers).not.toHaveBeenCalled() // no workspace IU needed for the individual path
     expect(mockExecuteRaw).toHaveBeenCalledTimes(1)
     expect(result).toMatchObject({ recipients: 1, sent: 1 })
+  })
+
+  it('falls back to the grouped summary when a single event has no snapshot (pre-migration row)', async () => {
+    mockQueryRaw.mockResolvedValue([row({ individualEmail: null })])
+
+    await flushGroupedEmailRun(payload)
+
+    expect(mockCreateNotification).not.toHaveBeenCalled()
+    expect(mockSendGroupedEmail).toHaveBeenCalledTimes(1)
+    expect(mockSendGroupedEmail.mock.calls[0][0].content.totalEventCount).toBe(1)
   })
 
   it('no-ops when there are no unsent rows (idempotent re-run)', async () => {

--- a/src/jobs/notifications/flush-grouped-email.test.ts
+++ b/src/jobs/notifications/flush-grouped-email.test.ts
@@ -1,6 +1,7 @@
 import { GroupedEmailEventType } from '@prisma/client'
 
 const mockSendGroupedEmail = jest.fn()
+const mockCreateNotification = jest.fn()
 const mockQueryRaw = jest.fn()
 const mockExecuteRaw = jest.fn()
 const mockFindManyTask = jest.fn()
@@ -31,7 +32,9 @@ jest.mock('@/lib/db', () => ({
 }))
 
 jest.mock('@/utils/CopilotAPI', () => ({
-  CopilotAPI: jest.fn().mockImplementation(() => ({ getInternalUsers: mockGetInternalUsers })),
+  CopilotAPI: jest
+    .fn()
+    .mockImplementation(() => ({ getInternalUsers: mockGetInternalUsers, createNotification: mockCreateNotification })),
 }))
 
 jest.mock('./send-grouped-email', () => ({
@@ -48,7 +51,7 @@ import {
 let seq = 0
 const row = (overrides: Record<string, unknown> = {}) => {
   seq += 1
-  return {
+  const base = {
     eventType: GroupedEmailEventType.ASSIGNED,
     taskId: `task_${seq}`,
     taskTitleSnapshot: `Task ${seq}`,
@@ -56,6 +59,15 @@ const row = (overrides: Record<string, unknown> = {}) => {
     recipientClientId: 'client_1',
     recipientCompanyId: 'company_1',
     ...overrides,
+  }
+  // the snapshotted individual email captured at interception (replayed for single-event windows)
+  return {
+    ...base,
+    individualEmail: {
+      senderId: 'actor_1',
+      recipientClientId: base.recipientClientId,
+      deliveryTargets: { email: { subject: base.taskTitleSnapshot } },
+    },
   }
 }
 
@@ -66,6 +78,7 @@ beforeEach(() => {
   seq = 0
   mockGetInternalUsers.mockResolvedValue({ data: [{ id: 'iu_1' }] })
   mockSendGroupedEmail.mockResolvedValue('notif_1')
+  mockCreateNotification.mockResolvedValue({ id: 'notif_1' })
   mockExecuteRaw.mockResolvedValue(1)
   // default: every buffered task is live
   mockFindManyTask.mockImplementation(({ where }: { where: { id: { in: string[] } } }) =>
@@ -74,7 +87,7 @@ beforeEach(() => {
 })
 
 describe('flushGroupedEmailRun', () => {
-  it('sends one grouped email for the window recipient and marks them sent', async () => {
+  it('sends a grouped summary when the window has multiple live events', async () => {
     mockQueryRaw.mockResolvedValue([row(), row()])
 
     const result = await flushGroupedEmailRun(payload)
@@ -83,7 +96,21 @@ describe('flushGroupedEmailRun', () => {
     const args = mockSendGroupedEmail.mock.calls[0][0]
     expect(args).toMatchObject({ senderId: 'iu_1', recipientClientId: 'client_1', recipientCompanyId: 'company_1' })
     expect(args.content.totalEventCount).toBe(2)
+    expect(mockCreateNotification).not.toHaveBeenCalled()
     expect(mockExecuteRaw).toHaveBeenCalledTimes(1) // markRecipientSent
+    expect(result).toMatchObject({ recipients: 1, sent: 1 })
+  })
+
+  it('replays the original individual email when the window has a single live event', async () => {
+    mockQueryRaw.mockResolvedValue([row()])
+
+    const result = await flushGroupedEmailRun(payload)
+
+    expect(mockCreateNotification).toHaveBeenCalledTimes(1)
+    expect(mockCreateNotification).toHaveBeenCalledWith(expect.objectContaining({ recipientClientId: 'client_1' }))
+    expect(mockSendGroupedEmail).not.toHaveBeenCalled()
+    expect(mockGetInternalUsers).not.toHaveBeenCalled() // no workspace IU needed for the individual path
+    expect(mockExecuteRaw).toHaveBeenCalledTimes(1)
     expect(result).toMatchObject({ recipients: 1, sent: 1 })
   })
 
@@ -94,11 +121,12 @@ describe('flushGroupedEmailRun', () => {
 
     expect(mockGetInternalUsers).not.toHaveBeenCalled()
     expect(mockSendGroupedEmail).not.toHaveBeenCalled()
+    expect(mockCreateNotification).not.toHaveBeenCalled()
     expect(mockExecuteRaw).not.toHaveBeenCalled()
     expect(result).toMatchObject({ sent: 0, skipped: true })
   })
 
-  it('excludes deleted/archived tasks from the email', async () => {
+  it('falls back to the individual email when deleted tasks reduce the window to one live event', async () => {
     const live = row({ taskId: 'live', taskTitleSnapshot: 'Live task' })
     const dead = row({ taskId: 'dead', taskTitleSnapshot: 'Deleted task' })
     mockQueryRaw.mockResolvedValue([live, dead])
@@ -106,9 +134,11 @@ describe('flushGroupedEmailRun', () => {
 
     await flushGroupedEmailRun(payload)
 
-    const content = mockSendGroupedEmail.mock.calls[0][0].content
-    expect(content.totalEventCount).toBe(1)
-    expect(content.sections[0].taskNames).toEqual(['Live task'])
+    expect(mockSendGroupedEmail).not.toHaveBeenCalled()
+    expect(mockCreateNotification).toHaveBeenCalledTimes(1)
+    expect(mockCreateNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ deliveryTargets: { email: { subject: 'Live task' } } }),
+    )
   })
 
   it('marks the recipient sent without emailing when all their tasks were deleted', async () => {
@@ -118,30 +148,45 @@ describe('flushGroupedEmailRun', () => {
     const result = await flushGroupedEmailRun(payload)
 
     expect(mockSendGroupedEmail).not.toHaveBeenCalled()
+    expect(mockCreateNotification).not.toHaveBeenCalled()
     expect(mockExecuteRaw).toHaveBeenCalledTimes(1)
     expect(result).toMatchObject({ sent: 0 })
   })
 
-  it('sends one email per recipient when a window spans multiple clients', async () => {
+  it('sends one individual email per recipient when single-event windows span multiple clients', async () => {
     mockQueryRaw.mockResolvedValue([row({ recipientClientId: 'client_a' }), row({ recipientClientId: 'client_b' })])
 
     const result = await flushGroupedEmailRun(payload)
 
-    expect(mockSendGroupedEmail).toHaveBeenCalledTimes(2)
+    expect(mockCreateNotification).toHaveBeenCalledTimes(2)
+    expect(mockSendGroupedEmail).not.toHaveBeenCalled()
     expect(mockExecuteRaw).toHaveBeenCalledTimes(2)
     expect(result).toMatchObject({ recipients: 2, sent: 2 })
   })
 
+  it('retries the individual email without senderCompanyId when the workspace rejects it', async () => {
+    mockQueryRaw.mockResolvedValue([row()])
+    mockCreateNotification
+      .mockRejectedValueOnce({ message: 'bad', body: { message: 'sender company ID is invalid based on sender' } })
+      .mockResolvedValueOnce({ id: 'notif_1' })
+
+    await flushGroupedEmailRun(payload)
+
+    expect(mockCreateNotification).toHaveBeenCalledTimes(2)
+    expect(mockCreateNotification.mock.calls[1][0]).toMatchObject({ senderCompanyId: undefined })
+    expect(mockExecuteRaw).toHaveBeenCalledTimes(1)
+  })
+
   it('does not mark a recipient sent when their send fails (so a retry re-sends)', async () => {
     mockQueryRaw.mockResolvedValue([row()])
-    mockSendGroupedEmail.mockRejectedValue(new Error('copilot 5xx'))
+    mockCreateNotification.mockRejectedValue(new Error('copilot 5xx'))
 
     await expect(flushGroupedEmailRun(payload)).rejects.toThrow('copilot 5xx')
     expect(mockExecuteRaw).not.toHaveBeenCalled()
   })
 
-  it('throws when the workspace has no internal user to send as', async () => {
-    mockQueryRaw.mockResolvedValue([row()])
+  it('throws when a grouped window has no internal user to send as', async () => {
+    mockQueryRaw.mockResolvedValue([row(), row()])
     mockGetInternalUsers.mockResolvedValue({ data: [] })
 
     await expect(flushGroupedEmailRun(payload)).rejects.toThrow('no internal user')

--- a/src/jobs/notifications/flush-grouped-email.ts
+++ b/src/jobs/notifications/flush-grouped-email.ts
@@ -19,7 +19,7 @@ export type FlushGroupedEmailPayload = {
   windowKey: string
 }
 
-type WindowEvent = GroupedEmailEventInput & { individualEmail: NotificationRequestBody }
+type WindowEvent = GroupedEmailEventInput & { individualEmail: NotificationRequestBody | null }
 
 type BufferedRow = WindowEvent & {
   recipientClientId: string | null
@@ -121,11 +121,13 @@ export const flushGroupedEmailRun = async (payload: FlushGroupedEmailPayload) =>
   const groups = groupByRecipient(rows)
   for (const group of groups) {
     const liveEvents = group.events.filter((e) => liveTaskIds.has(e.taskId))
-    if (liveEvents.length === 1) {
-      // A single event reads awkwardly as a "summary" — replay the original individual email verbatim.
-      await sendIndividualEmail(copilot, liveEvents[0].individualEmail)
+    // A single event reads awkwardly as a "summary" — replay the original individual email verbatim.
+    // Pre-migration rows have no snapshot; fall back to the grouped summary rather than crash.
+    const singleEmail = liveEvents.length === 1 ? liveEvents[0].individualEmail : null
+    if (singleEmail) {
+      await sendIndividualEmail(copilot, singleEmail)
       sent += 1
-    } else if (liveEvents.length > 1) {
+    } else if (liveEvents.length >= 1) {
       senderId ??= await resolveSenderId(copilot)
       await sendGroupedEmail({
         content: composeGroupedEmail(liveEvents),

--- a/src/jobs/notifications/flush-grouped-email.ts
+++ b/src/jobs/notifications/flush-grouped-email.ts
@@ -6,6 +6,8 @@ import { composeGroupedEmail, GroupedEmailEventInput } from '@/app/api/notificat
 import { copilotAPIKey } from '@/config'
 import { Sentry } from '@/jobs/sentry'
 import DBClient from '@/lib/db'
+import { NotificationRequestBody } from '@/types/common'
+import { isMessagableError } from '@/utils/copilotError'
 import { CopilotAPI } from '@/utils/CopilotAPI'
 import { serializeError } from '@/utils/serializeError'
 import { logger, task, tasks } from '@trigger.dev/sdk/v3'
@@ -17,7 +19,9 @@ export type FlushGroupedEmailPayload = {
   windowKey: string
 }
 
-type BufferedRow = GroupedEmailEventInput & {
+type WindowEvent = GroupedEmailEventInput & { individualEmail: NotificationRequestBody }
+
+type BufferedRow = WindowEvent & {
   recipientClientId: string | null
   recipientCompanyId: string | null
 }
@@ -25,14 +29,14 @@ type BufferedRow = GroupedEmailEventInput & {
 type RecipientGroup = {
   recipientClientId: string
   recipientCompanyId: string | null
-  events: GroupedEmailEventInput[]
+  events: WindowEvent[]
 }
 
 const TASK_ID = 'flush-grouped-email'
 
 const readUnsentWindowEvents = (db: ReturnType<typeof DBClient.getInstance>, windowKey: string) =>
   db.$queryRaw<BufferedRow[]>`
-    SELECT "eventType", "taskId", "taskTitleSnapshot", "createdAt", "recipientClientId", "recipientCompanyId"
+    SELECT "eventType", "taskId", "taskTitleSnapshot", "createdAt", "recipientClientId", "recipientCompanyId", "individualEmail"
     FROM "GroupedEmailEvents"
     WHERE "windowKey" = ${windowKey} AND "sentAt" IS NULL`
 
@@ -53,6 +57,19 @@ const resolveSenderId = async (copilot: CopilotAPI): Promise<string> => {
   return senderId
 }
 
+const sendIndividualEmail = async (copilot: CopilotAPI, payload: NotificationRequestBody): Promise<void> => {
+  try {
+    await copilot.createNotification(payload)
+  } catch (e: unknown) {
+    // Account for workspaces without multi-companies, which reject senderCompanyId (mirrors NotificationService).
+    if (isMessagableError(e) && e.body?.message === 'sender company ID is invalid based on sender') {
+      await copilot.createNotification({ ...payload, senderCompanyId: undefined })
+    } else {
+      throw e
+    }
+  }
+}
+
 const getLiveTaskIds = async (db: ReturnType<typeof DBClient.getInstance>, taskIds: string[]): Promise<Set<string>> => {
   const live = await db.task.findMany({
     where: { id: { in: taskIds }, isArchived: false },
@@ -66,11 +83,12 @@ const groupByRecipient = (rows: BufferedRow[]): RecipientGroup[] => {
   for (const row of rows) {
     if (!row.recipientClientId) continue
     const group = groups.get(row.recipientClientId)
-    const event: GroupedEmailEventInput = {
+    const event: WindowEvent = {
       eventType: row.eventType,
       taskId: row.taskId,
       taskTitleSnapshot: row.taskTitleSnapshot,
       createdAt: row.createdAt,
+      individualEmail: row.individualEmail,
     }
     if (group) group.events.push(event)
     else
@@ -95,17 +113,22 @@ export const flushGroupedEmailRun = async (payload: FlushGroupedEmailPayload) =>
   }
 
   const copilot = new CopilotAPI('', `${workspaceId}/${copilotAPIKey}`)
-  const senderId = await resolveSenderId(copilot)
 
   const liveTaskIds = await getLiveTaskIds(db, [...new Set(rows.map((r) => r.taskId))])
 
   let sent = 0
+  let senderId: string | undefined // resolved lazily — only the grouped branch needs a workspace IU
   const groups = groupByRecipient(rows)
   for (const group of groups) {
-    const content = composeGroupedEmail(group.events.filter((e) => liveTaskIds.has(e.taskId)))
-    if (content.sections.length > 0) {
+    const liveEvents = group.events.filter((e) => liveTaskIds.has(e.taskId))
+    if (liveEvents.length === 1) {
+      // A single event reads awkwardly as a "summary" — replay the original individual email verbatim.
+      await sendIndividualEmail(copilot, liveEvents[0].individualEmail)
+      sent += 1
+    } else if (liveEvents.length > 1) {
+      senderId ??= await resolveSenderId(copilot)
       await sendGroupedEmail({
-        content,
+        content: composeGroupedEmail(liveEvents),
         senderId,
         recipientClientId: group.recipientClientId,
         recipientCompanyId: group.recipientCompanyId,


### PR DESCRIPTION
## What & why

When a recipient's 5-minute grouping window resolves to **exactly one** live event, a grouped "Catch up on task activity" summary reads awkwardly ("You have 1 new task update"). This sends the **original individual email** in that case — byte-identical to the pre-grouping behavior (same subject/body with the actor's name, task-specific CTA, from the original actor).

Linear: [OUT-3880](https://linear.app/assemblycom/issue/OUT-3880)

> Stacked on PR #1321 (OUT-3823). Base is `OUT-3823-interception-grouped-buffer`; retarget to `feature/grouped-emails` once #1321 merges.

## Approach — snapshot & replay

The dispatcher can't re-render the individual email (the buffer row doesn't store the actor/precise action/sender), so we **snapshot the exact email payload at interception** and **replay** it. Replaying (not re-rendering) guarantees "exactly like the previous one".

- **Schema:** nullable `individualEmail Json?` column on `GroupedEmailEvent` + migration. Stores the email-only `NotificationRequestBody` the immediate path would have sent.
- **Interception** (`notification.service.ts`): at both divert sites, snapshot the payload via `buildNotificationDetails({ email })` onto the buffered row.
- **Dispatcher** (`flush-grouped-email.ts`): per recipient, after dropping deleted/archived tasks, branch on live-event count — **1** → `createNotification(individualEmail)` (with the `senderCompanyId`-invalid retry fallback), **>1** → grouped summary (unchanged), **0** → skip. Workspace-IU sender now resolved lazily (only the grouped branch needs it).

## Tests
- `notification.service.test.ts`: buffered row carries the `individualEmail` payload.
- `flush-grouped-email.test.ts`: single live event → individual replay; deleted-reduces-to-1 → individual for survivor; multi-client single windows → individual each; `senderCompanyId` fallback; grouped path unchanged; failure doesn't mark sent.
- `yarn tsc` / lint / prettier clean; full notification + jobs suites green (78).

## Out of scope
Real-DB idempotency/concurrency → OUT-3827.

🤖 Generated with [Claude Code](https://claude.com/claude-code)