### PR TITLE
OUT-3864: serve attachments/images via custom storage domain

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,9 @@ BLOB_READ_WRITE_TOKEN=
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
 NEXT_PUBLIC_SUPABASE_PROJECT_URL=
 NEXT_PUBLIC_SUPABASE_BUCKET=
+# Optional: Assembly custom domain fronting Supabase storage (e.g. https://task-files.assembly.com).
+# Empty falls back to NEXT_PUBLIC_SUPABASE_PROJECT_URL.
+NEXT_PUBLIC_SUPABASE_STORAGE_DOMAIN=
 
 # --- DB
 # Dev database

--- a/src/app/api/attachments/attachments.service.ts
+++ b/src/app/api/attachments/attachments.service.ts
@@ -8,7 +8,7 @@ import { supabaseBucket } from '@/config'
 import APIError from '@api/core/exceptions/api'
 import httpStatus from 'http-status'
 import { SupabaseService } from '@api/core/services/supabase.service'
-import { signedUrlTtl } from '@/constants/attachments'
+import { getSignedUrl as signStorageUrl } from '@/utils/signUrl'
 import { PrismaClient } from '@prisma/client'
 
 export class AttachmentsService extends BaseService {
@@ -82,10 +82,8 @@ export class AttachmentsService extends BaseService {
 
   async getSignedUrl(filePath: string) {
     const policyGate = new PoliciesService(this.user)
-    const supabase = new SupabaseService()
     policyGate.authorize(UserAction.Create, Resource.Attachments)
-    const { data } = await supabase.supabase.storage.from(supabaseBucket).createSignedUrl(filePath, signedUrlTtl)
-    return data?.signedUrl
+    return signStorageUrl(filePath)
   }
 
   async deleteAttachmentsOfComment(commentId: string) {

--- a/src/app/api/comments/comment.service.ts
+++ b/src/app/api/comments/comment.service.ts
@@ -8,7 +8,7 @@ import { CommentsPublicFilterType, CommentWithAttachments, CreateComment, Update
 import { DISPATCHABLE_EVENT } from '@/types/webhook'
 import { getArrayDifference, getArrayIntersection } from '@/utils/array'
 import { getFileNameFromPath } from '@/utils/attachmentUtils'
-import { getFilePathFromUrl } from '@/utils/signedUrlReplacer'
+import { extractMediaSrcMatches } from '@/utils/signedUrlReplacer'
 import { SupabaseActions } from '@/utils/SupabaseActions'
 import { getBasicPaginationAttributes } from '@/utils/pagination'
 import { CommentAddedSchema } from '@api/activity-logs/schemas/CommentAddedSchema'
@@ -324,33 +324,12 @@ export class CommentService extends BaseService {
   }
 
   private async updateCommentIdOfAttachmentsAfterCreation(htmlString: string, task_id: string, commentId: string) {
-    const imgTagRegex = /<img\s+[^>]*src="([^"]+)"[^>]*>/g //expression used to match all img srcs in provided HTML string.
-    const attachmentTagRegex = /<\s*[a-zA-Z]+\s+[^>]*data-type="attachment"[^>]*src="([^"]+)"[^>]*>/g //expression used to match all attachment srcs in provided HTML string.
-    let match
     const replacements: { originalSrc: string; newUrl: string }[] = []
 
     const newFilePaths: { originalSrc: string; newFilePath: string }[] = []
     const copyAttachmentPromises: Promise<void>[] = []
     const createAttachmentPayloads = []
-    const matches: { originalSrc: string; filePath: string; fileName: string }[] = []
-
-    while ((match = imgTagRegex.exec(htmlString)) !== null) {
-      const originalSrc = match[1]
-      const filePath = getFilePathFromUrl(originalSrc)
-      const fileName = filePath?.split('/').pop()
-      if (filePath && fileName) {
-        matches.push({ originalSrc, filePath, fileName })
-      }
-    }
-
-    while ((match = attachmentTagRegex.exec(htmlString)) !== null) {
-      const originalSrc = match[1]
-      const filePath = getFilePathFromUrl(originalSrc)
-      const fileName = filePath?.split('/').pop()
-      if (filePath && fileName) {
-        matches.push({ originalSrc, filePath, fileName })
-      }
-    }
+    const matches = extractMediaSrcMatches(htmlString)
 
     for (const { originalSrc, filePath, fileName } of matches) {
       const newFilePath = `${this.user.workspaceId}/${task_id}/comments/${commentId}/${fileName}`

--- a/src/app/api/tasks/public/public.serializer.ts
+++ b/src/app/api/tasks/public/public.serializer.ts
@@ -13,7 +13,7 @@ import { rfc3339ToDateString, toRFC3339 } from '@/utils/dateHelper'
 import { resolveAutofillTags, resolveDynamicFields } from '@/utils/dynamicFields'
 import { sanitizeHtml } from '@/utils/santizeContents'
 import { copyTemplateMediaToTask } from '@/utils/signedTemplateUrlReplacer'
-import { replaceImageSrc, replaceMediaSrcs } from '@/utils/signedUrlReplacer'
+import { replaceImageSrc, replaceMediaSources } from '@/utils/signedUrlReplacer'
 import { getSignedUrl } from '@/utils/signUrl'
 import { PublicTaskCreateDto, PublicTaskDto, PublicTaskDtoSchema, PublicTaskUpdateDto } from '@api/tasks/public/public.dto'
 import { Attachment, Task, WorkflowState } from '@prisma/client'
@@ -42,9 +42,7 @@ export class PublicTaskSerializer {
       id: task.id,
       object: 'task',
       name: task.title,
-      // Re-sign inline images/attachments so the body resolves to the current storage domain
-      // rather than whatever (possibly stale) host was baked in when the task was created.
-      description: sanitizeHtml(task.body ? await replaceMediaSrcs(task.body) : ''),
+      description: sanitizeHtml(task.body ? await replaceMediaSources(task.body) : ''),
       parentTaskId: task.parentId,
       dueDate: toRFC3339(task.dueDate),
       label: task.label,
@@ -57,7 +55,7 @@ export class PublicTaskSerializer {
       isArchived: task.isArchived,
       archivedDate: toRFC3339(task.lastArchivedDate),
       archivedBy: task.archivedBy,
-      isDeleted: task.deletedAt ? true : false,
+      isDeleted: !!task.deletedAt,
       deletedDate: toRFC3339(task.deletedAt),
       source: task.source,
       deletedBy: task.deletedBy,

--- a/src/app/api/tasks/public/public.serializer.ts
+++ b/src/app/api/tasks/public/public.serializer.ts
@@ -13,7 +13,7 @@ import { rfc3339ToDateString, toRFC3339 } from '@/utils/dateHelper'
 import { resolveAutofillTags, resolveDynamicFields } from '@/utils/dynamicFields'
 import { sanitizeHtml } from '@/utils/santizeContents'
 import { copyTemplateMediaToTask } from '@/utils/signedTemplateUrlReplacer'
-import { replaceImageSrc } from '@/utils/signedUrlReplacer'
+import { replaceImageSrc, replaceMediaSrcs } from '@/utils/signedUrlReplacer'
 import { getSignedUrl } from '@/utils/signUrl'
 import { PublicTaskCreateDto, PublicTaskDto, PublicTaskDtoSchema, PublicTaskUpdateDto } from '@api/tasks/public/public.dto'
 import { Attachment, Task, WorkflowState } from '@prisma/client'
@@ -42,7 +42,9 @@ export class PublicTaskSerializer {
       id: task.id,
       object: 'task',
       name: task.title,
-      description: sanitizeHtml(task.body || ''),
+      // Re-sign inline images/attachments so the body resolves to the current storage domain
+      // rather than whatever (possibly stale) host was baked in when the task was created.
+      description: sanitizeHtml(task.body ? await replaceMediaSrcs(task.body) : ''),
       parentTaskId: task.parentId,
       dueDate: toRFC3339(task.dueDate),
       label: task.label,

--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -2,18 +2,12 @@ import { deleteTaskNotifications, sendTaskCreateNotifications, sendTaskUpdateNot
 import { sendClientUpdateTaskNotifications } from '@/jobs/notifications/send-client-task-update-notifications'
 import { ClientResponse, CompanyResponse, InternalUsers } from '@/types/common'
 import { TaskWithWorkflowState } from '@/types/db'
-import {
-  AncestorTaskResponse,
-  CreateTaskRequest,
-  UpdateTaskRequest,
-  Associations,
-  AssociationsSchema,
-} from '@/types/dto/tasks.dto'
+import { AncestorTaskResponse, CreateTaskRequest, UpdateTaskRequest, Associations } from '@/types/dto/tasks.dto'
 import { DISPATCHABLE_EVENT } from '@/types/webhook'
 import { UserIdsType } from '@/utils/assignee'
 import { isPastDateString } from '@/utils/dateHelper'
 import { getIdsFromLtreePath } from '@/utils/ltree'
-import { replaceMediaSrcs } from '@/utils/signedUrlReplacer'
+import { replaceMediaSources } from '@/utils/signedUrlReplacer'
 import APIError from '@api/core/exceptions/api'
 import { PoliciesService } from '@api/core/services/policies.service'
 import { Resource } from '@api/core/types/api'
@@ -291,7 +285,7 @@ export class TasksService extends TasksSharedService {
 
     const accessWhere = await this.getAccessFilterForTasks()
 
-    const newBody = task.body ? await replaceMediaSrcs(task.body) : task.body
+    const newBody = task.body ? await replaceMediaSources(task.body) : task.body
     const bodyChanged = newBody !== task.body
 
     const [accessibleSubtaskCount, assignee] = await Promise.all([

--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -13,8 +13,7 @@ import { DISPATCHABLE_EVENT } from '@/types/webhook'
 import { UserIdsType } from '@/utils/assignee'
 import { isPastDateString } from '@/utils/dateHelper'
 import { getIdsFromLtreePath } from '@/utils/ltree'
-import { replaceImageSrc } from '@/utils/signedUrlReplacer'
-import { getSignedUrl } from '@/utils/signUrl'
+import { replaceMediaSrcs } from '@/utils/signedUrlReplacer'
 import APIError from '@api/core/exceptions/api'
 import { PoliciesService } from '@api/core/services/policies.service'
 import { Resource } from '@api/core/types/api'
@@ -292,7 +291,7 @@ export class TasksService extends TasksSharedService {
 
     const accessWhere = await this.getAccessFilterForTasks()
 
-    const newBody = task.body ? await replaceImageSrc(task.body, getSignedUrl) : task.body
+    const newBody = task.body ? await replaceMediaSrcs(task.body) : task.body
     const bodyChanged = newBody !== task.body
 
     const [accessibleSubtaskCount, assignee] = await Promise.all([

--- a/src/app/api/tasks/tasksShared.service.ts
+++ b/src/app/api/tasks/tasksShared.service.ts
@@ -12,7 +12,7 @@ import {
 import { getFileNameFromPath } from '@/utils/attachmentUtils'
 import { resolveDynamicFields, resolveAutofillTags } from '@/utils/dynamicFields'
 import { buildLtree, buildLtreeNodeString } from '@/utils/ltree'
-import { getFilePathFromUrl } from '@/utils/signedUrlReplacer'
+import { extractMediaSrcMatches } from '@/utils/signedUrlReplacer'
 import { getSignedUrl } from '@/utils/signUrl'
 import { SupabaseActions } from '@/utils/SupabaseActions'
 import APIError from '@api/core/exceptions/api'
@@ -496,33 +496,12 @@ export abstract class TasksSharedService extends BaseService {
   }
 
   protected async updateTaskIdOfAttachmentsAfterCreation(htmlString: string, task_id: string) {
-    const imgTagRegex = /<img\s+[^>]*src="([^"]+)"[^>]*>/g //expression used to match all img srcs in provided HTML string.
-    const attachmentTagRegex = /<\s*[a-zA-Z]+\s+[^>]*data-type="attachment"[^>]*src="([^"]+)"[^>]*>/g //expression used to match all attachment srcs in provided HTML string.
-    let match
     const replacements: { originalSrc: string; newUrl: string }[] = []
 
     const newFilePaths: { originalSrc: string; newFilePath: string }[] = []
     const copyAttachmentPromises: Promise<void>[] = []
     const createAttachmentPayloads = []
-    const matches: { originalSrc: string; filePath: string; fileName: string }[] = []
-
-    while ((match = imgTagRegex.exec(htmlString)) !== null) {
-      const originalSrc = match[1]
-      const filePath = getFilePathFromUrl(originalSrc)
-      const fileName = filePath?.split('/').pop()
-      if (filePath && fileName) {
-        matches.push({ originalSrc, filePath, fileName })
-      }
-    }
-
-    while ((match = attachmentTagRegex.exec(htmlString)) !== null) {
-      const originalSrc = match[1]
-      const filePath = getFilePathFromUrl(originalSrc)
-      const fileName = filePath?.split('/').pop()
-      if (filePath && fileName) {
-        matches.push({ originalSrc, filePath, fileName })
-      }
-    }
+    const matches = extractMediaSrcMatches(htmlString)
 
     for (const { originalSrc, filePath, fileName } of matches) {
       const newFilePath = `${this.user.workspaceId}/${task_id}/${fileName}`

--- a/src/app/api/tasks/templates/templates.service.ts
+++ b/src/app/api/tasks/templates/templates.service.ts
@@ -1,9 +1,6 @@
-import { SupabaseService } from '@/app/api/core/services/supabase.service'
-import { supabaseBucket } from '@/config'
-import { signedUrlTtl } from '@/constants/attachments'
 import { CreateTemplateRequest, UpdateTemplateRequest } from '@/types/dto/templates.dto'
 import { copyTemplateMediaToTask } from '@/utils/signedTemplateUrlReplacer'
-import { getFilePathFromUrl, replaceImageSrc } from '@/utils/signedUrlReplacer'
+import { extractMediaSrcMatches, replaceImageSrc } from '@/utils/signedUrlReplacer'
 import { getSignedUrl } from '@/utils/signUrl'
 import { sanitize } from '@/utils/sql'
 import { SupabaseActions } from '@/utils/SupabaseActions'
@@ -218,32 +215,11 @@ export class TemplatesService extends BaseService {
   }
 
   private async updateTaskIdOfAttachmentsAfterCreation(htmlString: string, template_id: string) {
-    const imgTagRegex = /<img\s+[^>]*src="([^"]+)"[^>]*>/g //expression used to match all img srcs in provided HTML string.
-    const attachmentTagRegex = /<\s*[a-zA-Z]+\s+[^>]*data-type="attachment"[^>]*src="([^"]+)"[^>]*>/g //expression used to match all attachment srcs in provided HTML string.
-    let match
     const replacements: { originalSrc: string; newUrl: string }[] = []
 
     const newFilePaths: { originalSrc: string; newFilePath: string }[] = []
     const copyAttachmentPromises: Promise<void>[] = []
-    const matches: { originalSrc: string; filePath: string; fileName: string }[] = []
-
-    while ((match = imgTagRegex.exec(htmlString)) !== null) {
-      const originalSrc = match[1]
-      const filePath = getFilePathFromUrl(originalSrc)
-      const fileName = filePath?.split('/').pop()
-      if (filePath && fileName) {
-        matches.push({ originalSrc, filePath, fileName })
-      }
-    }
-
-    while ((match = attachmentTagRegex.exec(htmlString)) !== null) {
-      const originalSrc = match[1]
-      const filePath = getFilePathFromUrl(originalSrc)
-      const fileName = filePath?.split('/').pop()
-      if (filePath && fileName) {
-        matches.push({ originalSrc, filePath, fileName })
-      }
-    }
+    const matches = extractMediaSrcMatches(htmlString)
 
     for (const { originalSrc, filePath, fileName } of matches) {
       const newFilePath = `${this.user.workspaceId}/templates/${template_id}/${fileName}`
@@ -255,7 +231,7 @@ export class TemplatesService extends BaseService {
     await Promise.all(copyAttachmentPromises)
 
     const signedUrlPromises = newFilePaths.map(async ({ originalSrc, newFilePath }) => {
-      const newUrl = await this.getSignedUrl(newFilePath)
+      const newUrl = await getSignedUrl(newFilePath)
       if (newUrl) {
         replacements.push({ originalSrc, newUrl })
       }
@@ -279,15 +255,6 @@ export class TemplatesService extends BaseService {
     })
     return htmlString
   }
-
-  private async getSignedUrl(filePath: string) {
-    const supabase = new SupabaseService()
-    const { data } = await supabase.supabase.storage.from(supabaseBucket).createSignedUrl(filePath, signedUrlTtl)
-
-    const url = data?.signedUrl
-
-    return url
-  } // used to replace urls for images in template body
 
   async hasMoreTemplatesAfterCursor(id: string): Promise<boolean> {
     const nextTemplate = await this.db.taskTemplate.findFirst({

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -33,6 +33,10 @@ export const advancedFeatureFlag = !!+(process.env.NEXT_PUBLIC_ADVANCED_FEATURES
 export const supabaseProjectUrl = process.env.NEXT_PUBLIC_SUPABASE_PROJECT_URL || ''
 export const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || ''
 export const supabaseBucket = process.env.NEXT_PUBLIC_SUPABASE_BUCKET || ''
+// Assembly custom domain fronting Supabase storage (e.g. https://task-files.assembly.com). Storage
+// is served through it so downloads aren't blocked by clients that allowlist only Assembly domains
+// (OUT-3864). Empty falls back to the project URL, so behaviour is unchanged until it's configured.
+export const supabaseStorageDomain = process.env.NEXT_PUBLIC_SUPABASE_STORAGE_DOMAIN || ''
 export const cronSecret = process.env.CRON_SECRET || ''
 export const APP_ID = process.env.COPILOT_APP_API_KEY
 

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,7 +1,14 @@
-import { supabaseAnonKey, supabaseProjectUrl } from '@/config'
+import { supabaseAnonKey, supabaseProjectUrl, supabaseStorageDomain } from '@/config'
 import { createClient, type SupabaseClient as SupabaseJSClient } from '@supabase/supabase-js'
 
+// Realtime + anon REST stay on the Supabase project URL.
 export const supabase = createClient(supabaseProjectUrl, supabaseAnonKey)
+
+// Storage (downloads, signed URLs, uploads, moves) goes through the Assembly custom domain when
+// configured. Signed-URL tokens sign the path + expiry, not the host, and the custom domain fronts
+// the same Supabase backend, so URLs/uploads stay valid. This is a separate client from `supabase`
+// so realtime is unaffected. See OUT-3864.
+const storageUrl = supabaseStorageDomain || supabaseProjectUrl
 
 class SupabaseClient {
   private static client: SupabaseJSClient
@@ -12,7 +19,7 @@ class SupabaseClient {
   static getInstance(): SupabaseJSClient {
     if (!this.client) {
       if (!this.isInitialized) {
-        this.client = createClient(supabaseProjectUrl, supabaseAnonKey)
+        this.client = createClient(storageUrl, supabaseAnonKey)
         this.isInitialized = true
       }
     }

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,18 +1,10 @@
 import { supabaseAnonKey, supabaseProjectUrl, supabaseStorageDomain } from '@/config'
 import { createClient, type SupabaseClient as SupabaseJSClient } from '@supabase/supabase-js'
 
-// Realtime + anon REST stay on the Supabase project URL.
 export const supabase = createClient(supabaseProjectUrl, supabaseAnonKey)
 
-// Storage (downloads, signed URLs, uploads, moves) goes through the Assembly custom domain when
-// configured. Signed-URL tokens sign the path + expiry, not the host, and the custom domain fronts
-// the same Supabase backend, so URLs/uploads stay valid. This is a separate client from `supabase`
-// so realtime is unaffected. See OUT-3864.
 const storageUrl = supabaseStorageDomain || supabaseProjectUrl
 
-// STORAGE-ONLY client. Its URL is `storageUrl` (custom domain || project URL), which may not serve
-// WebSockets or anon-REST. Do NOT use this for realtime channels or auth — use the `supabase` export
-// above (pinned to the project URL) for those.
 class SupabaseClient {
   private static client: SupabaseJSClient
   private static isInitialized = false

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -10,6 +10,9 @@ export const supabase = createClient(supabaseProjectUrl, supabaseAnonKey)
 // so realtime is unaffected. See OUT-3864.
 const storageUrl = supabaseStorageDomain || supabaseProjectUrl
 
+// STORAGE-ONLY client. Its URL is `storageUrl` (custom domain || project URL), which may not serve
+// WebSockets or anon-REST. Do NOT use this for realtime channels or auth — use the `supabase` export
+// above (pinned to the project URL) for those.
 class SupabaseClient {
   private static client: SupabaseJSClient
   private static isInitialized = false

--- a/src/utils/signedUrlReplacer.ts
+++ b/src/utils/signedUrlReplacer.ts
@@ -1,5 +1,54 @@
-import { getSignedUrl } from '@/utils/signUrl'
+import { createSignedUrls, getSignedUrl } from '@/utils/signUrl'
 import { Comment } from '@prisma/client'
+
+// Matches the src of every <img> and the data-src of every attachment tag (`data-type="attachment"`).
+// Created per-call: /g regexes carry mutable lastIndex state, so a shared instance would race when
+// these helpers run concurrently (e.g. Promise.all over many bodies).
+const imgSrcRegex = () => /<img\s+[^>]*src="([^"]+)"[^>]*>/g
+const attachmentSrcRegex = () => /<\s*[a-zA-Z]+\s+[^>]*data-type="attachment"[^>]*src="([^"]+)"[^>]*>/g
+
+/**
+ * Collects every media reference in an HTML string — both inline images and attachment tags — as
+ * `{ originalSrc, filePath, fileName }`, deduped by originalSrc. Single source of truth for the
+ * "scan body for media" step shared by read-time signing and the post-create attachment sweeps.
+ */
+export function extractMediaSrcMatches(htmlString: string): { originalSrc: string; filePath: string; fileName: string }[] {
+  const matches: { originalSrc: string; filePath: string; fileName: string }[] = []
+  const seen = new Set<string>()
+  for (const regex of [imgSrcRegex(), attachmentSrcRegex()]) {
+    let match
+    while ((match = regex.exec(htmlString)) !== null) {
+      const originalSrc = match[1]
+      if (seen.has(originalSrc)) continue
+      const filePath = getFilePathFromUrl(originalSrc)
+      const fileName = filePath?.split('/').pop()
+      if (!filePath || !fileName) continue
+      seen.add(originalSrc)
+      matches.push({ originalSrc, filePath, fileName })
+    }
+  }
+  return matches
+}
+
+/**
+ * Read-time signing for a task/template body: rewrites every inline image and attachment tag to a
+ * freshly signed URL (which resolves to the configured storage domain). Batches all paths into one
+ * createSignedUrls call rather than signing one at a time.
+ */
+export async function replaceMediaSrcs(htmlString: string): Promise<string> {
+  const matches = extractMediaSrcMatches(htmlString)
+  if (!matches.length) return htmlString
+
+  const signed = await createSignedUrls(matches.map((m) => m.filePath))
+  const urlByPath = new Map(signed.filter((item) => item.signedUrl).map((item) => [item.path, item.signedUrl as string]))
+
+  let result = htmlString
+  for (const { originalSrc, filePath } of matches) {
+    const newUrl = urlByPath.get(filePath)
+    if (newUrl) result = result.replaceAll(originalSrc, newUrl)
+  }
+  return result
+}
 
 export async function replaceImageSrc(htmlString: string, getSignedUrl: (filePath: string) => Promise<string | undefined>) {
   const imgTagRegex = /<img\s+[^>]*src="([^"]+)"[^>]*>/g //expression used to match all img tags in provided HTML string.

--- a/src/utils/signedUrlReplacer.ts
+++ b/src/utils/signedUrlReplacer.ts
@@ -39,7 +39,15 @@ export async function replaceMediaSrcs(htmlString: string): Promise<string> {
   const matches = extractMediaSrcMatches(htmlString)
   if (!matches.length) return htmlString
 
-  const signed = await createSignedUrls(matches.map((m) => m.filePath))
+  // A storage-signing outage must not take down task reads. createSignedUrls throws on a
+  // top-level error, so degrade to the stored body (original URLs) instead of 500-ing the
+  // whole task/serializer. Per-item failures already fall through the `signedUrl` filter below.
+  const signed = await createSignedUrls(matches.map((m) => m.filePath)).catch((error) => {
+    console.error('replaceMediaSrcs: failed to sign media, returning original body', error)
+    return null
+  })
+  if (!signed) return htmlString
+
   const urlByPath = new Map(signed.filter((item) => item.signedUrl).map((item) => [item.path, item.signedUrl as string]))
 
   let result = htmlString

--- a/src/utils/signedUrlReplacer.ts
+++ b/src/utils/signedUrlReplacer.ts
@@ -2,16 +2,9 @@ import { createSignedUrls, getSignedUrl } from '@/utils/signUrl'
 import { Comment } from '@prisma/client'
 
 // Matches the src of every <img> and the data-src of every attachment tag (`data-type="attachment"`).
-// Created per-call: /g regexes carry mutable lastIndex state, so a shared instance would race when
-// these helpers run concurrently (e.g. Promise.all over many bodies).
 const imgSrcRegex = () => /<img\s+[^>]*src="([^"]+)"[^>]*>/g
 const attachmentSrcRegex = () => /<\s*[a-zA-Z]+\s+[^>]*data-type="attachment"[^>]*src="([^"]+)"[^>]*>/g
 
-/**
- * Collects every media reference in an HTML string — both inline images and attachment tags — as
- * `{ originalSrc, filePath, fileName }`, deduped by originalSrc. Single source of truth for the
- * "scan body for media" step shared by read-time signing and the post-create attachment sweeps.
- */
 export function extractMediaSrcMatches(htmlString: string): { originalSrc: string; filePath: string; fileName: string }[] {
   const matches: { originalSrc: string; filePath: string; fileName: string }[] = []
   const seen = new Set<string>()
@@ -30,12 +23,7 @@ export function extractMediaSrcMatches(htmlString: string): { originalSrc: strin
   return matches
 }
 
-/**
- * Read-time signing for a task/template body: rewrites every inline image and attachment tag to a
- * freshly signed URL (which resolves to the configured storage domain). Batches all paths into one
- * createSignedUrls call rather than signing one at a time.
- */
-export async function replaceMediaSrcs(htmlString: string): Promise<string> {
+export async function replaceMediaSources(htmlString: string): Promise<string> {
   const matches = extractMediaSrcMatches(htmlString)
   if (!matches.length) return htmlString
 
@@ -43,7 +31,7 @@ export async function replaceMediaSrcs(htmlString: string): Promise<string> {
   // top-level error, so degrade to the stored body (original URLs) instead of 500-ing the
   // whole task/serializer. Per-item failures already fall through the `signedUrl` filter below.
   const signed = await createSignedUrls(matches.map((m) => m.filePath)).catch((error) => {
-    console.error('replaceMediaSrcs: failed to sign media, returning original body', error)
+    console.error('replaceMediaSources: failed to sign media, returning original body', error)
     return null
   })
   if (!signed) return htmlString


### PR DESCRIPTION
## What & why

Clients that allowlist only Assembly domains couldn't download task files, because Supabase storage was served from the raw Supabase project URL (OUT-3864).

This routes **storage only** (downloads, signed URLs, uploads, moves) through an Assembly custom domain via `NEXT_PUBLIC_SUPABASE_STORAGE_DOMAIN` (e.g. `task-files.assembly.com`). Signed-URL tokens sign the path + expiry, not the host, so URLs stay valid. **Realtime/anon stays on the project URL** (separate client).

## Activation (safe rollout)

- Empty `NEXT_PUBLIC_SUPABASE_STORAGE_DOMAIN` → falls back to the project URL → **behavior unchanged**.
- Set the env var only once the domain is verified/active in Supabase. No backfill needed — signing happens on read.

## Changes

- **`lib/supabase.ts`** — split into two clients: realtime/anon on the project URL, a storage-only client on the custom domain.
- **Public API task `description`** now re-signs inline media on read (it previously returned the raw stored body — see callout below).
- **DRY cleanup** — the duplicated "scan body for media" regex logic and per-service signers are consolidated into `extractMediaSrcMatches` / `replaceMediaSrcs` in `signedUrlReplacer.ts`.

## What to keep an eye on

- **Public task list (`GET /tasks`)**: now issues one batched signing call per task body (bounded by `limit`, default 100, concurrent). New cost for this endpoint, but the template list already does heavier per-image fan-out, and failures degrade to the stored body rather than 500-ing. Worth a glance at latency after enabling.
- **`description` re-signing is a fix, not just overhead**: signed URLs expire after 1h (`signedUrlTtl`), so the old public API was returning expired links for any task older than an hour. Re-signing on read matches what the internal app already does for every task/template read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
