### PR TITLE
OUT-3964 | Tasks App - Task(s) Created Using Template Not Saving

### DIFF
--- a/src/app/api/tasks/public/public.service.ts
+++ b/src/app/api/tasks/public/public.service.ts
@@ -273,9 +273,13 @@ export class PublicTasksService extends TasksSharedService {
 
       if (template.subTaskTemplates.length) {
         await runInBatches(template.subTaskTemplates, subtaskTemplateBatchSize, async (sub, index) => {
-          const updatedSubTemplate = await templateService.getAppliedTemplateDescription(sub.id)
-          const manualTimeStamp = new Date(template.createdAt.getTime() + (template.subTaskTemplates.length - index) * 10) //maintain the order of subtasks in tasks with respect to subtasks in templates
-          await this.createSubtasksFromTemplate(updatedSubTemplate, newTask, manualTimeStamp)
+          const manualTimestamp = new Date(template.createdAt.getTime() + (template.subTaskTemplates.length - index) * 10) //maintain the order of subtasks in tasks with respect to subtasks in templates
+          await this.createSubtasksFromTemplate({
+            subTemplateId: sub.id,
+            parentTask: newTask,
+            manualTimestamp,
+            templateService,
+          })
         })
       }
     }

--- a/src/app/api/tasks/public/public.service.ts
+++ b/src/app/api/tasks/public/public.service.ts
@@ -1,4 +1,6 @@
+import { subtaskTemplateBatchSize } from '@/constants/tasks'
 import { MAX_FETCH_ASSIGNEE_COUNT } from '@/constants/users'
+import { runInBatches } from '@/utils/array'
 import { deleteTaskNotifications, sendTaskCreateNotifications, sendTaskUpdateNotifications } from '@/jobs/notifications'
 import { CreateTaskRequest, UpdateTaskRequest, Associations, AssociationsSchema } from '@/types/dto/tasks.dto'
 import { DISPATCHABLE_EVENT } from '@/types/webhook'
@@ -270,13 +272,11 @@ export class PublicTasksService extends TasksSharedService {
       }
 
       if (template.subTaskTemplates.length) {
-        await Promise.all(
-          template.subTaskTemplates.map(async (sub, index) => {
-            const updatedSubTemplate = await templateService.getAppliedTemplateDescription(sub.id)
-            const manualTimeStamp = new Date(template.createdAt.getTime() + (template.subTaskTemplates.length - index) * 10) //maintain the order of subtasks in tasks with respect to subtasks in templates
-            await this.createSubtasksFromTemplate(updatedSubTemplate, newTask, manualTimeStamp)
-          }),
-        )
+        await runInBatches(template.subTaskTemplates, subtaskTemplateBatchSize, async (sub, index) => {
+          const updatedSubTemplate = await templateService.getAppliedTemplateDescription(sub.id)
+          const manualTimeStamp = new Date(template.createdAt.getTime() + (template.subTaskTemplates.length - index) * 10) //maintain the order of subtasks in tasks with respect to subtasks in templates
+          await this.createSubtasksFromTemplate(updatedSubTemplate, newTask, manualTimeStamp)
+        })
       }
     }
 

--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -4,6 +4,8 @@ import { ClientResponse, CompanyResponse, InternalUsers } from '@/types/common'
 import { TaskWithWorkflowState } from '@/types/db'
 import { AncestorTaskResponse, CreateTaskRequest, UpdateTaskRequest, Associations } from '@/types/dto/tasks.dto'
 import { DISPATCHABLE_EVENT } from '@/types/webhook'
+import { runInBatches } from '@/utils/array'
+import { subtaskTemplateBatchSize } from '@/constants/tasks'
 import { UserIdsType } from '@/utils/assignee'
 import { isPastDateString } from '@/utils/dateHelper'
 import { getIdsFromLtreePath } from '@/utils/ltree'
@@ -251,13 +253,11 @@ export class TasksService extends TasksSharedService {
       }
 
       if (template.subTaskTemplates.length) {
-        await Promise.all(
-          template.subTaskTemplates.map(async (sub, index) => {
-            const updatedSubTemplate = await templateService.getAppliedTemplateDescription(sub.id)
-            const manualTimeStamp = new Date(template.createdAt.getTime() + (template.subTaskTemplates.length - index) * 10) //maintain the order of subtasks in tasks with respect to subtasks in templates
-            await this.createSubtasksFromTemplate(updatedSubTemplate, newTask, manualTimeStamp)
-          }),
-        )
+        await runInBatches(template.subTaskTemplates, subtaskTemplateBatchSize, async (sub, index) => {
+          const updatedSubTemplate = await templateService.getAppliedTemplateDescription(sub.id)
+          const manualTimeStamp = new Date(template.createdAt.getTime() + (template.subTaskTemplates.length - index) * 10) //maintain the order of subtasks in tasks with respect to subtasks in templates
+          await this.createSubtasksFromTemplate(updatedSubTemplate, newTask, manualTimeStamp)
+        })
       }
     }
 

