### PR TITLE
OUT-3920 | Add the +N other tasks on the bullet point

### DIFF
--- a/src/app/api/notification/groupedEmail.renderer.test.ts
+++ b/src/app/api/notification/groupedEmail.renderer.test.ts
@@ -57,7 +57,7 @@ describe('renderGroupedEmail', () => {
       sections: [section({ count: 12, taskNames: ['A', 'B', 'C'], overflowCount: 9 })],
     })
 
-    expect(email.htmlBody).toContain('<em>+9 other tasks</em><br>')
+    expect(email.htmlBody).toContain('<li><em>+9 other tasks</em></li>')
   })
 
   it('singularizes the overflow line for a single other task', () => {
@@ -66,8 +66,8 @@ describe('renderGroupedEmail', () => {
       sections: [section({ count: 4, taskNames: ['A', 'B', 'C'], overflowCount: 1 })],
     })
 
-    expect(email.htmlBody).toContain('<em>+1 other task</em><br>')
-    expect(email.htmlBody).not.toContain('<em>+1 other tasks</em>')
+    expect(email.htmlBody).toContain('<li><em>+1 other task</em></li>')
+    expect(email.htmlBody).not.toContain('<li><em>+1 other tasks</em></li>')
   })
 
   it('omits overflow element when there is no overflow', () => {

--- a/src/app/api/notification/groupedEmail.renderer.ts
+++ b/src/app/api/notification/groupedEmail.renderer.ts
@@ -27,12 +27,12 @@ const sectionHeading: Record<GroupedEmailEventType, (count: number) => string> =
 }
 
 const renderSection = (section: GroupedEmailSection): string => {
-  const overflow =
+  const overflowItem =
     section.overflowCount > 0
-      ? `<em>+${section.overflowCount} other ${pluralize(section.overflowCount, 'task', 'tasks')}</em><br>`
+      ? `<li><em>+${section.overflowCount} other ${pluralize(section.overflowCount, 'task', 'tasks')}</em></li>`
       : ''
   const items = section.taskNames.map((name) => `<li>'${truncateTitle(name)}'</li>`).join('')
-  return `<strong>${sectionHeading[section.eventType](section.count)}</strong><ul>${items}</ul>${overflow}`
+  return `<strong>${sectionHeading[section.eventType](section.count)}</strong><ul>${items}${overflowItem}</ul>`
 }
 
 export const renderGroupedEmail = (content: GroupedEmailContent): GroupedEmailDetails => ({

--- a/src/app/api/notification/groupedReminderEmail.renderer.test.ts
+++ b/src/app/api/notification/groupedReminderEmail.renderer.test.ts
@@ -43,8 +43,8 @@ describe('renderGroupedReminderEmail', () => {
       { taskTitle: 'Overdue 4', reminderType: TaskReminderType.DUE_DATE_OVERDUE_3D },
     ]
     const result = renderGroupedReminderEmail(entries)
-    expect(result.htmlBody.match(/<li>/g)).toHaveLength(3)
-    expect(result.htmlBody).toContain('<em>+1 other task</em><br>')
+    expect(result.htmlBody.match(/<li>/g)).toHaveLength(4)
+    expect(result.htmlBody).toContain('<li><em>+1 other task</em></li>')
   })
 
   it('pluralizes overflow when more than 1 task is hidden', () => {
@@ -53,7 +53,7 @@ describe('renderGroupedReminderEmail', () => {
       reminderType: TaskReminderType.DUE_DATE_OVERDUE_3D,
     }))
     const result = renderGroupedReminderEmail(entries)
-    expect(result.htmlBody).toContain('<em>+2 other tasks</em><br>')
+    expect(result.htmlBody).toContain('<li><em>+2 other tasks</em></li>')
   })
 
   it('truncates task titles longer than 100 characters', () => {

--- a/src/app/api/notification/groupedReminderEmail.renderer.ts
+++ b/src/app/api/notification/groupedReminderEmail.renderer.ts
@@ -54,11 +54,11 @@ const pluralize = (n: number, singular: string, plural: string): string => (n ==
 const renderGroup = (group: UrgencyGroup, entries: ReminderEntry[]): string => {
   const shown = entries.slice(0, ITEMS_PER_GROUP)
   const overflow = entries.length - shown.length
-  const overflowHtml = overflow > 0 ? `<em>+${overflow} other ${pluralize(overflow, 'task', 'tasks')}</em><br>` : ''
+  const overflowItem = overflow > 0 ? `<li><em>+${overflow} other ${pluralize(overflow, 'task', 'tasks')}</em></li>` : ''
   const items = shown
     .map((e) => `<li>‘${truncateTitle(e.taskTitle)}’ – <em>${reminderLabel[e.reminderType]}</em></li>`)
     .join('')
-  return `<strong>${group}</strong><ul>${items}</ul>${overflowHtml}`
+  return `<strong>${group}</strong><ul>${items}${overflowItem}</ul>`
 }
 
 export const renderGroupedReminderEmail = (entries: ReminderEntry[]): GroupedReminderEmailDetails => {


### PR DESCRIPTION
## Summary
- Moves the `+N other tasks` overflow text from a bare `<em>...<br>` outside the `<ul>` into a `<li>` inside it, for both the normal grouped email and the grouped reminder email
- Both renderers now produce identical HTML structure; the overflow item renders as a bullet point in line with the task list

## Test plan
- [x] Both `groupedEmail.renderer.test.ts` and `groupedReminderEmail.renderer.test.ts` pass (28 tests)
- [x] Verify a grouped email with overflow visually shows `+N other tasks` as a bullet point, not as orphaned italic text below the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)