### PR TITLE
fix(OUT-3852): show & count standalone subtasks under associated-but-unshared parents

### DIFF
--- a/src/app/api/tasks/tasksShared.service.ts
+++ b/src/app/api/tasks/tasksShared.service.ts
@@ -250,15 +250,16 @@ export abstract class TasksSharedService extends BaseService {
                 },
                 {
                   // AND do not disjoint if parent is accessible to the client through association.
-                  // Uses `equals` (full-array exact match) to preserve the prior `hasSome` semantics
-                  // — tasks associated with a different client at the same company do not match.
+                  // An association only grants access when the task is shared (isShared), mirroring
+                  // getClientOrCompanyAssigneeFilter's CU-portal branch. Without the isShared guard,
+                  // a parent that is merely associated (but not shared) is wrongly treated as
+                  // accessible, dropping its assigned subtask from the disjoint (standalone) view.
+                  // Uses `equals` (full-array exact match) so associations to a different client at
+                  // the same company do not match.
                   NOT: {
+                    isShared: true,
                     OR: [
-                      {
-                        associations: {
-                          equals: [{ clientId: this.user.clientId, companyId: this.user.companyId }],
-                        },
-                      },
+                      { associations: { equals: [{ clientId: this.user.clientId, companyId: this.user.companyId }] } },
                       { associations: { equals: [{ companyId: this.user.companyId }] } },
                     ],
                   },


### PR DESCRIPTION
## OUT-3852 — In-product notifications do not appear or disappear in real time when task status changes

### Problem
A subtask **assigned to a client** whose parent is only **associated** to that client — but **not shared** (`isShared = false`) — was invisible to the client and missing from their in-product notification count.

### Root cause
`getDisjointTasksFilter` decides whether a subtask is "standalone" by checking if its parent is inaccessible. The parent-accessibility-via-association check matched any parent with a matching association, **ignoring `isShared`**:

```ts
NOT: { OR: [ { associations: { equals: [{ clientId, companyId }] } }, … ] }   // no isShared
```

But the real access rule (`getClientOrCompanyAssigneeFilter`, CU-portal branch) only grants association-based access when `isShared: true`. So an associated-but-unshared parent was wrongly treated as **accessible**, which demoted its assigned subtask from *standalone* to *nested* — and `getAllTasks` drops nested subtasks.

Because `getAllTasks` powers both the client task board and `ValidateCountService`, the subtask was both **invisible on the board** and **uncounted** in the notification badge.

### Fix
Require `isShared: true` for an association to count as parent-accessible, mirroring the access rule:

```ts
NOT: {
  isShared: true,
  OR: [
    { associations: { equals: [{ clientId, companyId }] } },
    { associations: { equals: [{ companyId }] } },
  ],
}
```

### Behavioral delta (provably minimal)
The only rows whose visibility changes are subtasks under an associated-but-**unshared** parent — exactly the bug. Associated-and-shared parents (→ nested) and all non-association cases are unchanged. This makes the disjoint filter consistent with the access filter rather than introducing new behavior.

### Scope / safety
- Non-IU (client) branch only; the limited-access-IU branch is untouched (IU access isn't gated by `isShared`).
- Board and notification count now agree (verified: pre-fix both hid the subtask, post-fix both show it).

### Testing
- Reproduced and fixed against the exact production row/token via the real `getAllTasks` on a Postgres testcontainer.
- Regression matrix verified: same-client / company / different-client / shared-to-other parents behave correctly.
- `yarn tsc` clean; ESLint clean on touched files; full integration suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)