### PR TITLE
OUT-3904: add missing break in CommentToIU notification case

### DIFF
--- a/src/app/api/notification/notification.service.ts
+++ b/src/app/api/notification/notification.service.ts
@@ -553,6 +553,7 @@ export class NotificationService extends BaseService {
             )
             .map((iu) => iu.id)
         }
+        break
       default:
         const userInfo = await this.copilot.me()
         senderId = z.string().parse(userInfo?.id)


### PR DESCRIPTION
## Summary

Potential fix for **TASKS-9D** / **OUT-3904** — a `ZodError` thrown from `NotificationService.getNotificationParties`.

The `CommentToIU` case in the `switch (action)` was missing a `break`, so it fell through into the `default` branch. `default` calls `copilot.me()` and runs `z.string().parse(userInfo?.id)`. For tokens where `me()` resolves to `null` (no `internalUserId`/`clientId`), that parse throws the reported `ZodError` and crashes comment notifications — even though the `CommentToIU` caller only consumes `recipientIds`/`senderCompanyId`, both already set before the fallthrough.

This adds the missing `break`.

> ⚠️ Framed as a **potential fix** — this is the most likely trigger of the reported error, but not confirmed as the definitive root cause.

## Sentry

https://copilot-platforms.sentry.io/issues/TASKS-9D

`Fixes TASKS-9D` — will auto-close the Sentry issue on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)