### PR TITLE
OUT-3789 | Filter chip key and value are vertically misaligned

### DIFF
--- a/src/components/buttons/FilterChip.tsx
+++ b/src/components/buttons/FilterChip.tsx
@@ -4,7 +4,7 @@ import { CrossIconSmall, FilterByAsigneeIcon } from '@/icons'
 import { selectTaskBoard } from '@/redux/features/taskBoardSlice'
 import { FilterType } from '@/types/common'
 import { emptyAssignee, getAssigneeName, UserIdsType } from '@/utils/assignee'
-import { Box, IconButton, Stack, Typography } from '@mui/material'
+import { Box, IconButton, Stack } from '@mui/material'
 import deepEqual from 'deep-equal'
 import { useMemo } from 'react'
 import { useSelector } from 'react-redux'
@@ -79,22 +79,17 @@ export const FilterChip = ({ type, assignee }: FilterChipProps) => {
             <FilterByAsigneeIcon />
             <Stack direction="row" sx={{ justifyContent: 'center', alignItems: 'center' }}>
               <Box sx={{ color: (theme) => theme.color.text.textSecondary }}>{type}:&nbsp;</Box>
-              <Box>
-                <Typography
-                  variant="sm"
-                  lineHeight="32px"
-                  sx={{
-                    color: (theme) => theme.color.gray[600],
-                    fontWeight: '400',
-                    textOverflow: 'ellipsis',
-                    maxWidth: '100px',
-                    whiteSpace: 'nowrap',
-                    overflow: 'hidden',
-                  }}
-                  title={name}
-                >
-                  {name}
-                </Typography>
+              <Box
+                title={name}
+                sx={{
+                  color: (theme) => theme.color.gray[600],
+                  textOverflow: 'ellipsis',
+                  maxWidth: '100px',
+                  whiteSpace: 'nowrap',
+                  overflow: 'hidden',
+                }}
+              >
+                {name}
               </Box>
             </Stack>
             <IconButton


### PR DESCRIPTION
## Summary
- Replaced `Typography variant="sm"` with a plain `Box` for the filter value text in `FilterChip.tsx`
- The `Typography` variant was applying its own `line-height` from the design system theme, causing the name text to sit at a different baseline than the sibling "key:" `Box`
- Both text pieces now inherit the same font styles from the parent Stack, aligning them consistently

## Test plan
- [x] Apply a filter (Assignee, Related to, Creator) and confirm the chip key and value are vertically aligned
- [x] Confirm long names are still truncated with ellipsis
- [x] Confirm the chip renders correctly in all three filter types

🤖 Generated with [Claude Code](https://claude.com/claude-code)