### PR TITLE
OUT-3930 | Filter out deleted /inactive users while creating grouped email notifications when task is assigned or any such thing.

### DIFF
--- a/src/utils/CopilotAPI.ts
+++ b/src/utils/CopilotAPI.ts
@@ -209,7 +209,8 @@ export class CopilotAPI {
 
   async _getCompanyClients(companyId: string): Promise<ClientResponse[]> {
     console.info('CopilotAPI#_getCompanyClients', this.token)
-    return (await this.getClients({ limit: 10000, companyId })).data || []
+    const clients = (await this.getClients({ limit: 10000, companyId })).data || []
+    return clients.filter((c) => c.status !== 'deleted')
   }
 
   async _getCustomFields(): Promise<CustomFieldResponse> {


### PR DESCRIPTION
## Summary
- `getCompanyClients` in `CopilotAPI` now filters out clients with `status === 'deleted'` before returning
- Affects all notification paths that fan out to company members: task assigned to company, shared to company, reassigned to company, comments, reminders, and completed notifications

## Test plan
- [x] Assign a task to a company that has at least one deleted client — verify the deleted client does not receive a notification
- [x] Confirm active company members still receive notifications as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)