### PR TITLE
OUT-3828 | Observability for the grouped email pipeline

### DIFF
--- a/src/jobs/notifications/flush-grouped-email.integration.test.ts
+++ b/src/jobs/notifications/flush-grouped-email.integration.test.ts
@@ -21,7 +21,10 @@ jest.mock('@/utils/CopilotAPI', () => ({
 }))
 
 jest.mock('@/jobs/sentry', () => ({
-  Sentry: { captureException: (...args: unknown[]) => mockCaptureException(...args) },
+  Sentry: {
+    captureException: (...args: unknown[]) => mockCaptureException(...args),
+    addBreadcrumb: jest.fn(),
+  },
 }))
 
 import { disconnectTestDb, getTestDb, seedTask, uuid } from '../../../test/integration/db'

--- a/src/jobs/notifications/flush-grouped-email.integration.test.ts
+++ b/src/jobs/notifications/flush-grouped-email.integration.test.ts
@@ -119,7 +119,7 @@ describe('flush-grouped-email idempotency (real DB)', () => {
     const result = await flushGroupedEmailRun({ workspaceId: WS, windowKey: window })
 
     expect(mockCreateNotification).toHaveBeenCalledTimes(1)
-    expect(result).toMatchObject({ recipients: 1, sent: 1 })
+    expect(result).toMatchObject({ recipients: 1, sent: 1, sentGrouped: 1, sentIndividual: 0 })
     expect(await unsentCount(window)).toBe(0)
   })
 
@@ -216,7 +216,7 @@ describe('flush-grouped-email idempotency (real DB)', () => {
     expect(mockCreateNotification).toHaveBeenCalledTimes(2)
     const recipients = mockCreateNotification.mock.calls.map((c) => c[0].recipientClientId).sort()
     expect(recipients).toEqual([CLIENT_A, CLIENT_B].sort())
-    expect(result).toMatchObject({ recipients: 2, sent: 2 })
+    expect(result).toMatchObject({ recipients: 2, sent: 2, sentGrouped: 2, sentIndividual: 0 })
     expect(await unsentCount(window)).toBe(0)
   })
 
@@ -239,10 +239,11 @@ describe('flush-grouped-email idempotency (real DB)', () => {
       eventType: GroupedEmailEventType.SHARED,
     })
 
-    await flushGroupedEmailRun({ workspaceId: WS, windowKey: window })
+    const result = await flushGroupedEmailRun({ workspaceId: WS, windowKey: window })
 
     // Only the live task appears in the grouped email (1 event); individual snapshot path.
     expect(mockCreateNotification).toHaveBeenCalledTimes(1)
+    expect(result).toMatchObject({ sentGrouped: 0, sentIndividual: 1 })
     // All rows are marked sent regardless of whether the task was live.
     expect(await unsentCount(window)).toBe(0)
   })

