### PR TITLE
OUT-3925, OUT-3926 | Extend grouped email system to support IU recipients

### DIFF
--- a/src/app/api/notification/isIuEmailEnabled.ts
+++ b/src/app/api/notification/isIuEmailEnabled.ts
@@ -1,0 +1,3 @@
+import { iuEmailAlwaysEnabled } from '@/config'
+
+export const isIuEmailEnabled = (): boolean => iuEmailAlwaysEnabled

--- a/src/app/api/notification/notification.helpers.test.ts
+++ b/src/app/api/notification/notification.helpers.test.ts
@@ -1,5 +1,6 @@
+import { NotificationTaskActions } from '@api/core/types/tasks'
 import { WorkspaceResponse } from '@/types/common'
-import { getReminderEmailDetails } from './notification.helpers'
+import { getEmailDetails, getReminderEmailDetails } from './notification.helpers'
 import { TaskReminderType } from '@prisma/client'
 
 const workspace: WorkspaceResponse = {
@@ -52,4 +53,18 @@ describe('getReminderEmailDetails', () => {
       expect(result[variant].ctaParams).toEqual({ taskId: 'task_1' })
     }
   })
+})
+
+describe('getEmailDetails', () => {
+  // Actions that email an IU recipient must have a template here, or the grouped
+  // buffer silently skips them (in-product fires but no email is ever flushed).
+  it.each([NotificationTaskActions.Assigned, NotificationTaskActions.ReassignedToIU])(
+    'defines an email template for IU-recipient action %s',
+    (action) => {
+      const details = getEmailDetails(workspace, 'Arpan Two')[action]
+      expect(details).toBeDefined()
+      expect(details?.subject).toBeTruthy()
+      expect(details?.body).toBeTruthy()
+    },
+  )
 })

--- a/src/app/api/notification/notification.helpers.ts
+++ b/src/app/api/notification/notification.helpers.ts
@@ -202,6 +202,13 @@ export const getEmailDetails = (
       title: 'View task',
       ctaParams,
     },
+    [NotificationTaskActions.ReassignedToIU]: {
+      subject: 'A task was reassigned to you',
+      header: 'A task was reassigned to you',
+      title: 'View task',
+      body: `The task ‘${task?.title}’ was reassigned to you by ${actionUser}. To see details about the task open it below.`,
+      ctaParams,
+    },
     [NotificationTaskActions.ReassignedToClient]: {
       subject: 'A task was reassigned to you',
       header: 'A task was reassigned to you',

--- a/src/app/api/notification/notification.service.test.ts
+++ b/src/app/api/notification/notification.service.test.ts
@@ -8,6 +8,7 @@ const mockFindFirst = jest.fn()
 const mockFindMany = jest.fn()
 const mockClientNotifCreate = jest.fn()
 const mockClientNotifCreateMany = jest.fn()
+const mockInternalUserNotifCreate = jest.fn()
 const mockQueryRaw = jest.fn()
 const mockGroupedCreateMany = jest.fn()
 
@@ -30,6 +31,7 @@ jest.mock('@/lib/db', () => ({
         createMany: (...args: unknown[]) => mockClientNotifCreateMany(...args),
       },
       groupedEmailEvent: { createMany: (...args: unknown[]) => mockGroupedCreateMany(...args) },
+      internalUserNotification: { create: (...args: unknown[]) => mockInternalUserNotifCreate(...args) },
       $queryRaw: (...args: unknown[]) => mockQueryRaw(...args),
     }),
   },
