### PR TITLE
OUT-3915 | Delete entries on GroupedEmailEvents table after emails are successfully sent

### DIFF
--- a/src/jobs/notifications/flush-grouped-email.integration.test.ts
+++ b/src/jobs/notifications/flush-grouped-email.integration.test.ts
@@ -81,9 +81,9 @@ const seedEvent = async ({
   })
 }
 
-const unsentCount = async (windowKey: string): Promise<number> => {
+const totalCount = async (windowKey: string): Promise<number> => {
   const rows = await getTestDb().$queryRaw<{ count: bigint }[]>`
-    SELECT count(*) FROM "GroupedEmailEvents" WHERE "windowKey" = ${windowKey} AND "sentAt" IS NULL`
+    SELECT count(*) FROM "GroupedEmailEvents" WHERE "windowKey" = ${windowKey}`
   return Number(rows[0].count)
 }
 
@@ -99,7 +99,7 @@ beforeEach(async () => {
 afterAll(disconnectTestDb)
 
 describe('flush-grouped-email idempotency (real DB)', () => {
-  it('sends one grouped email for multiple events and marks every row as sent', async () => {
+  it('sends one grouped email for multiple events and deletes all rows on success', async () => {
     const window = 'win_multi_event'
     const taskA = await seedTask({ workspaceId: WS, assigneeId: CLIENT_A, assigneeType: 'client', companyId: COMPANY })
     const taskB = await seedTask({ workspaceId: WS, assigneeId: CLIENT_A, assigneeType: 'client', companyId: COMPANY })
@@ -120,7 +120,7 @@ describe('flush-grouped-email idempotency (real DB)', () => {
 
     expect(mockCreateNotification).toHaveBeenCalledTimes(1)
     expect(result).toMatchObject({ recipients: 1, sent: 1, sentGrouped: 1, sentIndividual: 0 })
-    expect(await unsentCount(window)).toBe(0)
+    expect(await totalCount(window)).toBe(0)
   })
 
   it('is idempotent: re-flushing a fully-sent window is a no-op', async () => {
@@ -142,8 +142,9 @@ describe('flush-grouped-email idempotency (real DB)', () => {
 
     await flushGroupedEmailRun({ workspaceId: WS, windowKey: window })
     expect(mockCreateNotification).toHaveBeenCalledTimes(1)
+    expect(await totalCount(window)).toBe(0)
 
-    // Second flush: all rows already have sentAt set — no email, skipped return.
+    // Second flush: rows were deleted — no email, skipped return.
     const result = await flushGroupedEmailRun({ workspaceId: WS, windowKey: window })
     expect(mockCreateNotification).toHaveBeenCalledTimes(1)
     expect(result).toMatchObject({ skipped: true })
@@ -169,14 +170,14 @@ describe('flush-grouped-email idempotency (real DB)', () => {
     mockCreateNotification.mockRejectedValueOnce(new Error('copilot 5xx'))
     await expect(flushGroupedEmailRun({ workspaceId: WS, windowKey: window })).rejects.toThrow('copilot 5xx')
 
-    // Rows are still unsent — retry can re-attempt.
-    expect(await unsentCount(window)).toBe(2)
+    // Failed run: rows are preserved so the retry can re-attempt.
+    expect(await totalCount(window)).toBe(2)
 
-    // Retry succeeds.
+    // Retry succeeds: rows are deleted.
     mockCreateNotification.mockResolvedValueOnce({ id: 'notif_2' })
     await flushGroupedEmailRun({ workspaceId: WS, windowKey: window })
     expect(mockCreateNotification).toHaveBeenCalledTimes(2)
-    expect(await unsentCount(window)).toBe(0)
+    expect(await totalCount(window)).toBe(0)
   })
 
   it('sends one email per recipient when the window holds events for multiple clients', async () => {
@@ -217,10 +218,10 @@ describe('flush-grouped-email idempotency (real DB)', () => {
     const recipients = mockCreateNotification.mock.calls.map((c) => c[0].recipientClientId).sort()
     expect(recipients).toEqual([CLIENT_A, CLIENT_B].sort())
     expect(result).toMatchObject({ recipients: 2, sent: 2, sentGrouped: 2, sentIndividual: 0 })
-    expect(await unsentCount(window)).toBe(0)
+    expect(await totalCount(window)).toBe(0)
   })
 
-  it('skips events for archived tasks and marks their rows sent without emailing', async () => {
+  it('skips events for archived tasks and deletes all rows on success', async () => {
     const window = 'win_archived'
     const archivedTask = await seedTask({
       workspaceId: WS,
@@ -244,11 +245,10 @@ describe('flush-grouped-email idempotency (real DB)', () => {
     // Only the live task appears in the grouped email (1 event); individual snapshot path.
     expect(mockCreateNotification).toHaveBeenCalledTimes(1)
     expect(result).toMatchObject({ sentGrouped: 0, sentIndividual: 1 })
-    // All rows are marked sent regardless of whether the task was live.
-    expect(await unsentCount(window)).toBe(0)
+    expect(await totalCount(window)).toBe(0)
   })
 
-  it('marks the recipient sent without emailing when every task in the window was archived', async () => {
+  it('deletes rows without emailing when every task in the window was archived', async () => {
     const window = 'win_all_archived'
     const archivedTask = await seedTask({
       workspaceId: WS,
@@ -263,10 +263,10 @@ describe('flush-grouped-email idempotency (real DB)', () => {
 
     expect(mockCreateNotification).not.toHaveBeenCalled()
     expect(result).toMatchObject({ sent: 0 })
-    expect(await unsentCount(window)).toBe(0)
+    expect(await totalCount(window)).toBe(0)
   })
 
-  it('marks the recipient sent without emailing when every task in the window was soft-deleted', async () => {
+  it('deletes rows without emailing when every task in the window was soft-deleted', async () => {
     const window = 'win_all_deleted'
     const deletedTask = await seedTask({
       workspaceId: WS,
@@ -281,6 +281,6 @@ describe('flush-grouped-email idempotency (real DB)', () => {
 
     expect(mockCreateNotification).not.toHaveBeenCalled()
     expect(result).toMatchObject({ sent: 0 })
-    expect(await unsentCount(window)).toBe(0)
+    expect(await totalCount(window)).toBe(0)
   })
 })

--- a/src/jobs/notifications/flush-grouped-email.test.ts
+++ b/src/jobs/notifications/flush-grouped-email.test.ts
@@ -103,7 +103,7 @@ describe('flushGroupedEmailRun', () => {
     expect(args).toMatchObject({ senderId: 'iu_1', recipientClientId: 'client_1', recipientCompanyId: 'company_1' })
     expect(args.content.totalEventCount).toBe(2)
     expect(mockCreateNotification).not.toHaveBeenCalled()
-    expect(mockExecuteRaw).toHaveBeenCalledTimes(1) // markRecipientSent
+    expect(mockExecuteRaw).toHaveBeenCalledTimes(2) // markRecipientSent + deleteWindowRows
     expect(result).toMatchObject({ recipients: 1, sent: 1, sentGrouped: 1, sentIndividual: 0 })
   })
 
@@ -116,7 +116,7 @@ describe('flushGroupedEmailRun', () => {
     expect(mockCreateNotification).toHaveBeenCalledWith(expect.objectContaining({ recipientClientId: 'client_1' }))
     expect(mockSendGroupedEmail).not.toHaveBeenCalled()
     expect(mockGetInternalUsers).not.toHaveBeenCalled() // no workspace IU needed for the individual path
-    expect(mockExecuteRaw).toHaveBeenCalledTimes(1)
+    expect(mockExecuteRaw).toHaveBeenCalledTimes(2) // markRecipientSent + deleteWindowRows
     expect(result).toMatchObject({ recipients: 1, sent: 1, sentGrouped: 0, sentIndividual: 1 })
   })
 
@@ -166,7 +166,7 @@ describe('flushGroupedEmailRun', () => {
 
     expect(mockSendGroupedEmail).not.toHaveBeenCalled()
     expect(mockCreateNotification).not.toHaveBeenCalled()
-    expect(mockExecuteRaw).toHaveBeenCalledTimes(1)
+    expect(mockExecuteRaw).toHaveBeenCalledTimes(2) // markRecipientSent + deleteWindowRows
     expect(result).toMatchObject({ sent: 0, sentGrouped: 0, sentIndividual: 0 })
   })
 
@@ -177,7 +177,7 @@ describe('flushGroupedEmailRun', () => {
 
     expect(mockCreateNotification).toHaveBeenCalledTimes(2)
     expect(mockSendGroupedEmail).not.toHaveBeenCalled()
-    expect(mockExecuteRaw).toHaveBeenCalledTimes(2)
+    expect(mockExecuteRaw).toHaveBeenCalledTimes(3) // markRecipientSent x2 + deleteWindowRows
     expect(result).toMatchObject({ recipients: 2, sent: 2, sentGrouped: 0, sentIndividual: 2 })
   })
 
@@ -191,7 +191,7 @@ describe('flushGroupedEmailRun', () => {
 
     expect(mockCreateNotification).toHaveBeenCalledTimes(2)
     expect(mockCreateNotification.mock.calls[1][0]).toMatchObject({ senderCompanyId: undefined })
-    expect(mockExecuteRaw).toHaveBeenCalledTimes(1)
+    expect(mockExecuteRaw).toHaveBeenCalledTimes(2) // markRecipientSent + deleteWindowRows
   })
 
   it('does not mark a recipient sent when their send fails (so a retry re-sends)', async () => {

--- a/src/jobs/notifications/flush-grouped-email.ts
+++ b/src/jobs/notifications/flush-grouped-email.ts
@@ -41,7 +41,7 @@ const readUnsentWindowEvents = (db: ReturnType<typeof DBClient.getInstance>, win
     WHERE "windowKey" = ${windowKey} AND "sentAt" IS NULL`
 
 const deleteWindowRows = (db: ReturnType<typeof DBClient.getInstance>, windowKey: string) =>
-  db.$executeRaw`DELETE FROM "GroupedEmailEvents" WHERE "windowKey" = ${windowKey}`
+  db.$executeRaw`DELETE FROM "GroupedEmailEvents" WHERE "windowKey" = ${windowKey} AND "sentAt" IS NOT NULL`
 
 const markRecipientSent = (
   db: ReturnType<typeof DBClient.getInstance>,

--- a/src/jobs/notifications/flush-grouped-email.ts
+++ b/src/jobs/notifications/flush-grouped-email.ts
@@ -40,6 +40,9 @@ const readUnsentWindowEvents = (db: ReturnType<typeof DBClient.getInstance>, win
     FROM "GroupedEmailEvents"
     WHERE "windowKey" = ${windowKey} AND "sentAt" IS NULL`
 
+const deleteWindowRows = (db: ReturnType<typeof DBClient.getInstance>, windowKey: string) =>
+  db.$executeRaw`DELETE FROM "GroupedEmailEvents" WHERE "windowKey" = ${windowKey}`
+
 const markRecipientSent = (
   db: ReturnType<typeof DBClient.getInstance>,
   windowKey: string,
@@ -166,6 +169,16 @@ export const flushGroupedEmailRun = async (payload: FlushGroupedEmailPayload) =>
       recipientClientId: group.recipientClientId,
       liveEvents: liveEvents.length,
       outcome: singleEmail ? ('individual' as const) : liveEvents.length >= 1 ? ('grouped' as const) : ('skipped' as const),
+    })
+  }
+
+  try {
+    await deleteWindowRows(db, windowKey)
+  } catch (err) {
+    logger.error('flush-grouped-email: window cleanup failed, rows left with sentAt set', {
+      workspaceId,
+      windowKey,
+      error: serializeError(err),
     })
   }
 


### PR DESCRIPTION
## Summary

- Adds a `DELETE FROM GroupedEmailEvents WHERE windowKey = $windowKey` at the end of `flushGroupedEmailRun`, executed only on full success
- Wrapped in try/catch so a transient delete failure logs the error without triggering an unnecessary Trigger.dev retry (rows are already marked `sentAt` so they'll never be re-sent)
- `markRecipientSent` is preserved — still needed for partial-failure retry safety mid-loop

## Why

`GroupedEmailEvents` rows serve as a 5-minute buffer and are not needed after the window is flushed. Previously they accumulated indefinitely with `sentAt` set, bulking up the table with data that was never read again.

## Behaviour

- **Success**: all rows for the window are deleted after the loop completes
- **Failure (send throws)**: exception propagates before `deleteWindowRows` is reached — rows stay intact for Trigger.dev retry
- **Delete fails**: caught, logged, run still returns successfully — rows remain with `sentAt` set (harmless, ignored by future queries)

## Test plan

- Updated integration tests to assert `totalCount === 0` (full row deletion) after successful runs rather than checking unsent count
- Retry test explicitly asserts rows survive a failed run (`totalCount === 2`) and are deleted after the successful retry (`totalCount === 0`)
- Updated stale test descriptions that referenced "marks rows as sent" to reflect deletion

🤖 Generated with [Claude Code](https://claude.com/claude-code)