### PR TITLE
OUT-4093 | Stop reading localStorage in the assignee cache

### DIFF
--- a/src/app/_cache/AssigneeCacheGetter.tsx
+++ b/src/app/_cache/AssigneeCacheGetter.tsx
@@ -3,7 +3,7 @@
 import { setAssigneeList } from '@/redux/features/taskBoardSlice'
 import store from '@/redux/store'
 import { useEffect } from 'react'
-import { getAssignees, migrateAssignees } from '@/app/_cache/forageStorage'
+import { getAssignees } from '@/app/_cache/forageStorage'
 
 interface ClientAssigneeCacheGetterProps {
   lookupKey: string
@@ -12,7 +12,6 @@ interface ClientAssigneeCacheGetterProps {
 export const AssigneeCacheGetter = ({ lookupKey }: ClientAssigneeCacheGetterProps) => {
   useEffect(() => {
     const run = async () => {
-      await migrateAssignees(lookupKey) //migrate from localStorage to localForage if required. Remember to remove this after a while.
       const assignee = await getAssignees(lookupKey)
       if (assignee.length) {
         store.dispatch(setAssigneeList(assignee))

--- a/src/app/_cache/forageStorage.test.ts
+++ b/src/app/_cache/forageStorage.test.ts
@@ -1,0 +1,45 @@
+const mockGetItem = jest.fn()
+const mockSetItem = jest.fn()
+
+jest.mock('localforage', () => ({
+  __esModule: true,
+  default: {
+    config: jest.fn(),
+    getItem: (...args: unknown[]) => mockGetItem(...args),
+    setItem: (...args: unknown[]) => mockSetItem(...args),
+  },
+}))
+
+import { getAssignees, setAssignees } from '@/app/_cache/forageStorage'
+
+const denied = () => new DOMException('Access is denied for this document.', 'SecurityError')
+
+describe('assignee cache', () => {
+  beforeAll(() => {
+    globalThis.window = {} as Window & typeof globalThis
+  })
+  afterAll(() => {
+    delete (globalThis as { window?: unknown }).window
+  })
+  beforeEach(() => jest.clearAllMocks())
+
+  it('returns an empty list when storage access is denied', async () => {
+    mockGetItem.mockRejectedValue(denied())
+
+    await expect(getAssignees('lookup-key')).resolves.toEqual([])
+    expect(mockGetItem).toHaveBeenCalledWith('assignees.lookup-key')
+  })
+
+  it('swallows write failures when storage access is denied', async () => {
+    mockSetItem.mockRejectedValue(denied())
+
+    await expect(setAssignees('lookup-key', [])).resolves.toBeUndefined()
+    expect(mockSetItem).toHaveBeenCalledWith('assignees.lookup-key', [])
+  })
+
+  it('returns an empty list when nothing is cached', async () => {
+    mockGetItem.mockResolvedValue(null)
+
+    await expect(getAssignees('lookup-key')).resolves.toEqual([])
+  })
+})

--- a/src/app/_cache/forageStorage.ts
+++ b/src/app/_cache/forageStorage.ts
@@ -12,33 +12,19 @@ export async function getAssignees(lookupKey: string): Promise<IAssigneeCombined
   if (typeof window === 'undefined') return []
 
   try {
-    if (!(await document.hasStorageAccess())) {
-      console.info('Browswer has no storage access')
-      await document.requestStorageAccess()
-    }
-
     return (await localforage.getItem<IAssigneeCombined[]>(`assignees.${lookupKey}`)) ?? []
   } catch (error: unknown) {
-    console.error(
-      "Storage access not granted. Under Chrome's Settings > Privacy and Security, make sure 'Third-party cookies' is allowed.",
-    )
+    console.info('Assignee cache unavailable, falling back to network', error)
     return []
   }
 }
 
-export async function setAssignees(lookupKey: string, value: any) {
+export async function setAssignees(lookupKey: string, value: IAssigneeCombined[]) {
   if (typeof window === 'undefined') return
 
   try {
-    if (!(await document.hasStorageAccess())) {
-      console.info('Browswer has no storage access')
-      await document.requestStorageAccess()
-    }
-
     return await localforage.setItem(`assignees.${lookupKey}`, value)
   } catch (error: unknown) {
-    console.error(
-      "Storage access not granted. Under Chrome's Settings > Privacy and Security, make sure 'Third-party cookies' is allowed.",
-    )
+    console.info('Assignee cache write skipped, storage unavailable', error)
   }
 }

--- a/src/app/_cache/forageStorage.ts
+++ b/src/app/_cache/forageStorage.ts
@@ -8,21 +8,6 @@ localforage.config({
   storeName: 'assignees',
 })
 
-export async function migrateAssignees(lookupKey: string) {
-  const lKey = `assignees.${lookupKey}`
-  const existing = localStorage.getItem(lKey)
-
-  if (existing) {
-    try {
-      const parsed = JSON.parse(existing)
-      await localforage.setItem(lKey, parsed)
-      localStorage.removeItem(lKey)
-    } catch (err) {
-      console.error('Migration failed', err)
-    }
-  }
-} //a utility function to migrate existing assignee data from localStorage to localForage
-
 export async function getAssignees(lookupKey: string): Promise<IAssigneeCombined[]> {
   if (typeof window === 'undefined') return []
 


### PR DESCRIPTION
Fixes the Sentry `SecurityError: Failed to read the 'localStorage' property from 'Window'` ([OUT-4093](https://linear.app/assemblycom/issue/OUT-4093/securityerror-failed-to-read-the-localstorage-property-from-window), TASKS-9X) by deleting the code that read `localStorage` rather than guarding it. Net -25 lines in `forageStorage.ts`.

`migrateAssignees()` touched `window.localStorage`, which throws on property access when Chrome blocks third-party storage in our iframe. It shipped in OUT-2348 eleven months ago tagged "remove this after a while" and only moved a cache, so unmigrated users just re-fetch over the network.

What to look at:

- `forageStorage.ts` — the `hasStorageAccess()`/`requestStorageAccess()` gate is gone. It reports access to unpartitioned *cookies*, but the cache is IndexedDB; MDN documents it returning `false` where third-party access is actually fine, which fed into a `requestStorageAccess()` that is auto-denied without a user gesture (there is none in `AssigneeCacheGetter`'s mount effect). It disabled the cache for the users it was meant to protect. The existing try/catch already degrades to a network fetch.
- `forageStorage.test.ts` — stubs `globalThis.window` because `jest-environment-jsdom` isn't installed. The `toHaveBeenCalledWith` assertions are load-bearing: without them the tests pass vacuously via the `typeof window === 'undefined'` early return.

Verified: `yarn tsc` clean; `grep -rn localStorage src/` empty, so no path can still throw this; 3 new tests pass. The 10 failures in `withErrorHandler`/`authenticate` reproduce on a clean `main` and are unrelated.

Not verified: the cache actually populating in a real Chrome iframe with third-party cookies blocked. That upside rests on documentation, not observation — the crash fix does not.

Supersedes #1407, which guarded the migration instead of removing it.