@@ -90,6 +92,7 @@ beforeEach(() => {
   mockGroupedCreateMany.mockResolvedValue({ count: 1 })
   mockClientNotifCreate.mockResolvedValue({})
   mockClientNotifCreateMany.mockResolvedValue({ count: 1 })
+  mockInternalUserNotifCreate.mockResolvedValue({})
   mockCreateNotification.mockResolvedValue({
     id: 'notif_1',
     createdAt: '2026-06-15T10:00:00.000Z',
@@ -319,5 +322,49 @@ describe('guard: CU wiring boundaries', () => {
     await buildService().create(NotificationTaskActions.Assigned, makeTask())
     const row = mockGroupedCreateMany.mock.calls[0][0].data[0]
     expect(row.recipientIuId).toBeNull()
+  })
+})
+
+describe('guard: IU wiring boundaries', () => {
+  it('buffers an Assigned IU email with recipientIuId set and all client fields null', async () => {
+    const task = makeTask({ assigneeType: AssigneeType.internalUser, clientId: null })
+    await buildService().create(NotificationTaskActions.Assigned, task, { disableEmail: false })
+
+    expect(mockGroupedCreateMany).toHaveBeenCalledTimes(1)
+    const row = mockGroupedCreateMany.mock.calls[0][0].data[0]
+    expect(row).toMatchObject({
+      workspaceId: 'ws_1',
+      recipientIuId: task.assigneeId,
+      recipientClientId: null,
+      recipientCompanyId: null,
+      eventType: GroupedEmailEventType.ASSIGNED,
+      taskId: task.id,
+    })
+    expect(row.windowKey).toMatch(/^33333333-3333-3333-3333-333333333333:iu:/)
+    expect(mockEnqueueFlush).toHaveBeenCalledWith({ workspaceId: 'ws_1', windowKey: row.windowKey })
+
+    // individual email snapshot routes to the IU, not a client
+    expect(row.individualEmail.recipientInternalUserId).toBe(task.assigneeId)
+    expect(row.individualEmail.recipientClientId).toBeUndefined()
+  })
+
+  it('sends the in-product notification to recipientInternalUserId and strips the email target', async () => {
+    const task = makeTask({ assigneeType: AssigneeType.internalUser, clientId: null })
+    await buildService().create(NotificationTaskActions.Assigned, task, { disableEmail: false })
+
+    expect(mockCreateNotification).toHaveBeenCalledTimes(1)
+    const sent = mockCreateNotification.mock.calls[0][0]
+    expect(sent.recipientInternalUserId).toBe(task.assigneeId)
+    expect(sent.recipientClientId).toBeUndefined()
+    expect(deliveryTargetsOf(0).inProduct).toBeDefined()
+    expect(deliveryTargetsOf(0).email).toBeUndefined()
+  })
+
+  it('does not buffer when disableEmail is true for an IU task', async () => {
+    const task = makeTask({ assigneeType: AssigneeType.internalUser, clientId: null })
+    await buildService().create(NotificationTaskActions.Assigned, task, { disableEmail: true })
+
+    expect(mockGroupedCreateMany).not.toHaveBeenCalled()
+    expect(mockEnqueueFlush).not.toHaveBeenCalled()
   })
 })

--- a/src/app/api/notification/notification.service.test.ts
+++ b/src/app/api/notification/notification.service.test.ts
@@ -280,12 +280,13 @@ describe('NotificationService grouped-email interception', () => {
 })
 
 describe('guard: CU wiring boundaries', () => {
-  it('maps every CU-targeted action to the correct GroupedEmailEventType', () => {
+  it('maps every buffered action to the correct GroupedEmailEventType', () => {
     const svc = buildService() as unknown as {
       groupedEventTypeFor: (a: NotificationTaskActions) => GroupedEmailEventType | null
     }
     expect(svc.groupedEventTypeFor(NotificationTaskActions.Assigned)).toBe(GroupedEmailEventType.ASSIGNED)
     expect(svc.groupedEventTypeFor(NotificationTaskActions.AssignedToCompany)).toBe(GroupedEmailEventType.ASSIGNED)
+    expect(svc.groupedEventTypeFor(NotificationTaskActions.ReassignedToIU)).toBe(GroupedEmailEventType.ASSIGNED)
     expect(svc.groupedEventTypeFor(NotificationTaskActions.Shared)).toBe(GroupedEmailEventType.SHARED)
     expect(svc.groupedEventTypeFor(NotificationTaskActions.SharedToCompany)).toBe(GroupedEmailEventType.SHARED)
     expect(svc.groupedEventTypeFor(NotificationTaskActions.Commented)).toBe(GroupedEmailEventType.COMMENT)
@@ -298,6 +299,7 @@ describe('guard: CU wiring boundaries', () => {
     const mapped = [
       NotificationTaskActions.Assigned,
       NotificationTaskActions.AssignedToCompany,
+      NotificationTaskActions.ReassignedToIU,
       NotificationTaskActions.Shared,
       NotificationTaskActions.SharedToCompany,
       NotificationTaskActions.Commented,

--- a/src/app/api/notification/notification.service.test.ts
+++ b/src/app/api/notification/notification.service.test.ts
@@ -318,6 +318,6 @@ describe('guard: CU wiring boundaries', () => {
   it('never writes recipientIuId in a CU grouped event row', async () => {
     await buildService().create(NotificationTaskActions.Assigned, makeTask())
     const row = mockGroupedCreateMany.mock.calls[0][0].data[0]
-    expect(row.recipientIuId).toBeUndefined()
+    expect(row.recipientIuId).toBeNull()
   })
 })

--- a/src/app/api/notification/notification.service.test.ts
+++ b/src/app/api/notification/notification.service.test.ts
@@ -101,6 +101,8 @@ beforeEach(() => {
 })
 
 const deliveryTargetsOf = (call: number) => mockCreateNotification.mock.calls[call][0].deliveryTargets
+const queryRawParamsOf = (call: number) =>
+  mockQueryRaw.mock.calls[call].flatMap((arg: { values?: unknown[] }) => arg?.values ?? arg)
 
 describe('NotificationService grouped-email interception', () => {
   describe('create()', () => {
@@ -121,7 +123,7 @@ describe('NotificationService grouped-email interception', () => {
       })
       // window is scoped to the (clientId, companyId) pair, not the client alone
       expect(row.windowKey).toMatch(new RegExp(`^${task.assigneeId}:${task.companyId}:`))
-      expect(mockQueryRaw.mock.calls[0]).toContain(task.companyId)
+      expect(queryRawParamsOf(0)).toContain(task.companyId)
       expect(mockEnqueueFlush).toHaveBeenCalledWith({ workspaceId: 'ws_1', windowKey: row.windowKey })
 
       // the row snapshots the exact individual email to replay for a single-event window
@@ -156,7 +158,7 @@ describe('NotificationService grouped-email interception', () => {
       const row = mockGroupedCreateMany.mock.calls[0][0].data[0]
       expect(row.recipientCompanyId).toBe(companyB)
       expect(row.windowKey).toMatch(new RegExp(`^33333333-3333-3333-3333-333333333333:${companyB}:`))
-      expect(mockQueryRaw.mock.calls[0]).toContain(companyB)
+      expect(queryRawParamsOf(0)).toContain(companyB)
     })
 
     it('does not buffer or strip email for a non-target action (byte-for-byte)', async () => {

--- a/src/app/api/notification/notification.service.ts
+++ b/src/app/api/notification/notification.service.ts
@@ -597,6 +597,7 @@ export class NotificationService extends BaseService {
     switch (action) {
       case NotificationTaskActions.Assigned:
       case NotificationTaskActions.AssignedToCompany:
+      case NotificationTaskActions.ReassignedToIU:
         return GroupedEmailEventType.ASSIGNED
       case NotificationTaskActions.Shared:
       case NotificationTaskActions.SharedToCompany:

--- a/src/app/api/notification/notification.service.ts
+++ b/src/app/api/notification/notification.service.ts
@@ -72,9 +72,9 @@ export class NotificationService extends BaseService {
         const association = AssociationsSchema.parse(task.associations)?.[0]
         await this.bufferGroupedEmailEvent({
           task,
-          recipientClientId: isIuRecipient ? null : recipientId,
-          recipientCompanyId: isIuRecipient ? null : (task.companyId ?? association?.companyId ?? null),
-          recipientIuId: isIuRecipient ? recipientId : null,
+          ...(!isIuRecipient && { recipientClientId: recipientId }),
+          ...(!isIuRecipient && { recipientCompanyId: task.companyId ?? association?.companyId ?? undefined }),
+          ...(isIuRecipient && { recipientIuId: recipientId }),
           eventType: groupedType,
           commentId: opts.commentId,
           individualEmail: this.buildNotificationDetails(
@@ -207,7 +207,7 @@ export class NotificationService extends BaseService {
             await this.bufferGroupedEmailEvent({
               task,
               recipientClientId: recipientId,
-              recipientCompanyId: task.companyId ?? association?.companyId ?? null,
+              recipientCompanyId: task.companyId ?? association?.companyId ?? undefined,
               eventType: groupedType,
               commentId: opts?.commentId,
               individualEmail: this.buildNotificationDetails(task, senderId, recipientId, { email }, opts?.senderCompanyId),
@@ -611,9 +611,9 @@ export class NotificationService extends BaseService {
 
   private async bufferGroupedEmailEvent(args: {
     task: Task
-    recipientClientId?: string | null
-    recipientCompanyId?: string | null
-    recipientIuId?: string | null
+    recipientClientId?: string
+    recipientCompanyId?: string
+    recipientIuId?: string
     eventType: GroupedEmailEventType
     commentId?: string
     individualEmail: NotificationRequestBody

--- a/src/app/api/notification/notification.service.ts
+++ b/src/app/api/notification/notification.service.ts
@@ -55,6 +55,10 @@ export class NotificationService extends BaseService {
         action,
       )
 
+      const isIuRecipient =
+        task.assigneeType === AssigneeType.internalUser &&
+        (action === NotificationTaskActions.Assigned || action === NotificationTaskActions.ReassignedToIU)
+
       const inProduct = opts.disableInProduct
         ? undefined
         : getInProductNotificationDetails(workspace, actionUser, task, { companyName, commentId: opts?.commentId })[action]
@@ -63,21 +67,28 @@ export class NotificationService extends BaseService {
         : getEmailDetails(workspace, actionUser, task, { commentId: opts?.commentId })[action]
       const email = baseEmail ? mergeEmailOverride({ base: baseEmail, override: opts.emailOverride }) : baseEmail
 
-      // Non-null only when this CU email should be diverted into the grouped buffer.
       const groupedType = email && recipientId ? this.groupedEventTypeFor(action) : null
       if (groupedType) {
         const association = AssociationsSchema.parse(task.associations)?.[0]
         await this.bufferGroupedEmailEvent({
           task,
-          recipientClientId: recipientId,
-          recipientCompanyId: task.companyId ?? association?.companyId ?? null,
+          recipientClientId: isIuRecipient ? null : recipientId,
+          recipientCompanyId: isIuRecipient ? null : (task.companyId ?? association?.companyId ?? null),
+          recipientIuId: isIuRecipient ? recipientId : null,
           eventType: groupedType,
           commentId: opts.commentId,
-          individualEmail: this.buildNotificationDetails(task, senderId, recipientId, { email }, senderCompanyId),
+          individualEmail: this.buildNotificationDetails(
+            task,
+            senderId,
+            recipientId,
+            { email },
+            senderCompanyId,
+            isIuRecipient,
+          ),
         })
       }
 
-      // Build with the email so the recipient is routed as a client, then drop the email target
+      // Build with the email so the recipient is routed correctly, then drop the email target
       // once it has been diverted to the buffer (the in-product notification still fires now).
       const notificationDetails = this.buildNotificationDetails(
         task,
@@ -85,6 +96,7 @@ export class NotificationService extends BaseService {
         recipientId,
         { inProduct, email },
         senderCompanyId,
+        isIuRecipient,
       )
       if (groupedType) notificationDetails.deliveryTargets = { inProduct }
       if (!inProduct && !notificationDetails.deliveryTargets?.email) return
@@ -106,10 +118,7 @@ export class NotificationService extends BaseService {
       // NOTE: There are cases where task.assigneeType does not account for IU notification!
       // E.g. When receiving notifications from others completing task that IU created.
       // For now we don't have to store these so this hasn't been accounted for
-      const shouldSendIUNotification =
-        task.assigneeType === AssigneeType.internalUser &&
-        (action === NotificationTaskActions.Assigned || action === NotificationTaskActions.ReassignedToIU)
-      if (shouldSendIUNotification) {
+      if (isIuRecipient) {
         // Notification recipient is IU in this case
         await this.db.internalUserNotification.create({
           data: {
@@ -601,35 +610,49 @@ export class NotificationService extends BaseService {
 
   private async bufferGroupedEmailEvent(args: {
     task: Task
-    recipientClientId: string
-    recipientCompanyId: string | null
+    recipientClientId?: string | null
+    recipientCompanyId?: string | null
+    recipientIuId?: string | null
     eventType: GroupedEmailEventType
     commentId?: string
     individualEmail: NotificationRequestBody
   }): Promise<void> {
-    const { task, recipientClientId, recipientCompanyId, eventType, commentId, individualEmail } = args
+    const { task, recipientClientId, recipientCompanyId, recipientIuId, eventType, commentId, individualEmail } = args
+    const isIuRecipient = !!recipientIuId
 
-    const activeWindow = await this.db.$queryRaw<{ windowKey: string }[]>`
-      SELECT "windowKey" FROM "GroupedEmailEvents"
-      WHERE "workspaceId" = ${task.workspaceId}
-        AND "recipientClientId" = ${recipientClientId}::uuid
-        AND "recipientCompanyId" IS NOT DISTINCT FROM ${recipientCompanyId}::uuid
-        AND "sentAt" IS NULL
-        AND "createdAt" > now() - interval '5 minutes'
-      ORDER BY "createdAt" DESC
-      LIMIT 1`
+    const activeWindow = isIuRecipient
+      ? await this.db.$queryRaw<{ windowKey: string }[]>`
+          SELECT "windowKey" FROM "GroupedEmailEvents"
+          WHERE "workspaceId" = ${task.workspaceId}
+            AND "recipientIuId" = ${recipientIuId}::uuid
+            AND "sentAt" IS NULL
+            AND "createdAt" > now() - interval '5 minutes'
+          ORDER BY "createdAt" DESC
+          LIMIT 1`
+      : await this.db.$queryRaw<{ windowKey: string }[]>`
+          SELECT "windowKey" FROM "GroupedEmailEvents"
+          WHERE "workspaceId" = ${task.workspaceId}
+            AND "recipientClientId" = ${recipientClientId}::uuid
+            AND "recipientCompanyId" IS NOT DISTINCT FROM ${recipientCompanyId}::uuid
+            AND "sentAt" IS NULL
+            AND "createdAt" > now() - interval '5 minutes'
+          ORDER BY "createdAt" DESC
+          LIMIT 1`
 
     const isNewWindow = activeWindow.length === 0
     const windowKey = isNewWindow
-      ? `${recipientClientId}:${recipientCompanyId ?? 'none'}:${randomUUID()}`
+      ? isIuRecipient
+        ? `${recipientIuId}:iu:${randomUUID()}`
+        : `${recipientClientId}:${recipientCompanyId ?? 'none'}:${randomUUID()}`
       : activeWindow[0].windowKey
 
     await this.db.groupedEmailEvent.createMany({
       data: [
         {
           workspaceId: task.workspaceId,
-          recipientClientId,
-          recipientCompanyId,
+          recipientClientId: recipientClientId ?? null,
+          recipientCompanyId: recipientCompanyId ?? null,
+          recipientIuId: recipientIuId ?? null,
           eventType,
           taskId: task.id,
           taskTitleSnapshot: task.title,
@@ -670,8 +693,8 @@ export class NotificationService extends BaseService {
     recipientId: string,
     deliveryTargets: NotificationRequestBody['deliveryTargets'],
     senderCompanyId?: string,
+    isIuRecipient?: boolean,
   ): NotificationRequestBody {
-    // Assume client notification then change details body if IU
     const associations = AssociationsSchema.parse(task.associations)
     const association = associations?.[0]
     const notificationDetails: NotificationRequestBody = {
@@ -680,12 +703,10 @@ export class NotificationService extends BaseService {
       senderType: this.user.role,
       recipientClientId: recipientId ?? undefined,
       recipientCompanyId: task.companyId ?? association?.companyId ?? undefined,
-      // If any of the given action is not present in details obj, that type of notification is not sent
       deliveryTargets: deliveryTargets || {},
     }
-    //! Since IU's NEVER get email notifications, we send recipientCompanyId only if email is present
-    const isIU = !notificationDetails.deliveryTargets?.email
-    // In case this logic ever changes, good luck
+    // Fall back to inferring IU from absence of email for paths not yet updated (e.g. CommentToIU).
+    const isIU = isIuRecipient ?? !notificationDetails.deliveryTargets?.email
     if (isIU) {
       delete notificationDetails.recipientCompanyId
       delete notificationDetails.recipientClientId

--- a/src/app/api/notification/notification.service.ts
+++ b/src/app/api/notification/notification.service.ts
@@ -55,7 +55,7 @@ export class NotificationService extends BaseService {
         action,
       )
 
-      const isIuRecipient =
+      const isAssignedToIu =
         task.assigneeType === AssigneeType.internalUser &&
         (action === NotificationTaskActions.Assigned || action === NotificationTaskActions.ReassignedToIU)
 
@@ -72,9 +72,9 @@ export class NotificationService extends BaseService {
         const association = AssociationsSchema.parse(task.associations)?.[0]
         await this.bufferGroupedEmailEvent({
           task,
-          ...(!isIuRecipient && { recipientClientId: recipientId }),
-          ...(!isIuRecipient && { recipientCompanyId: task.companyId ?? association?.companyId ?? undefined }),
-          ...(isIuRecipient && { recipientIuId: recipientId }),
+          recipientId,
+          companyId: task.companyId ?? association?.companyId ?? undefined,
+          isRecipientIu: isAssignedToIu,
           eventType: groupedType,
           commentId: opts.commentId,
           individualEmail: this.buildNotificationDetails(
@@ -83,7 +83,7 @@ export class NotificationService extends BaseService {
             recipientId,
             { email },
             senderCompanyId,
-            isIuRecipient,
+            isAssignedToIu,
           ),
         })
       }
@@ -96,7 +96,7 @@ export class NotificationService extends BaseService {
         recipientId,
         { inProduct, email },
         senderCompanyId,
-        isIuRecipient,
+        isAssignedToIu,
       )
       if (groupedType) notificationDetails.deliveryTargets = { inProduct }
       if (!inProduct && !notificationDetails.deliveryTargets?.email) return
@@ -118,7 +118,7 @@ export class NotificationService extends BaseService {
       // NOTE: There are cases where task.assigneeType does not account for IU notification!
       // E.g. When receiving notifications from others completing task that IU created.
       // For now we don't have to store these so this hasn't been accounted for
-      if (isIuRecipient) {
+      if (isAssignedToIu) {
         // Notification recipient is IU in this case
         await this.db.internalUserNotification.create({
           data: {
@@ -206,8 +206,8 @@ export class NotificationService extends BaseService {
           if (groupedType) {
             await this.bufferGroupedEmailEvent({
               task,
-              recipientClientId: recipientId,
-              recipientCompanyId: task.companyId ?? association?.companyId ?? undefined,
+              recipientId,
+              companyId: task.companyId ?? association?.companyId ?? undefined,
               eventType: groupedType,
               commentId: opts?.commentId,
               individualEmail: this.buildNotificationDetails(task, senderId, recipientId, { email }, opts?.senderCompanyId),
@@ -611,49 +611,41 @@ export class NotificationService extends BaseService {
 
   private async bufferGroupedEmailEvent(args: {
     task: Task
-    recipientClientId?: string
-    recipientCompanyId?: string
-    recipientIuId?: string
+    recipientId: string
+    companyId?: string
+    isRecipientIu?: boolean
     eventType: GroupedEmailEventType
     commentId?: string
     individualEmail: NotificationRequestBody
   }): Promise<void> {
-    const { task, recipientClientId, recipientCompanyId, recipientIuId, eventType, commentId, individualEmail } = args
-    const isIuRecipient = !!recipientIuId
+    const { task, recipientId, companyId, isRecipientIu, eventType, commentId, individualEmail } = args
 
-    const activeWindow = isIuRecipient
-      ? await this.db.$queryRaw<{ windowKey: string }[]>`
-          SELECT "windowKey" FROM "GroupedEmailEvents"
-          WHERE "workspaceId" = ${task.workspaceId}
-            AND "recipientIuId" = ${recipientIuId}::uuid
-            AND "sentAt" IS NULL
-            AND "createdAt" > now() - interval '5 minutes'
-          ORDER BY "createdAt" DESC
-          LIMIT 1`
-      : await this.db.$queryRaw<{ windowKey: string }[]>`
-          SELECT "windowKey" FROM "GroupedEmailEvents"
-          WHERE "workspaceId" = ${task.workspaceId}
-            AND "recipientClientId" = ${recipientClientId}::uuid
-            AND "recipientCompanyId" IS NOT DISTINCT FROM ${recipientCompanyId}::uuid
-            AND "sentAt" IS NULL
-            AND "createdAt" > now() - interval '5 minutes'
-          ORDER BY "createdAt" DESC
-          LIMIT 1`
+    const recipientFilter = isRecipientIu
+      ? Prisma.sql`"recipientIuId" = ${recipientId}::uuid`
+      : Prisma.sql`"recipientClientId" = ${recipientId}::uuid AND "recipientCompanyId" IS NOT DISTINCT FROM ${companyId ?? null}::uuid`
+    const activeWindow = await this.db.$queryRaw<{ windowKey: string }[]>`
+        SELECT "windowKey" FROM "GroupedEmailEvents"
+        WHERE "workspaceId" = ${task.workspaceId}
+          AND ${recipientFilter}
+          AND "sentAt" IS NULL
+          AND "createdAt" > now() - interval '5 minutes'
+        ORDER BY "createdAt" DESC
+        LIMIT 1`
 
     const isNewWindow = activeWindow.length === 0
     const windowKey = isNewWindow
-      ? isIuRecipient
-        ? `${recipientIuId}:iu:${randomUUID()}`
-        : `${recipientClientId}:${recipientCompanyId ?? 'none'}:${randomUUID()}`
+      ? isRecipientIu
+        ? `${recipientId}:iu:${randomUUID()}`
+        : `${recipientId}:${companyId ?? 'none'}:${randomUUID()}`
       : activeWindow[0].windowKey
 
     await this.db.groupedEmailEvent.createMany({
       data: [
         {
           workspaceId: task.workspaceId,
-          recipientClientId: recipientClientId ?? null,
-          recipientCompanyId: recipientCompanyId ?? null,
-          recipientIuId: recipientIuId ?? null,
+          recipientClientId: isRecipientIu ? null : recipientId,
+          recipientCompanyId: isRecipientIu ? null : (companyId ?? null),
+          recipientIuId: isRecipientIu ? recipientId : null,
           eventType,
           taskId: task.id,
           taskTitleSnapshot: task.title,
@@ -694,7 +686,7 @@ export class NotificationService extends BaseService {
     recipientId: string,
     deliveryTargets: NotificationRequestBody['deliveryTargets'],
     senderCompanyId?: string,
-    isIuRecipient?: boolean,
+    isRecipientIu?: boolean,
   ): NotificationRequestBody {
     const associations = AssociationsSchema.parse(task.associations)
     const association = associations?.[0]
@@ -707,7 +699,7 @@ export class NotificationService extends BaseService {
       deliveryTargets: deliveryTargets || {},
     }
     // Fall back to inferring IU from absence of email for paths not yet updated (e.g. CommentToIU).
-    const isIU = isIuRecipient ?? !notificationDetails.deliveryTargets?.email
+    const isIU = isRecipientIu ?? !notificationDetails.deliveryTargets?.email
     if (isIU) {
       delete notificationDetails.recipientCompanyId
       delete notificationDetails.recipientClientId

--- a/src/app/api/tasks/task-notifications.service.ts
+++ b/src/app/api/tasks/task-notifications.service.ts
@@ -6,6 +6,7 @@ import { CopilotAPI } from '@/utils/CopilotAPI'
 import User from '@api/core/models/User.model'
 import { BaseService } from '@api/core/services/base.service'
 import { NotificationTaskActions } from '@api/core/types/tasks'
+import { isIuEmailEnabled } from '@api/notification/isIuEmailEnabled'
 import { NotificationService } from '@api/notification/notification.service'
 import { AssigneeType, StateType, Task, WorkflowState } from '@prisma/client'
 import { z } from 'zod'
@@ -484,7 +485,7 @@ export class TaskNotificationsService extends BaseService {
       // In future when reassignment is supported, change this logic to support reassigned to client as well
       notificationType,
       task,
-      { disableEmail: task.assigneeType === AssigneeType.internalUser, emailOverride },
+      { disableEmail: task.assigneeType === AssigneeType.internalUser && !isIuEmailEnabled(), emailOverride },
     )
     // Create a new entry in ClientNotifications table so we can mark as read on
     // behalf of client later

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -53,6 +53,9 @@ export const assemblyApiDomain = z.string().url().parse(process.env.NEXT_PUBLIC_
 // Substring stripped from the task title when building the reminder email subject for
 // subject-override workspaces, and the value it's replaced with. Configured via env so the
 // workspace-specific phrasing isn't hardcoded (OUT-3919).
+// Bypasses the platform preference check while OUT-3929 is pending. Set true in dev/staging.
+export const iuEmailAlwaysEnabled = process.env.IU_EMAIL_ALWAYS_ENABLED === 'true'
+
 export const reminderSubjectSearch = process.env.REMINDER_SUBJECT_SEARCH || ''
 export const reminderSubjectReplacement = process.env.REMINDER_SUBJECT_REPLACEMENT || ''
 

--- a/src/jobs/notifications/flush-grouped-email.test.ts
+++ b/src/jobs/notifications/flush-grouped-email.test.ts
@@ -100,11 +100,36 @@ describe('flushGroupedEmailRun', () => {
 
     expect(mockSendGroupedEmail).toHaveBeenCalledTimes(1)
     const args = mockSendGroupedEmail.mock.calls[0][0]
-    expect(args).toMatchObject({ senderId: 'iu_1', recipientClientId: 'client_1', recipientCompanyId: 'company_1' })
+    // Sender is the real actor from the buffered event, not an arbitrary workspace IU.
+    expect(args).toMatchObject({ senderId: 'actor_1', recipientClientId: 'client_1', recipientCompanyId: 'company_1' })
+    expect(mockGetInternalUsers).not.toHaveBeenCalled()
     expect(args.content.totalEventCount).toBe(2)
     expect(mockCreateNotification).not.toHaveBeenCalled()
     expect(mockExecuteRaw).toHaveBeenCalledTimes(2) // markRecipientSent + deleteWindowRows
     expect(result).toMatchObject({ recipients: 1, sent: 1, sentGrouped: 1, sentIndividual: 0 })
+  })
+
+  it('sends an IU grouped summary from the real actor, not an arbitrary workspace IU', async () => {
+    const iuRow = () =>
+      row({
+        recipientClientId: null,
+        recipientCompanyId: null,
+        recipientIuId: 'iu_recipient',
+        individualEmail: {
+          senderId: 'actor_1',
+          recipientInternalUserId: 'iu_recipient',
+          deliveryTargets: { email: { subject: 'A task' } },
+        },
+      })
+    mockQueryRaw.mockResolvedValue([iuRow(), iuRow()])
+
+    const result = await flushGroupedEmailRun(payload)
+
+    expect(mockSendGroupedEmail).toHaveBeenCalledTimes(1)
+    const args = mockSendGroupedEmail.mock.calls[0][0]
+    expect(args).toMatchObject({ senderId: 'actor_1', recipientInternalUserId: 'iu_recipient' })
+    expect(mockGetInternalUsers).not.toHaveBeenCalled()
+    expect(result).toMatchObject({ recipients: 1, sent: 1, sentGrouped: 1 })
   })
 
   it('replays the original individual email when the window has a single live event', async () => {
@@ -202,8 +227,9 @@ describe('flushGroupedEmailRun', () => {
     expect(mockExecuteRaw).not.toHaveBeenCalled()
   })
 
-  it('throws when a grouped window has no internal user to send as', async () => {
-    mockQueryRaw.mockResolvedValue([row(), row()])
+  it('throws when a grouped window has no buffered sender and no workspace internal user', async () => {
+    // Pre-migration rows carry no individualEmail, so the sender falls back to a workspace IU.
+    mockQueryRaw.mockResolvedValue([row({ individualEmail: null }), row({ individualEmail: null })])
     mockGetInternalUsers.mockResolvedValue({ data: [] })
 
     await expect(flushGroupedEmailRun(payload)).rejects.toThrow('no internal user')

--- a/src/jobs/notifications/flush-grouped-email.ts
+++ b/src/jobs/notifications/flush-grouped-email.ts
@@ -76,6 +76,11 @@ const resolveSenderId = async (copilot: CopilotAPI): Promise<string> => {
   return senderId
 }
 
+// Copilot only emails an IU recipient when the sender is a real participant, so attribute the
+// grouped summary to the actual actor from the buffered events, not an arbitrary workspace IU.
+const senderFromEvents = (events: WindowEvent[]): string | undefined =>
+  events.map((e) => e.individualEmail?.senderId).find((id): id is string => Boolean(id))
+
 const sendIndividualEmail = async (copilot: CopilotAPI, payload: NotificationRequestBody): Promise<void> => {
   try {
     await copilot.createNotification(payload)
@@ -180,10 +185,10 @@ export const flushGroupedEmailRun = async (payload: FlushGroupedEmailPayload) =>
       sent += 1
       sentIndividual += 1
     } else if (liveEvents.length >= 1) {
-      senderId ??= await resolveSenderId(copilot)
+      const groupSenderId = senderFromEvents(liveEvents) ?? (senderId ??= await resolveSenderId(copilot))
       await sendGroupedEmail({
         content: composeGroupedEmail(liveEvents),
-        senderId,
+        senderId: groupSenderId,
         recipientClientId: group.recipientClientId,
         recipientCompanyId: group.recipientCompanyId,
         copilot,
@@ -217,10 +222,10 @@ export const flushGroupedEmailRun = async (payload: FlushGroupedEmailPayload) =>
       sent += 1
       sentIndividual += 1
     } else if (liveEvents.length >= 1) {
-      senderId ??= await resolveSenderId(copilot)
+      const groupSenderId = senderFromEvents(liveEvents) ?? (senderId ??= await resolveSenderId(copilot))
       await sendGroupedEmail({
         content: composeGroupedEmail(liveEvents),
-        senderId,
+        senderId: groupSenderId,
         recipientInternalUserId: group.recipientIuId,
         copilot,
       })

--- a/src/jobs/notifications/flush-grouped-email.ts
+++ b/src/jobs/notifications/flush-grouped-email.ts
@@ -24,11 +24,17 @@ type WindowEvent = GroupedEmailEventInput & { individualEmail: NotificationReque
 type BufferedRow = WindowEvent & {
   recipientClientId: string | null
   recipientCompanyId: string | null
+  recipientIuId: string | null
 }
 
-type RecipientGroup = {
+type CuRecipientGroup = {
   recipientClientId: string
   recipientCompanyId: string | null
+  events: WindowEvent[]
+}
+
+type IuRecipientGroup = {
+  recipientIuId: string
   events: WindowEvent[]
 }
 
@@ -36,14 +42,14 @@ const TASK_ID = 'flush-grouped-email'
 
 const readUnsentWindowEvents = (db: ReturnType<typeof DBClient.getInstance>, windowKey: string) =>
   db.$queryRaw<BufferedRow[]>`
-    SELECT "eventType", "taskId", "taskTitleSnapshot", "createdAt", "recipientClientId", "recipientCompanyId", "individualEmail"
+    SELECT "eventType", "taskId", "taskTitleSnapshot", "createdAt", "recipientClientId", "recipientCompanyId", "recipientIuId", "individualEmail"
     FROM "GroupedEmailEvents"
     WHERE "windowKey" = ${windowKey} AND "sentAt" IS NULL`
 
 const deleteWindowRows = (db: ReturnType<typeof DBClient.getInstance>, windowKey: string) =>
   db.$executeRaw`DELETE FROM "GroupedEmailEvents" WHERE "windowKey" = ${windowKey} AND "sentAt" IS NOT NULL`
 
-const markRecipientSent = (
+const markCuRecipientSent = (
   db: ReturnType<typeof DBClient.getInstance>,
   windowKey: string,
   recipientClientId: string,
@@ -52,6 +58,16 @@ const markRecipientSent = (
   db.$executeRaw`
     UPDATE "GroupedEmailEvents" SET "sentAt" = now(), "batchId" = ${batchId}::uuid
     WHERE "windowKey" = ${windowKey} AND "recipientClientId" = ${recipientClientId}::uuid AND "sentAt" IS NULL`
+
+const markIuRecipientSent = (
+  db: ReturnType<typeof DBClient.getInstance>,
+  windowKey: string,
+  recipientIuId: string,
+  batchId: string,
+) =>
+  db.$executeRaw`
+    UPDATE "GroupedEmailEvents" SET "sentAt" = now(), "batchId" = ${batchId}::uuid
+    WHERE "windowKey" = ${windowKey} AND "recipientIuId" = ${recipientIuId}::uuid AND "sentAt" IS NULL`
 
 const resolveSenderId = async (copilot: CopilotAPI): Promise<string> => {
   const { data } = await copilot.getInternalUsers({ limit: 1 })
@@ -81,25 +97,37 @@ const getLiveTaskIds = async (db: ReturnType<typeof DBClient.getInstance>, taskI
   return new Set(live.map((t) => t.id))
 }
 
-const groupByRecipient = (rows: BufferedRow[]): RecipientGroup[] => {
-  const groups = new Map<string, RecipientGroup>()
+const toWindowEvent = (row: BufferedRow): WindowEvent => ({
+  eventType: row.eventType,
+  taskId: row.taskId,
+  taskTitleSnapshot: row.taskTitleSnapshot,
+  createdAt: row.createdAt,
+  individualEmail: row.individualEmail,
+})
+
+const groupCuRecipients = (rows: BufferedRow[]): CuRecipientGroup[] => {
+  const groups = new Map<string, CuRecipientGroup>()
   for (const row of rows) {
     if (!row.recipientClientId) continue
     const group = groups.get(row.recipientClientId)
-    const event: WindowEvent = {
-      eventType: row.eventType,
-      taskId: row.taskId,
-      taskTitleSnapshot: row.taskTitleSnapshot,
-      createdAt: row.createdAt,
-      individualEmail: row.individualEmail,
-    }
-    if (group) group.events.push(event)
+    if (group) group.events.push(toWindowEvent(row))
     else
       groups.set(row.recipientClientId, {
         recipientClientId: row.recipientClientId,
         recipientCompanyId: row.recipientCompanyId,
-        events: [event],
+        events: [toWindowEvent(row)],
       })
+  }
+  return [...groups.values()]
+}
+
+const groupIuRecipients = (rows: BufferedRow[]): IuRecipientGroup[] => {
+  const groups = new Map<string, IuRecipientGroup>()
+  for (const row of rows) {
+    if (!row.recipientIuId) continue
+    const group = groups.get(row.recipientIuId)
+    if (group) group.events.push(toWindowEvent(row))
+    else groups.set(row.recipientIuId, { recipientIuId: row.recipientIuId, events: [toWindowEvent(row)] })
   }
   return [...groups.values()]
 }
@@ -120,20 +148,22 @@ export const flushGroupedEmailRun = async (payload: FlushGroupedEmailPayload) =>
   const liveTaskIds = await getLiveTaskIds(db, [...new Set(rows.map((r) => r.taskId))])
   const skippedDeletedTasks = rows.length - rows.filter((r) => liveTaskIds.has(r.taskId)).length
 
-  const groups = groupByRecipient(rows)
+  const cuGroups = groupCuRecipients(rows)
+  const iuGroups = groupIuRecipients(rows)
   logger.log('flush-grouped-email: starting', {
     workspaceId,
     windowKey,
     bufferedEvents: rows.length,
     skippedDeletedTasks,
-    recipients: groups.length,
+    recipients: cuGroups.length + iuGroups.length,
   })
 
   let sent = 0
   let sentGrouped = 0
   let sentIndividual = 0
   let senderId: string | undefined // resolved lazily — only the grouped branch needs a workspace IU
-  for (const group of groups) {
+
+  for (const group of cuGroups) {
     const liveEvents = group.events.filter((e) => liveTaskIds.has(e.taskId))
     // A single event reads awkwardly as a "summary" — replay the original individual email verbatim.
     // Pre-migration rows have no snapshot; fall back to the grouped summary rather than crash.
@@ -141,7 +171,7 @@ export const flushGroupedEmailRun = async (payload: FlushGroupedEmailPayload) =>
 
     Sentry.addBreadcrumb({
       category: 'flush-grouped-email',
-      message: `recipient ${group.recipientClientId}`,
+      message: `cu recipient ${group.recipientClientId}`,
       data: { workspaceId, windowKey, recipientClientId: group.recipientClientId, liveEvents: liveEvents.length },
     })
 
@@ -162,11 +192,47 @@ export const flushGroupedEmailRun = async (payload: FlushGroupedEmailPayload) =>
       sentGrouped += 1
     }
 
-    await markRecipientSent(db, windowKey, group.recipientClientId, batchId)
+    await markCuRecipientSent(db, windowKey, group.recipientClientId, batchId)
     logger.log('flush-grouped-email: recipient processed', {
       workspaceId,
       windowKey,
       recipientClientId: group.recipientClientId,
+      liveEvents: liveEvents.length,
+      outcome: singleEmail ? ('individual' as const) : liveEvents.length >= 1 ? ('grouped' as const) : ('skipped' as const),
+    })
+  }
+
+  for (const group of iuGroups) {
+    const liveEvents = group.events.filter((e) => liveTaskIds.has(e.taskId))
+    const singleEmail = liveEvents.length === 1 ? liveEvents[0].individualEmail : null
+
+    Sentry.addBreadcrumb({
+      category: 'flush-grouped-email',
+      message: `iu recipient ${group.recipientIuId}`,
+      data: { workspaceId, windowKey, recipientIuId: group.recipientIuId, liveEvents: liveEvents.length },
+    })
+
+    if (singleEmail) {
+      await sendIndividualEmail(copilot, singleEmail)
+      sent += 1
+      sentIndividual += 1
+    } else if (liveEvents.length >= 1) {
+      senderId ??= await resolveSenderId(copilot)
+      await sendGroupedEmail({
+        content: composeGroupedEmail(liveEvents),
+        senderId,
+        recipientInternalUserId: group.recipientIuId,
+        copilot,
+      })
+      sent += 1
+      sentGrouped += 1
+    }
+
+    await markIuRecipientSent(db, windowKey, group.recipientIuId, batchId)
+    logger.log('flush-grouped-email: recipient processed', {
+      workspaceId,
+      windowKey,
+      recipientIuId: group.recipientIuId,
       liveEvents: liveEvents.length,
       outcome: singleEmail ? ('individual' as const) : liveEvents.length >= 1 ? ('grouped' as const) : ('skipped' as const),
     })
@@ -185,14 +251,14 @@ export const flushGroupedEmailRun = async (payload: FlushGroupedEmailPayload) =>
   logger.log('flush-grouped-email: run summary', {
     workspaceId,
     windowKey,
-    recipients: groups.length,
+    recipients: cuGroups.length + iuGroups.length,
     sent,
     sentGrouped,
     sentIndividual,
     bufferedEvents: rows.length,
     skippedDeletedTasks,
   })
-  return { windowKey, recipients: groups.length, sent, sentGrouped, sentIndividual }
+  return { windowKey, recipients: cuGroups.length + iuGroups.length, sent, sentGrouped, sentIndividual }
 }
 
 export const flushGroupedEmailOnFailure = async ({ payload, error }: { payload: unknown; error: unknown }) => {

--- a/src/jobs/notifications/send-grouped-email.ts
+++ b/src/jobs/notifications/send-grouped-email.ts
@@ -8,8 +8,9 @@ import { CopilotAPI } from '@/utils/CopilotAPI'
 export type SendGroupedEmailArgs = {
   content: GroupedEmailContent
   senderId: string
-  recipientClientId: string
-  recipientCompanyId: string | null
+  recipientClientId?: string | null
+  recipientCompanyId?: string | null
+  recipientInternalUserId?: string | null
   copilot: CopilotAPI
 }
 
@@ -18,6 +19,7 @@ export const sendGroupedEmail = async ({
   senderId,
   recipientClientId,
   recipientCompanyId,
+  recipientInternalUserId,
   copilot,
 }: SendGroupedEmailArgs): Promise<string> => {
   const email = renderGroupedEmail(content)
@@ -25,8 +27,9 @@ export const sendGroupedEmail = async ({
   const payload: NotificationRequestBody = {
     senderId,
     senderType: 'internalUser',
-    recipientClientId,
+    recipientClientId: recipientClientId ?? undefined,
     recipientCompanyId: recipientCompanyId ?? undefined,
+    recipientInternalUserId: recipientInternalUserId ?? undefined,
     deliveryTargets: {
       email: {
         subject: email.subject,


### PR DESCRIPTION
## Summary

- Wires `recipientIuId` into `bufferGroupedEmailEvent` with a separate window query and IU-specific window key format (`{iuId}:iu:{uuid}`) to avoid collisions with CU keys
- Teaches `flushGroupedEmail` to group and flush IU buffer rows, sending to `recipientInternalUserId` in the Copilot notification payload
- Adds `isIuEmailEnabled()` stub backed by `IU_EMAIL_ALWAYS_ENABLED` env var so IU emails can be tested locally before OUT-3929 (platform preference flag) ships
- Removes the hard `disableEmail` block for IU assignees in `sendUserTaskNotification`, gating it on `isIuEmailEnabled()` instead
- Fixes `buildNotificationDetails` to accept an explicit `isIuRecipient` flag so the payload correctly sets `recipientInternalUserId` (the old inference from absence-of-email breaks once IUs have email)

## Test plan

- [x] Set `IU_EMAIL_ALWAYS_ENABLED=true` in `.env.local`
- [x] Assign a task to an IU — confirm a `GroupedEmailEvents` row is written with `recipientIuId` set and `recipientClientId` null
- [x] Wait 5 minutes (or trigger `flushGroupedEmail` manually) — confirm the email is sent to the IU via `recipientInternalUserId`
- [x] Assign multiple tasks to the same IU within 5 minutes — confirm a single grouped summary email is sent
- [x] Assign a task to a CU — confirm existing CU grouped email behaviour is unchanged
- [x] With `IU_EMAIL_ALWAYS_ENABLED` unset — confirm no IU emails are sent (prod-safe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)