--- a/src/jobs/notifications/flush-grouped-email.test.ts
+++ b/src/jobs/notifications/flush-grouped-email.test.ts
@@ -17,7 +17,10 @@ jest.mock('@trigger.dev/sdk/v3', () => ({
 jest.mock('@/config', () => ({ copilotAPIKey: 'test-api-key' }))
 
 jest.mock('@/jobs/sentry', () => ({
-  Sentry: { captureException: (...args: unknown[]) => mockCaptureException(...args) },
+  Sentry: {
+    captureException: (...args: unknown[]) => mockCaptureException(...args),
+    addBreadcrumb: jest.fn(),
+  },
 }))
 
 jest.mock('@/lib/db', () => ({

--- a/src/jobs/notifications/flush-grouped-email.test.ts
+++ b/src/jobs/notifications/flush-grouped-email.test.ts
@@ -104,7 +104,7 @@ describe('flushGroupedEmailRun', () => {
     expect(args.content.totalEventCount).toBe(2)
     expect(mockCreateNotification).not.toHaveBeenCalled()
     expect(mockExecuteRaw).toHaveBeenCalledTimes(1) // markRecipientSent
-    expect(result).toMatchObject({ recipients: 1, sent: 1 })
+    expect(result).toMatchObject({ recipients: 1, sent: 1, sentGrouped: 1, sentIndividual: 0 })
   })
 
   it('replays the original individual email when the window has a single live event', async () => {
@@ -117,17 +117,18 @@ describe('flushGroupedEmailRun', () => {
     expect(mockSendGroupedEmail).not.toHaveBeenCalled()
     expect(mockGetInternalUsers).not.toHaveBeenCalled() // no workspace IU needed for the individual path
     expect(mockExecuteRaw).toHaveBeenCalledTimes(1)
-    expect(result).toMatchObject({ recipients: 1, sent: 1 })
+    expect(result).toMatchObject({ recipients: 1, sent: 1, sentGrouped: 0, sentIndividual: 1 })
   })
 
   it('falls back to the grouped summary when a single event has no snapshot (pre-migration row)', async () => {
     mockQueryRaw.mockResolvedValue([row({ individualEmail: null })])
 
-    await flushGroupedEmailRun(payload)
+    const result = await flushGroupedEmailRun(payload)
 
     expect(mockCreateNotification).not.toHaveBeenCalled()
     expect(mockSendGroupedEmail).toHaveBeenCalledTimes(1)
     expect(mockSendGroupedEmail.mock.calls[0][0].content.totalEventCount).toBe(1)
+    expect(result).toMatchObject({ sentGrouped: 1, sentIndividual: 0 })
   })
 
   it('no-ops when there are no unsent rows (idempotent re-run)', async () => {
@@ -166,7 +167,7 @@ describe('flushGroupedEmailRun', () => {
     expect(mockSendGroupedEmail).not.toHaveBeenCalled()
     expect(mockCreateNotification).not.toHaveBeenCalled()
     expect(mockExecuteRaw).toHaveBeenCalledTimes(1)
-    expect(result).toMatchObject({ sent: 0 })
+    expect(result).toMatchObject({ sent: 0, sentGrouped: 0, sentIndividual: 0 })
   })
 
   it('sends one individual email per recipient when single-event windows span multiple clients', async () => {
@@ -177,7 +178,7 @@ describe('flushGroupedEmailRun', () => {
     expect(mockCreateNotification).toHaveBeenCalledTimes(2)
     expect(mockSendGroupedEmail).not.toHaveBeenCalled()
     expect(mockExecuteRaw).toHaveBeenCalledTimes(2)
-    expect(result).toMatchObject({ recipients: 2, sent: 2 })
+    expect(result).toMatchObject({ recipients: 2, sent: 2, sentGrouped: 0, sentIndividual: 2 })
   })
 
   it('retries the individual email without senderCompanyId when the workspace rejects it', async () => {

--- a/src/jobs/notifications/flush-grouped-email.ts
+++ b/src/jobs/notifications/flush-grouped-email.ts
@@ -160,7 +160,7 @@ export const flushGroupedEmailRun = async (payload: FlushGroupedEmailPayload) =>
     }
 
     await markRecipientSent(db, windowKey, group.recipientClientId, batchId)
-    logger.log('flush-grouped-email: recipient sent', {
+    logger.log('flush-grouped-email: recipient processed', {
       workspaceId,
       windowKey,
       recipientClientId: group.recipientClientId,

--- a/src/jobs/notifications/flush-grouped-email.ts
+++ b/src/jobs/notifications/flush-grouped-email.ts
@@ -115,18 +115,37 @@ export const flushGroupedEmailRun = async (payload: FlushGroupedEmailPayload) =>
   const copilot = new CopilotAPI('', `${workspaceId}/${copilotAPIKey}`)
 
   const liveTaskIds = await getLiveTaskIds(db, [...new Set(rows.map((r) => r.taskId))])
+  const skippedDeletedTasks = rows.length - rows.filter((r) => liveTaskIds.has(r.taskId)).length
+
+  const groups = groupByRecipient(rows)
+  logger.log('flush-grouped-email: starting', {
+    workspaceId,
+    windowKey,
+    bufferedEvents: rows.length,
+    skippedDeletedTasks,
+    recipients: groups.length,
+  })
 
   let sent = 0
+  let sentGrouped = 0
+  let sentIndividual = 0
   let senderId: string | undefined // resolved lazily — only the grouped branch needs a workspace IU
-  const groups = groupByRecipient(rows)
   for (const group of groups) {
     const liveEvents = group.events.filter((e) => liveTaskIds.has(e.taskId))
     // A single event reads awkwardly as a "summary" — replay the original individual email verbatim.
     // Pre-migration rows have no snapshot; fall back to the grouped summary rather than crash.
     const singleEmail = liveEvents.length === 1 ? liveEvents[0].individualEmail : null
+
+    Sentry.addBreadcrumb({
+      category: 'flush-grouped-email',
+      message: `recipient ${group.recipientClientId}`,
+      data: { workspaceId, windowKey, recipientClientId: group.recipientClientId, liveEvents: liveEvents.length },
+    })
+
     if (singleEmail) {
       await sendIndividualEmail(copilot, singleEmail)
       sent += 1
+      sentIndividual += 1
     } else if (liveEvents.length >= 1) {
       senderId ??= await resolveSenderId(copilot)
       await sendGroupedEmail({
@@ -137,8 +156,17 @@ export const flushGroupedEmailRun = async (payload: FlushGroupedEmailPayload) =>
         copilot,
       })
       sent += 1
+      sentGrouped += 1
     }
+
     await markRecipientSent(db, windowKey, group.recipientClientId, batchId)
+    logger.log('flush-grouped-email: recipient sent', {
+      workspaceId,
+      windowKey,
+      recipientClientId: group.recipientClientId,
+      liveEvents: liveEvents.length,
+      outcome: singleEmail ? ('individual' as const) : liveEvents.length >= 1 ? ('grouped' as const) : ('skipped' as const),
+    })
   }
 
   logger.log('flush-grouped-email: run summary', {
@@ -146,10 +174,12 @@ export const flushGroupedEmailRun = async (payload: FlushGroupedEmailPayload) =>
     windowKey,
     recipients: groups.length,
     sent,
+    sentGrouped,
+    sentIndividual,
     bufferedEvents: rows.length,
-    skippedDeletedTasks: rows.length - rows.filter((r) => liveTaskIds.has(r.taskId)).length,
+    skippedDeletedTasks,
   })
-  return { windowKey, recipients: groups.length, sent }
+  return { windowKey, recipients: groups.length, sent, sentGrouped, sentIndividual }
 }
 
 export const flushGroupedEmailOnFailure = async ({ payload, error }: { payload: unknown; error: unknown }) => {


### PR DESCRIPTION
## Summary

- Adds `sentGrouped` and `sentIndividual` counters to `flushGroupedEmailRun` so prod logs distinguish grouped summaries from individual snapshot replays
- Adds a `flush-grouped-email: starting` log before the recipient loop (bufferedEvents, skippedDeletedTasks, recipients) — mirrors the sweep-starting pattern in `send-task-reminders.ts`
- Adds a per-recipient `flush-grouped-email: recipient sent` log with `outcome: grouped | individual | skipped` after each send
- Adds `Sentry.addBreadcrumb` per recipient before processing so `onFailure` captures which client was mid-flight when the terminal failure occurred
- Surfaces `sentGrouped` and `sentIndividual` in the final run summary log and return value
- Updates the Sentry mock in both `flush-grouped-email.test.ts` and `flush-grouped-email.integration.test.ts` to expose `addBreadcrumb`

## Test plan

- [x] `yarn test src/jobs/notifications/flush-grouped-email.test.ts` — 12 tests pass (all existing)
- [x] `yarn test:integration src/jobs/notifications/flush-grouped-email.integration.test.ts` — 6 tests pass (all existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)