### PR TITLE
fix(detail): task details 'Something went wrong' for clients (OUT-3898)

### DIFF
--- a/src/app/detail/[task_id]/[user_type]/page.tsx
+++ b/src/app/detail/[task_id]/[user_type]/page.tsx
@@ -107,9 +107,12 @@ export default async function TaskDetailPage(props: {
       viewSettings={viewSettings}
     >
       {!!token && <OneTaskDataFetcher token={token} task_id={task_id} initialTask={task} />}
-      <Suspense fallback={null}>
-        <TemplatesFetcher token={token} />
-      </Suspense>
+      {/* Templates are IU-only (clients have no TaskTemplates policy); fetching them as a client 401s and crashes the page */}
+      {tokenPayload.internalUserId && (
+        <Suspense fallback={null}>
+          <TemplatesFetcher token={token} />
+        </Suspense>
+      )}
       <RealTime tokenPayload={tokenPayload}>
         <RealTimeTemplates tokenPayload={tokenPayload} token={token}>
           <EscapeHandler />


### PR DESCRIPTION
## Issue
Clients opening a task detail page hit a "Something went wrong" crash.

## Cause
Clients have no `TaskTemplates` policy, so `/api/tasks/templates` returns 401. The detail page mounted `TemplatesFetcher` for all users; since #1282 routes it through `fetchWithErrorHandler` (throws on non-OK), that 401 now crashes the page. Previously the 401 was silently swallowed.

## Fix
Guard `TemplatesFetcher` behind `internalUserId` — templates are IU-only.