### PR TITLE
OUT-3820 | confirm markdown feature set + validate grouped email rendering

### DIFF
--- a/src/app/api/notification/groupedEmail.renderer.test.ts
+++ b/src/app/api/notification/groupedEmail.renderer.test.ts
@@ -11,7 +11,7 @@ const section = (overrides: Partial<GroupedEmailContent['sections'][number]> = {
 })
 
 describe('renderGroupedEmail', () => {
-  it('renders the PRD sample (assigned + shared + comment) as dashed plain text', () => {
+  it('renders the PRD sample (assigned + shared + comment) as HTML', () => {
     const content: GroupedEmailContent = {
       totalEventCount: 6,
       sections: [
@@ -41,30 +41,23 @@ describe('renderGroupedEmail', () => {
     expect(email.subject).toBe('You have 6 new task updates')
     expect(email.header).toBe(GROUPED_EMAIL_HEADER)
     expect(email.title).toBe(GROUPED_EMAIL_CTA_TITLE)
-    expect(email.body).toBe(
-      [
-        '3 tasks assigned to you',
-        '- ‘Q4 Tax Document Upload’',
-        '- ‘Complete W-9 Form’',
-        '- ‘Review Engagement Letter’',
-        '',
-        '2 tasks shared with you',
-        '- ‘Annual Filing Preparation’',
-        '- ‘Bookkeeping Review’',
-        '',
-        '1 comment was added',
-        '- ‘Task with a conversation’',
-      ].join('\n'),
+    expect(email.htmlBody).toBe(
+      '<strong>3 tasks assigned to you</strong>' +
+        "<ul><li>'Q4 Tax Document Upload'</li><li>'Complete W-9 Form'</li><li>'Review Engagement Letter'</li></ul>" +
+        '<strong>2 tasks shared with you</strong>' +
+        "<ul><li>'Annual Filing Preparation'</li><li>'Bookkeeping Review'</li></ul>" +
+        '<strong>1 comment was added</strong>' +
+        "<ul><li>'Task with a conversation'</li></ul>",
     )
   })
 
-  it('renders the "+N other tasks" overflow line', () => {
+  it('renders the "+N other tasks" overflow with em tag', () => {
     const email = renderGroupedEmail({
       totalEventCount: 12,
       sections: [section({ count: 12, taskNames: ['A', 'B', 'C'], overflowCount: 9 })],
     })
 
-    expect(email.body).toBe(['12 tasks assigned to you', '- ‘A’', '- ‘B’', '- ‘C’', '+9 other tasks'].join('\n'))
+    expect(email.htmlBody).toContain('<em>+9 other tasks</em>')
   })
 
   it('singularizes the overflow line for a single other task', () => {
@@ -73,8 +66,17 @@ describe('renderGroupedEmail', () => {
       sections: [section({ count: 4, taskNames: ['A', 'B', 'C'], overflowCount: 1 })],
     })
 
-    expect(email.body).toContain('+1 other task')
-    expect(email.body).not.toContain('+1 other tasks')
+    expect(email.htmlBody).toContain('<em>+1 other task</em>')
+    expect(email.htmlBody).not.toContain('<em>+1 other tasks</em>')
+  })
+
+  it('omits overflow element when there is no overflow', () => {
+    const email = renderGroupedEmail({
+      totalEventCount: 1,
+      sections: [section()],
+    })
+
+    expect(email.htmlBody).not.toContain('<em>')
   })
 
   it('uses singular copy for the subject when there is one update', () => {
@@ -87,24 +89,24 @@ describe('renderGroupedEmail', () => {
   })
 
   it.each([
-    [GroupedEmailEventType.ASSIGNED, 1, '1 task assigned to you'],
-    [GroupedEmailEventType.ASSIGNED, 3, '3 tasks assigned to you'],
-    [GroupedEmailEventType.SHARED, 1, '1 task shared with you'],
-    [GroupedEmailEventType.SHARED, 2, '2 tasks shared with you'],
-    [GroupedEmailEventType.COMMENT, 1, '1 comment was added'],
-    [GroupedEmailEventType.COMMENT, 4, '4 comments were added'],
-    [GroupedEmailEventType.COMPLETED, 1, '1 task completed'],
-    [GroupedEmailEventType.COMPLETED, 2, '2 tasks completed'],
+    [GroupedEmailEventType.ASSIGNED, 1, '<strong>1 task assigned to you</strong>'],
+    [GroupedEmailEventType.ASSIGNED, 3, '<strong>3 tasks assigned to you</strong>'],
+    [GroupedEmailEventType.SHARED, 1, '<strong>1 task shared with you</strong>'],
+    [GroupedEmailEventType.SHARED, 2, '<strong>2 tasks shared with you</strong>'],
+    [GroupedEmailEventType.COMMENT, 1, '<strong>1 comment was added</strong>'],
+    [GroupedEmailEventType.COMMENT, 4, '<strong>4 comments were added</strong>'],
+    [GroupedEmailEventType.COMPLETED, 1, '<strong>1 task completed</strong>'],
+    [GroupedEmailEventType.COMPLETED, 2, '<strong>2 tasks completed</strong>'],
   ])('renders the %s heading correctly for count %i', (eventType, count, expected) => {
     const email = renderGroupedEmail({
       totalEventCount: count,
       sections: [section({ eventType, count, taskNames: ['Task A'] })],
     })
 
-    expect(email.body.split('\n')[0]).toBe(expected)
+    expect(email.htmlBody).toContain(expected)
   })
 
   it('returns an empty body when there are no sections', () => {
-    expect(renderGroupedEmail({ totalEventCount: 0, sections: [] }).body).toBe('')
+    expect(renderGroupedEmail({ totalEventCount: 0, sections: [] }).htmlBody).toBe('')
   })
 })

--- a/src/app/api/notification/groupedEmail.renderer.ts
+++ b/src/app/api/notification/groupedEmail.renderer.ts
@@ -8,7 +8,7 @@ export interface GroupedEmailDetails {
   subject: string
   header: string
   title: string
-  body: string
+  htmlBody: string
 }
 
 const pluralize = (count: number, singular: string, plural: string): string => (count === 1 ? singular : plural)
@@ -22,16 +22,17 @@ const sectionHeading: Record<GroupedEmailEventType, (count: number) => string> =
 }
 
 const renderSection = (section: GroupedEmailSection): string => {
-  const lines = [sectionHeading[section.eventType](section.count), ...section.taskNames.map((name) => `- ‘${name}’`)]
-  if (section.overflowCount > 0) {
-    lines.push(`+${section.overflowCount} other ${pluralize(section.overflowCount, 'task', 'tasks')}`)
-  }
-  return lines.join('\n')
+  const items = section.taskNames.map((name) => `<li>'${name}'</li>`).join('')
+  const overflow =
+    section.overflowCount > 0
+      ? `<em>+${section.overflowCount} other ${pluralize(section.overflowCount, 'task', 'tasks')}</em>`
+      : ''
+  return `<strong>${sectionHeading[section.eventType](section.count)}</strong><ul>${items}</ul>${overflow}`
 }
 
 export const renderGroupedEmail = (content: GroupedEmailContent): GroupedEmailDetails => ({
   subject: `You have ${content.totalEventCount} new task ${pluralize(content.totalEventCount, 'update', 'updates')}`,
   header: GROUPED_EMAIL_HEADER,
   title: GROUPED_EMAIL_CTA_TITLE,
-  body: content.sections.map(renderSection).join('\n\n'),
+  htmlBody: content.sections.map(renderSection).join(''),
 })

--- a/src/app/api/notification/groupedReminderEmail.renderer.test.ts
+++ b/src/app/api/notification/groupedReminderEmail.renderer.test.ts
@@ -2,7 +2,7 @@ import { TaskReminderType } from '@prisma/client'
 import { ReminderEntry, renderGroupedReminderEmail } from './groupedReminderEmail.renderer'
 
 describe('renderGroupedReminderEmail', () => {
-  it('renders N=2 grouped reminder with correct subject, header, title, and body', () => {
+  it('renders N=2 grouped reminder with correct subject, header, title, and htmlBody', () => {
     const entries: ReminderEntry[] = [
       { taskTitle: 'Submit tax documents', reminderType: TaskReminderType.DUE_DATE_TODAY },
       { taskTitle: 'Review contract', reminderType: TaskReminderType.DUE_DATE_OVERDUE_3D },
@@ -12,7 +12,9 @@ describe('renderGroupedReminderEmail', () => {
     expect(result.subject).toBe('[Reminder] You have 2 tasks to complete')
     expect(result.header).toBe('Task reminders')
     expect(result.title).toBe('View all tasks')
-    expect(result.body).toBe(["- 'Submit tax documents' - Due today", "- 'Review contract' - Overdue by 3 days"].join('\n'))
+    expect(result.htmlBody).toBe(
+      "<ul><li>'Submit tax documents' – <em>Due today</em></li><li>'Review contract' – <em>Overdue by 3 days</em></li></ul>",
+    )
   })
 
   it('singularizes "task" in subject when N=1', () => {
@@ -20,7 +22,7 @@ describe('renderGroupedReminderEmail', () => {
     expect(result.subject).toBe('[Reminder] You have 1 task to complete')
   })
 
-  it('renders 4 tasks with one line per task', () => {
+  it('renders 4 tasks as 4 li elements', () => {
     const entries: ReminderEntry[] = [
       { taskTitle: 'Task A', reminderType: TaskReminderType.DUE_DATE_TODAY },
       { taskTitle: 'Task B', reminderType: TaskReminderType.DUE_DATE_OVERDUE_3D },
@@ -29,7 +31,7 @@ describe('renderGroupedReminderEmail', () => {
     ]
     const result = renderGroupedReminderEmail(entries)
     expect(result.subject).toBe('[Reminder] You have 4 tasks to complete')
-    expect(result.body.split('\n')).toHaveLength(4)
+    expect(result.htmlBody.match(/<li>/g)).toHaveLength(4)
   })
 
   it.each([
@@ -44,6 +46,6 @@ describe('renderGroupedReminderEmail', () => {
       { taskTitle: 'A task', reminderType },
       { taskTitle: 'Another task', reminderType: TaskReminderType.DUE_DATE_TODAY },
     ])
-    expect(result.body).toContain(expectedLabel)
+    expect(result.htmlBody).toContain(expectedLabel)
   })
 })

--- a/src/app/api/notification/groupedReminderEmail.renderer.ts
+++ b/src/app/api/notification/groupedReminderEmail.renderer.ts
@@ -9,7 +9,7 @@ export interface GroupedReminderEmailDetails {
   subject: string
   header: string
   title: string
-  body: string
+  htmlBody: string
 }
 
 const reminderLabel: Record<TaskReminderType, string> = {
@@ -23,10 +23,11 @@ const reminderLabel: Record<TaskReminderType, string> = {
 
 export const renderGroupedReminderEmail = (entries: ReminderEntry[]): GroupedReminderEmailDetails => {
   const n = entries.length
+  const items = entries.map((e) => `<li>'${e.taskTitle}' – <em>${reminderLabel[e.reminderType]}</em></li>`).join('')
   return {
     subject: `[Reminder] You have ${n} ${n === 1 ? 'task' : 'tasks'} to complete`,
     header: 'Task reminders',
     title: 'View all tasks',
-    body: entries.map((e) => `- '${e.taskTitle}' - ${reminderLabel[e.reminderType]}`).join('\n'),
+    htmlBody: `<ul>${items}</ul>`,
   }
 }

--- a/src/jobs/notifications/send-grouped-email.test.ts
+++ b/src/jobs/notifications/send-grouped-email.test.ts
@@ -55,7 +55,7 @@ describe('sendGroupedEmail', () => {
       subject: 'You have 2 new task updates',
       header: 'Catch up on task activity',
       title: 'View all tasks',
-      body: expect.stringContaining('2 tasks assigned to you'),
+      htmlBody: expect.stringContaining('2 tasks assigned to you'),
     })
     expect(payload.deliveryTargets.inProduct).toBeUndefined()
   })

--- a/src/jobs/notifications/send-grouped-email.ts
+++ b/src/jobs/notifications/send-grouped-email.ts
@@ -32,7 +32,7 @@ export const sendGroupedEmail = async ({
         subject: email.subject,
         header: email.header,
         title: email.title,
-        body: email.body,
+        htmlBody: email.htmlBody,
       },
     },
   }

--- a/src/jobs/notifications/send-grouped-reminder-email.ts
+++ b/src/jobs/notifications/send-grouped-reminder-email.ts
@@ -31,7 +31,7 @@ export const sendGroupedReminderEmail = async ({
         subject: email.subject,
         header: email.header,
         title: email.title,
-        body: email.body,
+        htmlBody: email.htmlBody,
       },
     },
   }


### PR DESCRIPTION
## Linear

[OUT-3820](https://linear.app/assemblycom/issue/OUT-3820/spike-confirm-markdown-feature-set-validate-grouped-email-rendering)

## What & why

Assembly's notification API now supports `htmlBody` (enabled by #1342). This PR applies HTML formatting to both grouped task notification emails and grouped reminder emails, replacing the previous plain-text body.

## Changes

- **`groupedEmail.renderer.ts`** — `renderSection` now emits `<strong>` for section headings, `<ul>/<li>` for task names, and `<em>` for overflow counts (`+N other tasks`). Return field renamed from `body` to `htmlBody`.
- **`groupedReminderEmail.renderer.ts`** — Each reminder entry renders as `<li>'Task title' – <em>Reminder label</em></li>` inside a single `<ul>`. Return field renamed from `body` to `htmlBody`.
- **`send-grouped-email.ts`** / **`send-grouped-reminder-email.ts`** — Pass `htmlBody` instead of `body` in the notification payload.
- Tests updated to assert HTML output; all 95 tests pass.

All tags used (`strong`, `em`, `ul`, `li`) are within the Assembly API's `htmlBody` allowlist.

## Testing

- `yarn tsc` — clean (pre-existing errors in unrelated files on this branch)
- 95 tests pass across notification and jobs suites
- Manual: seeded 7 reminder tasks (all 6 types for one recipient + 1 for a second company) via local Supabase to validate grouped reminder email rendering end-to-end

<img width="2179" height="929" alt="image" src="https://github.com/user-attachments/assets/64eae8b6-c6ed-4bab-b422-d92746998747" />
<img width="2191" height="1017" alt="image" src="https://github.com/user-attachments/assets/7ef3c15c-e09c-4f94-b2ea-fa29fe146385" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)

