### PR TITLE
OUT-4027 | Fix 500 when deleting a task whose label row is missing (#…

### DIFF
--- a/src/app/api/label-mapping/label-mapping.service.test.ts
+++ b/src/app/api/label-mapping/label-mapping.service.test.ts
@@ -1,0 +1,44 @@
+const mockLabelFindFirst = jest.fn()
+const mockLabelDelete = jest.fn()
+
+jest.mock('@/lib/db', () => ({
+  __esModule: true,
+  default: {
+    getInstance: () => ({
+      label: { findFirst: mockLabelFindFirst, delete: mockLabelDelete },
+    }),
+  },
+}))
+
+jest.mock('@/utils/CopilotAPI', () => ({ CopilotAPI: jest.fn() }))
+
+import { LabelMappingService } from '@api/label-mapping/label-mapping.service'
+import User from '@api/core/models/User.model'
+import { UserRole } from '@api/core/types/user'
+
+const user = {
+  workspaceId: 'ws-1',
+  role: UserRole.IU,
+  internalUserId: 'iu-1',
+  token: 'token',
+} as unknown as User
+
+describe('LabelMappingService#deleteLabel', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  it('deletes the matching label row', async () => {
+    mockLabelFindFirst.mockResolvedValue({ id: 'label-1' })
+
+    await new LabelMappingService(user).deleteLabel('ASS10-009')
+
+    expect(mockLabelDelete).toHaveBeenCalledWith({ where: { id: 'label-1' } })
+  })
+
+  it('no-ops when the label row is already gone', async () => {
+    mockLabelFindFirst.mockResolvedValue(null)
+
+    await new LabelMappingService(user).deleteLabel('ASS10-009')
+
+    expect(mockLabelDelete).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/api/label-mapping/label-mapping.service.ts
+++ b/src/app/api/label-mapping/label-mapping.service.ts
@@ -175,9 +175,10 @@ export class LabelMappingService extends BaseService {
         label,
       },
     })
+    if (!currentLabel) return
     await this.db.label.delete({
       where: {
-        id: currentLabel?.id,
+        id: currentLabel.id,
       },
     })
   }


### PR DESCRIPTION
…1397)

deleteLabel passed `id: currentLabel?.id` straight into label.delete, so when findFirst matched nothing Prisma got `{ id: undefined }` and threw PrismaClientValidationError, failing the whole delete transaction. Return early instead.

## Changes

- [ ] ...

## Testing Criteria

- [ ] Test Criterias (explain how you did testing for this PR mentioning all the cases you tested for) [Loom](video link going through the test criteria)

## Notes

- Dependencies on other PRs, any required changes in config/setup to test behaviour, or links to external documents, threads, etc -- if any of them are required

## Impact & Surface Area of Change

- An overview of components behaviour to be looked at for unintended breaks after the changes. This will make regression testing easier and efficient.
