### PR TITLE
fix(notifications): clean up window rows in flushGroupedEmailOnFailure

### DIFF
--- a/src/jobs/notifications/flush-grouped-email.test.ts
+++ b/src/jobs/notifications/flush-grouped-email.test.ts
@@ -241,4 +241,10 @@ describe('flushGroupedEmailOnFailure', () => {
       windowKey: 'client_1:win_1',
     })
   })
+
+  it('deletes all rows for the window so orphaned events do not accumulate', async () => {
+    await flushGroupedEmailOnFailure({ payload, error: new Error('terminal') })
+
+    expect(mockExecuteRaw).toHaveBeenCalledTimes(1)
+  })
 })

--- a/src/jobs/notifications/flush-grouped-email.ts
+++ b/src/jobs/notifications/flush-grouped-email.ts
@@ -198,7 +198,21 @@ export const flushGroupedEmailRun = async (payload: FlushGroupedEmailPayload) =>
 export const flushGroupedEmailOnFailure = async ({ payload, error }: { payload: unknown; error: unknown }) => {
   const { workspaceId, windowKey } = payload as FlushGroupedEmailPayload
   Sentry.captureException(error, { tags: { job: TASK_ID, workspaceId, windowKey } })
-  logger.error('flush-grouped-email: retries exhausted', { workspaceId, windowKey, error: serializeError(error) })
+  logger.error('flush-grouped-email: retries exhausted, cleaning up window', {
+    workspaceId,
+    windowKey,
+    error: serializeError(error),
+  })
+  const db = DBClient.getInstance()
+  try {
+    await db.$executeRaw`DELETE FROM "GroupedEmailEvents" WHERE "windowKey" = ${windowKey}`
+  } catch (deleteErr) {
+    logger.error('flush-grouped-email: window cleanup on failure failed, rows are orphaned', {
+      workspaceId,
+      windowKey,
+      error: serializeError(deleteErr),
+    })
+  }
 }
 
 export const flushGroupedEmail = task({


### PR DESCRIPTION
## Summary
- When `flushGroupedEmail` exhausts all Trigger.dev retries, `flushGroupedEmailOnFailure` previously only logged to Sentry — leaving all unsent `GroupedEmailEvents` rows orphaned forever with no recovery path
- Fix: hard-delete all rows for the failed window in `onFailure`, mirroring the compensation pattern in `dispatchGroupedReminderEmailOnFailure`
- Unprocessed recipients' grouped emails are permanently lost on terminal failure, but their in-product notifications were already created at event-buffer time

## Test plan
- [ ] `flushGroupedEmailOnFailure` unit test verifies `$executeRaw` (DELETE) is called once on terminal failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)