--- a/src/app/api/tasks/tasks.service.ts
+++ b/src/app/api/tasks/tasks.service.ts
@@ -254,9 +254,13 @@ export class TasksService extends TasksSharedService {
 
       if (template.subTaskTemplates.length) {
         await runInBatches(template.subTaskTemplates, subtaskTemplateBatchSize, async (sub, index) => {
-          const updatedSubTemplate = await templateService.getAppliedTemplateDescription(sub.id)
-          const manualTimeStamp = new Date(template.createdAt.getTime() + (template.subTaskTemplates.length - index) * 10) //maintain the order of subtasks in tasks with respect to subtasks in templates
-          await this.createSubtasksFromTemplate(updatedSubTemplate, newTask, manualTimeStamp)
+          const manualTimestamp = new Date(template.createdAt.getTime() + (template.subTaskTemplates.length - index) * 10) //maintain the order of subtasks in tasks with respect to subtasks in templates
+          await this.createSubtasksFromTemplate({
+            subTemplateId: sub.id,
+            parentTask: newTask,
+            manualTimestamp,
+            templateService,
+          })
         })
       }
     }

--- a/src/app/api/tasks/tasksShared.service.ts
+++ b/src/app/api/tasks/tasksShared.service.ts
@@ -18,7 +18,7 @@ import { SupabaseActions } from '@/utils/SupabaseActions'
 import APIError from '@api/core/exceptions/api'
 import { BaseService } from '@api/core/services/base.service'
 import { UserRole } from '@api/core/types/user'
-import { AssigneeType, Prisma, StateType, Task } from '@prisma/client'
+import { AssigneeType, Prisma, PrismaClient, StateType, Task } from '@prisma/client'
 import httpStatus from 'http-status'
 import z from 'zod'
 import { AttachmentsService } from '@api/attachments/attachments.service'
