### PR TITLE
OUT-3878 | Fix tasks empty and loading states appearing too high up

### DIFF
--- a/src/components/layouts/EmptyState/DashboardEmptyState.tsx
+++ b/src/components/layouts/EmptyState/DashboardEmptyState.tsx
@@ -20,11 +20,11 @@ const DashboardEmptyState = ({ userType }: { userType: UserRole }) => {
 
   return (
     <>
-      <AppMargin size={SizeofAppMargin.LARGE} py="20px">
+      <AppMargin size={SizeofAppMargin.LARGE}>
         <Box
           sx={{
             display: 'flex',
-            height: '80vh',
+            minHeight: '100dvh',
             ...SxCenter,
           }}
         >

--- a/src/components/layouts/Loader.tsx
+++ b/src/components/layouts/Loader.tsx
@@ -4,11 +4,7 @@ const LoaderComponent = () => {
   return (
     <Box
       sx={{
-        position: 'absolute',
-        top: 0,
-        left: 0,
-        width: '100%',
-        height: '100%',
+        minHeight: '100dvh',
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',


### PR DESCRIPTION
## Problem

[OUT-3878](https://linear.app/assemblycom/issue/OUT-3878/tasks-app-loading-and-empty-states-are-too-high-up) — the loading spinner and the "No tasks assigned" empty state render pinned near the top of the page instead of centered, in the Copilot embed. It was not reproducible in a plain browser tab.

## Root cause

Both states centered against a **viewport-relative height that collapses inside a content-sized iframe**:

- `DashboardEmptyState` used `height: 80vh` — this actively shrinks the body to 80% of the iframe viewport, the iframe (sized to its content) shrinks to match, and the loop spirals down until the content sits at the top.
- `Loader` used `position: absolute; height: 100%` — `100%` of an auto-height (or positioned-but-unsized) ancestor resolves to `0`, dropping the spinner to the top.

In a normal browser tab `vh`/`100%` resolve against the real window, so everything centered — which is why it only showed up in the embed.

Reproduced in a controlled Chrome harness: the `80vh` box collapsed from 1857px of available space down to 273px (content at the top); `min-height: 100dvh` stayed full-height and centered (1855px) in the same scenario.

## Fix

Switch both to a flow-based `min-height: 100dvh` flex-center. `min-height` resists shrinking below the viewport, breaking the collapse loop, and stays centered in both a fixed-height and an auto-resizing iframe.

- `DashboardEmptyState.tsx` — `height: '80vh'` → `minHeight: '100dvh'`; dropped `py="20px"` from `AppMargin` (the extra 40px pushed past the viewport into a stray scrollbar; flex already handles vertical centering).
- `Loader.tsx` — replaced `position: absolute; top/left: 0; width/height: 100%` with `minHeight: '100dvh'` flex-center.

`NoFilteredTasksState` is intentionally left as-is: it renders among the FilterBar siblings and a `calc(100vh - Npx)` offset would compound under auto-resize and re-collapse; its current form mirrors the working board.

## Testing

- `yarn tsc` passes.
- Empirically verified the fix holds in both a fixed-viewport tab and a simulated auto-resizing iframe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)