### PR TITLE
OUT-4027 | Fix 500 when deleting a task whose label row is missing

### DIFF
--- a/src/app/api/label-mapping/label-mapping.service.test.ts
+++ b/src/app/api/label-mapping/label-mapping.service.test.ts
@@ -1,0 +1,44 @@
+const mockLabelFindFirst = jest.fn()
+const mockLabelDelete = jest.fn()
+
+jest.mock('@/lib/db', () => ({
+  __esModule: true,
+  default: {
+    getInstance: () => ({
+      label: { findFirst: mockLabelFindFirst, delete: mockLabelDelete },
+    }),
+  },
+}))
+
+jest.mock('@/utils/CopilotAPI', () => ({ CopilotAPI: jest.fn() }))
+
+import { LabelMappingService } from '@api/label-mapping/label-mapping.service'
+import User from '@api/core/models/User.model'
+import { UserRole } from '@api/core/types/user'
+
+const user = {
+  workspaceId: 'ws-1',
+  role: UserRole.IU,
+  internalUserId: 'iu-1',
+  token: 'token',
+} as unknown as User
+
+describe('LabelMappingService#deleteLabel', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  it('deletes the matching label row', async () => {
+    mockLabelFindFirst.mockResolvedValue({ id: 'label-1' })
+
+    await new LabelMappingService(user).deleteLabel('ASS10-009')
+
+    expect(mockLabelDelete).toHaveBeenCalledWith({ where: { id: 'label-1' } })
+  })
+
+  it('no-ops when the label row is already gone', async () => {
+    mockLabelFindFirst.mockResolvedValue(null)
+
+    await new LabelMappingService(user).deleteLabel('ASS10-009')
+
+    expect(mockLabelDelete).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/api/label-mapping/label-mapping.service.ts
+++ b/src/app/api/label-mapping/label-mapping.service.ts
@@ -175,9 +175,10 @@ export class LabelMappingService extends BaseService {
         label,
       },
     })
+    if (!currentLabel) return
     await this.db.label.delete({
       where: {
-        id: currentLabel?.id,
+        id: currentLabel.id,
       },
     })
   }


### PR DESCRIPTION
Deleting a task 500'd with `PrismaClientValidationError … Argument where of type LabelWhereUniqueInput needs at least one of id`. [OUT-4027](https://linear.app/assemblycom/issue/OUT-4027/debug-task-delete-issue)

`deleteLabel` passed `id: currentLabel?.id` straight into `label.delete`, so when the `findFirst` matched nothing Prisma received `{ id: undefined }` and threw, failing the whole delete transaction. One guard, plus a test.

**What to look at**
- `label-mapping.service.ts` — the early return. The label row being absent is now a no-op; `Labels` is a next-number registry, so a missing row costs nothing at delete time.

**Verified**: new unit test covers both branches. `yarn tsc` and `yarn lint:check` clean. Unit suite passes except `withErrorHandler` / `authenticate`, which fail identically on `main`.
**Not verified**: no manual run of the delete endpoint.

**Not fixed here — [OUT-4029](https://linear.app/assemblycom/issue/OUT-4029/tasklabel-deletion-is-keyed-on-label-string-not-id-cross-workspace)**: rows go missing in the first place because `softDeleteAllSubtasks` matches `Tasks` and `Labels` by label string with no workspace scope. Prod has 3,631 label strings shared across 2+ workspaces (`THE10-001` spans 121), 747 live tasks that hit this 500, and 2,390 tasks soft-deleted as collateral by the unscoped `task.deleteMany`. This PR stops the 500; it does not stop the collateral deletes, so those counts keep climbing until OUT-4029 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)