@@ -622,13 +622,27 @@ export abstract class TasksSharedService extends BaseService {
 
       await this.createTask(createTaskPayload, { disableSubtaskTemplates: true, manualTimestamp })
     } catch (e) {
-      // A failed subtask must never delete or abort the already-created parent task
-      // (previously caused templated tasks to vanish). Skip it; the rest still get created.
-      console.error('TasksSharedService#createSubtasksFromTemplate | Skipping subtask that failed to create', {
+      // All-or-nothing: if any subtask fails to apply, roll back the parent task
+      // rather than leaving a partially-applied template, and surface the error.
+      const deleteTask = this.db.task.delete({ where: { id: parentId } })
+      const deleteActivityLogs = this.db.activityLog.deleteMany({ where: { taskId: parentId } })
+
+      await this.db.$transaction(async (tx) => {
+        this.setTransaction(tx as PrismaClient)
+        await deleteTask
+        await deleteActivityLogs
+        this.unsetTransaction()
+      })
+
+      console.error('TasksSharedService#createSubtasksFromTemplate | Rolling back task creation', {
         parentId,
         subTemplateId,
         e,
       })
+      throw new APIError(
+        httpStatus.INTERNAL_SERVER_ERROR,
+        'Failed to create subtask from template, new task was not created.',
+      )
     }
   }
 

--- a/src/app/api/tasks/tasksShared.service.ts
+++ b/src/app/api/tasks/tasksShared.service.ts
@@ -18,10 +18,11 @@ import { SupabaseActions } from '@/utils/SupabaseActions'
 import APIError from '@api/core/exceptions/api'
 import { BaseService } from '@api/core/services/base.service'
 import { UserRole } from '@api/core/types/user'
-import { AssigneeType, Prisma, PrismaClient, StateType, Task, TaskTemplate } from '@prisma/client'
+import { AssigneeType, Prisma, StateType, Task } from '@prisma/client'
 import httpStatus from 'http-status'
 import z from 'zod'
 import { AttachmentsService } from '@api/attachments/attachments.service'
+import type { TemplatesService } from '@api/tasks/templates/templates.service'
 
 //Base class with shared permission logic and methods that both tasks.service.ts and public.service.ts could use
 export abstract class TasksSharedService extends BaseService {
@@ -589,11 +590,22 @@ export abstract class TasksSharedService extends BaseService {
     }
   }
 
-  protected async createSubtasksFromTemplate(data: TaskTemplate, parentTask: Task, manualTimestamp: Date) {
-    const { workspaceId, title, body, workflowStateId } = data
+  protected async createSubtasksFromTemplate({
+    subTemplateId,
+    parentTask,
+    manualTimestamp,
+    templateService,
+  }: {
+    subTemplateId: string
+    parentTask: Task
+    manualTimestamp: Date
+    templateService: TemplatesService
+  }) {
     const { id: parentId, internalUserId, clientId, companyId, associations, isShared } = parentTask
 
     try {
+      const { workspaceId, title, body, workflowStateId } =
+        await templateService.getAppliedTemplateDescription(subTemplateId)
       const createTaskPayload = CreateTaskRequestSchema.parse({
         title: resolveDynamicFields(title),
         body: body ? resolveAutofillTags(body) : body,
@@ -608,23 +620,15 @@ export abstract class TasksSharedService extends BaseService {
         isShared,
       })
 
-      await this.createTask(createTaskPayload, { disableSubtaskTemplates: true, manualTimestamp: manualTimestamp })
+      await this.createTask(createTaskPayload, { disableSubtaskTemplates: true, manualTimestamp })
     } catch (e) {
-      const deleteTask = this.db.task.delete({ where: { id: parentId } })
-      const deleteActivityLogs = this.db.activityLog.deleteMany({ where: { taskId: parentId } })
-
-      await this.db.$transaction(async (tx) => {
-        this.setTransaction(tx as PrismaClient)
-        await deleteTask
-        await deleteActivityLogs
-        this.unsetTransaction()
+      // A failed subtask must never delete or abort the already-created parent task
+      // (previously caused templated tasks to vanish). Skip it; the rest still get created.
+      console.error('TasksSharedService#createSubtasksFromTemplate | Skipping subtask that failed to create', {
+        parentId,
+        subTemplateId,
+        e,
       })
-
-      console.error('TasksService#createTask | Rolling back task creation', e)
-      throw new APIError(
-        httpStatus.INTERNAL_SERVER_ERROR,
-        'Failed to create subtask from template, new task was not created.',
-      )
     }
   }
 

--- a/src/constants/tasks.ts
+++ b/src/constants/tasks.ts
@@ -2,4 +2,4 @@ export const maxSubTaskDepth = 1
 
 // Bounds how many subtasks we create concurrently when applying a template, so a
 // template with many sub-templates can't exhaust the DB connection pool.
-export const subtaskTemplateBatchSize = 5
+export const subtaskTemplateBatchSize = 10

--- a/src/constants/tasks.ts
+++ b/src/constants/tasks.ts
@@ -2,4 +2,4 @@ export const maxSubTaskDepth = 1
 
 // Bounds how many subtasks we create concurrently when applying a template, so a
 // template with many sub-templates can't exhaust the DB connection pool.
-export const subtaskTemplateBatchSize = 10
+export const subtaskTemplateBatchSize = 5

--- a/src/constants/tasks.ts
+++ b/src/constants/tasks.ts
@@ -1,1 +1,5 @@
 export const maxSubTaskDepth = 1
+
+// Bounds how many subtasks we create concurrently when applying a template, so a
+// template with many sub-templates can't exhaust the DB connection pool.
+export const subtaskTemplateBatchSize = 5

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -28,3 +28,24 @@ export const groupBy = <T, K extends keyof T>(arr: T[], key: K): Grouped<T> => {
     return acc
   }, {} as Grouped<T>)
 }
+
+export const chunk = <T>(arr: T[], size: number): T[][] =>
+  Array.from({ length: Math.ceil(arr.length / size) }, (_, i) => arr.slice(i * size, i * size + size))
+
+/**
+ * Runs `handler` over `items` with bounded concurrency: at most `size` run at once,
+ * one batch after another. Prevents unbounded fan-out from exhausting the DB connection
+ * pool (and downstream rate limits) when the input can be large.
+ */
+export const runInBatches = async <T, R>(
+  items: T[],
+  size: number,
+  handler: (item: T, index: number) => Promise<R>,
+): Promise<R[]> => {
+  const indexed = items.map((item, index) => ({ item, index }))
+  const results: R[] = []
+  for (const batch of chunk(indexed, size)) {
+    results.push(...(await Promise.all(batch.map(({ item, index }) => handler(item, index)))))
+  }
+  return results
+}


### PR DESCRIPTION
## Problem

Creating a task from a template with many sub-templates left some subtasks unsaved, and opening the task detail threw:

> `P2024` — Timed out fetching a new connection from the connection pool (in `getSubtaskCounts` → `getSubtaskStatus`)

## Root cause

Applying a template fanned out **every** sub-template's task creation concurrently via `Promise.all`. Each `createSubtasksFromTemplate` → `createTask` is heavy (multiple queries + activity log + notifications trigger + webhook). For a large template (e.g. 90 sub-templates), ~90 concurrent `createTask` calls saturated the Prisma connection pool — so:

- some subtask creations failed → not all subtasks saved
- the subsequent single-query `getSubtaskCounts` on the detail page couldn't acquire a connection within `pool_timeout` → `P2024`

`getSubtaskCounts` was the victim, not the cause.

## Fix

Bound the fan-out concurrency so it can't monopolize the pool, independent of pool size:

- `src/utils/array.ts` — add `chunk` + `runInBatches(items, size, handler)` (at most `size` run at once, one batch after another)
- `src/constants/tasks.ts` — `subtaskTemplateBatchSize = 5`
- `tasks.service.ts` & `public.service.ts` — both template-apply sites use `runInBatches` instead of `Promise.all`

Ordering is preserved (the per-subtask timestamp is still derived from `index`).

## Notes

- Pure concurrency change — no behavior/schema change.
- `subtaskTemplateBatchSize` is deliberately conservative; bump it in one place if more throughput is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)