### PR TITLE
Warn on known Prisma errors instead of silencing them

### DIFF
--- a/src/app/api/core/utils/withErrorHandler.ts
+++ b/src/app/api/core/utils/withErrorHandler.ts
@@ -75,12 +75,15 @@ const normalizeError = (error: unknown): ErrorResponse => {
   return defaultResponse
 }
 
+const isExpectedPrismaError = (error: unknown) =>
+  error instanceof PrismaClientKnownRequestError && getPrismaKnownRequestErrorResponse(error) !== null
+
 const isExpectedClientError = (error: unknown) => {
   return (
     error instanceof ZodError ||
     error instanceof CopilotApiError ||
     error instanceof APIError ||
-    (error instanceof PrismaClientKnownRequestError && getPrismaKnownRequestErrorResponse(error) !== null)
+    isExpectedPrismaError(error)
   )
 }
 
@@ -120,6 +123,10 @@ export const withErrorHandler = (handler: RequestHandler): RequestHandler => {
 
       if (shouldLogError(error, response)) {
         console.error(error instanceof ZodError ? error.format() : error)
+      } else if (isExpectedPrismaError(error)) {
+        // Keep a breadcrumb for mapped Prisma errors (e.g. P2025) without alerting Sentry —
+        // a nested-write failure can still signal a real data-integrity issue worth seeing.
+        console.warn(error)
       }
 
       return NextResponse.json({ error: response.message, errors: response.errors }, { status: response.status })

--- a/src/app/api/core/utils/withErrorHandler.ts
+++ b/src/app/api/core/utils/withErrorHandler.ts
@@ -120,10 +120,11 @@ export const withErrorHandler = (handler: RequestHandler): RequestHandler => {
       return await handler(req, params)
     } catch (error: unknown) {
       const response = normalizeError(error)
+      const expectedPrismaError = isExpectedPrismaError(error)
 
       if (shouldLogError(error, response)) {
         console.error(error instanceof ZodError ? error.format() : error)
-      } else if (isExpectedPrismaError(error)) {
+      } else if (expectedPrismaError) {
         // Keep a breadcrumb for mapped Prisma errors (e.g. P2025) without alerting Sentry —
         // a nested-write failure can still signal a real data-integrity issue worth seeing.
         console.warn(error)

--- a/src/app/api/tests/utils/withErrorHandler.test.ts
+++ b/src/app/api/tests/utils/withErrorHandler.test.ts
@@ -18,6 +18,7 @@ describe('withErrorHandler util', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     jest.spyOn(console, 'error').mockImplementation()
+    jest.spyOn(console, 'warn').mockImplementation()
     req = buildNextRequest(`/?token=iu-token`)
   })
 
@@ -62,12 +63,13 @@ describe('withErrorHandler util', () => {
     expect(console.error).not.toHaveBeenCalled()
   })
 
-  it('maps Prisma not-found errors to 404 without logging', async () => {
+  it('maps Prisma not-found errors to 404 and warns instead of erroring', async () => {
+    const error = new PrismaClientKnownRequestError('Record not found', {
+      code: 'P2025',
+      clientVersion: '5.19.0',
+    })
     const handler = async (_req: NextRequest, _params: any) => {
-      throw new PrismaClientKnownRequestError('Record not found', {
-        code: 'P2025',
-        clientVersion: '5.19.0',
-      })
+      throw error
     }
 
     const nextResponse = await withErrorHandler(handler)(req, null)
@@ -75,15 +77,17 @@ describe('withErrorHandler util', () => {
     expect(response.error).toBe('The requested resource was not found')
     expect(nextResponse.status).toBe(httpStatus.NOT_FOUND)
     expect(console.error).not.toHaveBeenCalled()
+    expect(console.warn).toHaveBeenCalledWith(error)
   })
 
-  it('maps Prisma invalid UUID errors to 404 without logging', async () => {
+  it('maps Prisma invalid UUID errors to 404 and warns instead of erroring', async () => {
+    const error = new PrismaClientKnownRequestError('Malformed UUID', {
+      code: 'P2023',
+      clientVersion: '5.19.0',
+      meta: { message: 'Inconsistent column data: Error creating UUID, invalid character' },
+    })
     const handler = async (_req: NextRequest, _params: any) => {
-      throw new PrismaClientKnownRequestError('Malformed UUID', {
-        code: 'P2023',
-        clientVersion: '5.19.0',
-        meta: { message: 'Inconsistent column data: Error creating UUID, invalid character' },
-      })
+      throw error
     }
 
     const nextResponse = await withErrorHandler(handler)(req, null)
@@ -91,6 +95,7 @@ describe('withErrorHandler util', () => {
     expect(response.error).toBe('The requested resource was not found')
     expect(nextResponse.status).toBe(httpStatus.NOT_FOUND)
     expect(console.error).not.toHaveBeenCalled()
+    expect(console.warn).toHaveBeenCalledWith(error)
   })
 
   it('logs non-UUID Prisma P2023 errors instead of hiding them as 404', async () => {
@@ -110,13 +115,14 @@ describe('withErrorHandler util', () => {
     expect(console.error).toHaveBeenCalledWith(error)
   })
 
-  it('maps raw query invalid UUID errors to 404 without logging', async () => {
+  it('maps raw query invalid UUID errors to 404 and warns instead of erroring', async () => {
+    const error = new PrismaClientKnownRequestError('Raw query failed', {
+      code: 'P2010',
+      clientVersion: '5.19.0',
+      meta: { code: '22P02' },
+    })
     const handler = async (_req: NextRequest, _params: any) => {
-      throw new PrismaClientKnownRequestError('Raw query failed', {
-        code: 'P2010',
-        clientVersion: '5.19.0',
-        meta: { code: '22P02' },
-      })
+      throw error
     }
 
     const nextResponse = await withErrorHandler(handler)(req, null)
@@ -124,6 +130,7 @@ describe('withErrorHandler util', () => {
     expect(response.error).toBe('The requested resource was not found')
     expect(nextResponse.status).toBe(httpStatus.NOT_FOUND)
     expect(console.error).not.toHaveBeenCalled()
+    expect(console.warn).toHaveBeenCalledWith(error)
   })
 
   it('logs unclassified Prisma known request errors', async () => {


### PR DESCRIPTION
## What

Follow-up to #1367 addressing Greptile's concern that blanket suppression of known Prisma errors could hide real data-integrity issues.

Mapped Prisma errors (`P2025`, invalid-UUID `P2023`/`P2010`) now log via `console.warn` instead of being fully silenced. The response is unchanged (still 404) — only logging changes.

## Why

The original suppression in #1367 stopped these from hitting Sentry (good — they're mostly client-supplied bad IDs and genuine not-founds). But `P2025` is also thrown during nested `connect`/`update` writes when a related record is missing, which can indicate a stale/incorrect FK — a real bug you'd want visibility on.

`console.warn` threads the needle: keeps a breadcrumb in Vercel logs at a lower severity than `console.error` (so it doesn't trip Sentry's error alerting) without silencing it entirely.

## Log tiers after this change

- **5xx / unexpected errors** → `console.error` (alerts Sentry)
- **Mapped Prisma errors** (P2025 / invalid UUID) → `console.warn` (breadcrumb only) ← new
- **Zod / Copilot / APIError** → still silent (genuine client-input errors, no data-integrity signal)

## Also

- Extracted `isExpectedPrismaError`, reused in `isExpectedClientError` — removes the double `getPrismaKnownRequestErrorResponse` call Greptile flagged.
- Updated the three mapped-Prisma tests to assert the new `console.warn` breadcrumb.

## Notes

Worth confirming separately whether `console.error` is actually the path to Sentry — `sentry.server.config.ts` has no `captureConsoleIntegration`, so suppression may rely on Vercel log drains. Doesn't affect the correctness of this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)